### PR TITLE
add pomerium_otel tracer extension

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,4 @@
+bazel-bin
+bazel-envoy-custom
+bazel-out
+bazel-testlogs

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ clang.bazelrc
 user.bazelrc
 compile_commands.json
 .vscode
+.cache
 user.bazelrc

--- a/BUILD
+++ b/BUILD
@@ -13,6 +13,7 @@ envoy_cc_binary(
     deps = [
         "//source/extensions/http/early_header_mutation/trace_context:pomerium_trace_context",
         "//source/extensions/request_id/uuidx:pomerium_uuidx",
+        "//source/extensions/tracers/pomerium_otel",
         "@envoy//source/exe:envoy_main_entry_lib",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,6 +12,7 @@ http_archive(
     patch_tool = "patch",
     patches = [
         "//:patches/0001-fix-otel-grpc-trace-exporter.patch",
+        "//:patches/0002-opentelemetry-tracer-lib-visibility.patch",
     ],
     strip_prefix = "envoy-" + envoy_version,
     url = "https://github.com/envoyproxy/envoy/archive/refs/tags/v" + envoy_version + ".zip",

--- a/patches/0002-opentelemetry-tracer-lib-visibility.patch
+++ b/patches/0002-opentelemetry-tracer-lib-visibility.patch
@@ -1,0 +1,10 @@
+diff --git a/source/extensions/tracers/opentelemetry/BUILD b/source/extensions/tracers/opentelemetry/BUILD
+index 0b6e75abea..0cac8092aa 100644
+--- a/source/extensions/tracers/opentelemetry/BUILD
++++ b/source/extensions/tracers/opentelemetry/BUILD
+@@ -24,4 +24,5 @@ envoy_cc_extension(
+
+ envoy_cc_library(
++    visibility = ["//visibility:public"],
+     name = "opentelemetry_tracer_lib",
+     srcs = [

--- a/source/extensions/http/early_header_mutation/trace_context/BUILD
+++ b/source/extensions/http/early_header_mutation/trace_context/BUILD
@@ -46,6 +46,7 @@ envoy_cc_test(
     deps = [
         ":pomerium_trace_context",
         ":trace_context_cc_proto",
+        "@com_google_absl//absl/random",
         "@envoy//source/common/common:random_generator_lib",
         "@envoy//test/mocks/runtime:runtime_mocks",
         "@envoy//test/mocks/stream_info:stream_info_mocks",

--- a/source/extensions/http/early_header_mutation/trace_context/BUILD
+++ b/source/extensions/http/early_header_mutation/trace_context/BUILD
@@ -23,6 +23,7 @@ envoy_cc_library(
         ":trace_context_cc_proto",
         "@envoy//envoy/http:early_header_mutation_interface",
         "@envoy//envoy/registry",
+        "@envoy//source/common/common:base64_lib",
         "@envoy//source/common/common:logger_lib",
         "@envoy//source/common/http:header_mutation_lib",
     ],

--- a/source/extensions/http/early_header_mutation/trace_context/trace_context.cc
+++ b/source/extensions/http/early_header_mutation/trace_context/trace_context.cc
@@ -1,5 +1,6 @@
 #include "source/extensions/http/early_header_mutation/trace_context/trace_context.h"
 #include "source/common/common/logger.h"
+#include "source/common/common/base64.h"
 
 namespace Envoy::Extensions::Http::EarlyHeaderMutation {
 
@@ -37,7 +38,27 @@ bool TraceContext::mutate(Envoy::Http::RequestHeaderMap& headers,
       if (auto traceparent = values[0]->value().getStringView(); traceparent.size() == 55) {
         headers.setCopy(pomerium_external_parent_header, traceparent.substr(36, 16));
       }
+    } else if (headers.getPathValue().starts_with("/oauth2/callback")) {
+      // oauth2 callback is a special case, we can't encode the traceparent in the usual way since
+      // the query parameters are standard and managed by oauth2 clients
+      const auto state = params.getFirstValue(Envoy::Http::LowerCaseString("state"));
+      if (state.has_value()) {
+        const std::string stateDecoded =
+            Base64Url::decode(StringUtil::removeTrailingCharacters(state.value(), '='));
+        const std::vector<absl::string_view> segments =
+            absl::StrSplit(stateDecoded, absl::MaxSplits('|', 3));
+        if (segments.size() == 4) {
+          const auto traceidDecoded = Base64Url::decode(segments[2]);
+          if (traceidDecoded.size() == 17) { // 16 byte trace ID + 1 byte flags
+            const auto traceID = traceidDecoded.substr(0, 16);
+            const auto flags = traceidDecoded.at(16);
+            headers.setCopy(pomerium_traceid_header, absl::BytesToHexString(traceID));
+            headers.setCopy(pomerium_sampling_decision_header, (flags & 1) == 1 ? "1" : "0");
+          }
+        }
+      }
     }
+
     return true;
   }
 
@@ -56,12 +77,8 @@ bool TraceContext::mutate(Envoy::Http::RequestHeaderMap& headers,
   auto flags = absl::HexStringToBytes(flags_hex).front();
   if (flags & 1) { // sampled
     headers.setCopy(pomerium_sampling_decision_header, "1");
-    ENVOY_LOG(debug, "pomerium_traceparent={}, forcing trace decision (on)",
-              pomerium_traceparent.value());
   } else { // not sampled
     headers.setCopy(pomerium_sampling_decision_header, "0");
-    ENVOY_LOG(debug, "pomerium_traceparent={}, forcing sampling decision (off)",
-              pomerium_traceparent.value());
   }
 
   headers.setCopy(pomerium_traceparent_header, pomerium_traceparent.value());

--- a/source/extensions/http/early_header_mutation/trace_context/trace_context.h
+++ b/source/extensions/http/early_header_mutation/trace_context/trace_context.h
@@ -20,6 +20,7 @@ private:
   Envoy::Http::LowerCaseString pomerium_sampling_decision_header{"x-pomerium-sampling-decision"};
   Envoy::Http::LowerCaseString pomerium_traceparent_header{"x-pomerium-traceparent"};
   Envoy::Http::LowerCaseString pomerium_tracestate_header{"x-pomerium-tracestate"};
+  Envoy::Http::LowerCaseString pomerium_traceid_header{"x-pomerium-traceid"};
   Envoy::Http::LowerCaseString pomerium_external_parent_header{"x-pomerium-external-parent-span"};
   Envoy::Http::LowerCaseString traceparent_header{"traceparent"};
 };

--- a/source/extensions/tracers/pomerium_otel/BUILD
+++ b/source/extensions/tracers/pomerium_otel/BUILD
@@ -45,3 +45,21 @@ proto_library(
         "@envoy_api//envoy/config/core/v3:pkg",
     ],
 )
+
+envoy_cc_test(
+    name = "pomerium_otel_test",
+    srcs = [
+        "pomerium_otel_test.cc",
+    ],
+    repository = "@envoy",
+    deps = [
+        ":pomerium_otel",
+        ":pomerium_otel_cc_proto",
+        "@envoy//test/mocks/server:tracer_factory_context_mocks",
+        "@envoy//test/mocks/stream_info:stream_info_mocks",
+        "@envoy//test/mocks/thread_local:thread_local_mocks",
+        "@envoy//test/mocks/tracing:tracing_mocks",
+        "@envoy//test/mocks/upstream:cluster_manager_mocks",
+        "@envoy//test/test_common:utility_lib",
+    ],
+)

--- a/source/extensions/tracers/pomerium_otel/BUILD
+++ b/source/extensions/tracers/pomerium_otel/BUILD
@@ -1,0 +1,47 @@
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_cc_test",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+envoy_cc_library(
+    name = "pomerium_otel",
+    srcs = [
+        "config.cc",
+        "span.cc",
+        "tracer_impl.cc",
+    ],
+    hdrs = [
+        "config.h",
+        "span.h",
+        "tracer_impl.h",
+        "typeutils.h",
+    ],
+    repository = "@envoy",
+    deps = [
+        ":pomerium_otel_cc_proto",
+        "@envoy//source/common/common:logger_lib",
+        "@envoy//source/common/common:utility_lib",
+        "@envoy//source/extensions/tracers/opentelemetry:opentelemetry_tracer_lib",
+    ],
+)
+
+cc_proto_library(
+    name = "pomerium_otel_cc_proto",
+    deps = ["pomerium_otel_proto"],
+)
+
+proto_library(
+    name = "pomerium_otel_proto",
+    srcs = ["pomerium_otel.proto"],
+    deps = [
+        "@com_envoyproxy_protoc_gen_validate//validate:validate_proto",
+        "@com_github_cncf_xds//udpa/annotations:pkg",
+        "@envoy_api//envoy/annotations:pkg",
+        "@envoy_api//envoy/config/core/v3:pkg",
+    ],
+)

--- a/source/extensions/tracers/pomerium_otel/config.cc
+++ b/source/extensions/tracers/pomerium_otel/config.cc
@@ -1,0 +1,33 @@
+#include "source/extensions/tracers/pomerium_otel/config.h"
+
+#include "envoy/config/trace/v3/opentelemetry.pb.h"
+#include "envoy/config/trace/v3/opentelemetry.pb.validate.h"
+#include "envoy/registry/registry.h"
+
+#include "source/common/common/logger.h"
+#include "source/extensions/tracers/pomerium_otel/tracer_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+PomeriumOpenTelemetryTracerFactory::PomeriumOpenTelemetryTracerFactory()
+    : FactoryBase("envoy.tracers.pomerium_otel") {}
+
+Tracing::DriverSharedPtr PomeriumOpenTelemetryTracerFactory::createTracerDriverTyped(
+    const pomerium::extensions::OpenTelemetryConfig& proto_config,
+    Server::Configuration::TracerFactoryContext& context) {
+  envoy::config::trace::v3::OpenTelemetryConfig base = toBaseConfig(proto_config);
+  return std::make_shared<PomeriumDriver>(base, context);
+}
+
+/**
+ * Static registration for the OpenTelemetry tracer. @see RegisterFactory.
+ */
+REGISTER_FACTORY(PomeriumOpenTelemetryTracerFactory, Server::Configuration::TracerFactory);
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/pomerium_otel/config.cc
+++ b/source/extensions/tracers/pomerium_otel/config.cc
@@ -1,16 +1,10 @@
 #include "source/extensions/tracers/pomerium_otel/config.h"
 
-#include "envoy/config/trace/v3/opentelemetry.pb.h"
-#include "envoy/config/trace/v3/opentelemetry.pb.validate.h"
 #include "envoy/registry/registry.h"
-
-#include "source/common/common/logger.h"
+#include "source/extensions/tracers/pomerium_otel/typeutils.h"
 #include "source/extensions/tracers/pomerium_otel/tracer_impl.h"
 
-namespace Envoy {
-namespace Extensions {
-namespace Tracers {
-namespace OpenTelemetry {
+namespace Envoy::Extensions::Tracers::OpenTelemetry {
 
 PomeriumOpenTelemetryTracerFactory::PomeriumOpenTelemetryTracerFactory()
     : FactoryBase("envoy.tracers.pomerium_otel") {}
@@ -18,16 +12,9 @@ PomeriumOpenTelemetryTracerFactory::PomeriumOpenTelemetryTracerFactory()
 Tracing::DriverSharedPtr PomeriumOpenTelemetryTracerFactory::createTracerDriverTyped(
     const pomerium::extensions::OpenTelemetryConfig& proto_config,
     Server::Configuration::TracerFactoryContext& context) {
-  envoy::config::trace::v3::OpenTelemetryConfig base = toBaseConfig(proto_config);
-  return std::make_shared<PomeriumDriver>(base, context);
+  return std::make_shared<PomeriumDriver>(toBaseConfig(proto_config), context);
 }
 
-/**
- * Static registration for the OpenTelemetry tracer. @see RegisterFactory.
- */
 REGISTER_FACTORY(PomeriumOpenTelemetryTracerFactory, Server::Configuration::TracerFactory);
 
-} // namespace OpenTelemetry
-} // namespace Tracers
-} // namespace Extensions
-} // namespace Envoy
+} // namespace Envoy::Extensions::Tracers::OpenTelemetry

--- a/source/extensions/tracers/pomerium_otel/config.cc
+++ b/source/extensions/tracers/pomerium_otel/config.cc
@@ -1,7 +1,6 @@
 #include "source/extensions/tracers/pomerium_otel/config.h"
 
 #include "envoy/registry/registry.h"
-#include "source/extensions/tracers/pomerium_otel/typeutils.h"
 #include "source/extensions/tracers/pomerium_otel/tracer_impl.h"
 
 namespace Envoy::Extensions::Tracers::OpenTelemetry {

--- a/source/extensions/tracers/pomerium_otel/config.h
+++ b/source/extensions/tracers/pomerium_otel/config.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <string>
+
+#include "source/extensions/tracers/pomerium_otel/typeutils.h"
+
+#include "envoy/config/trace/v3/opentelemetry.pb.h"
+#include "envoy/config/trace/v3/opentelemetry.pb.validate.h"
+#include "source/extensions/tracers/pomerium_otel/pomerium_otel.pb.h"
+
+#include "source/extensions/tracers/common/factory_base.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+/**
+ * Config registration for the OpenTelemetry tracer. @see TracerFactory.
+ */
+class PomeriumOpenTelemetryTracerFactory
+    : Logger::Loggable<Logger::Id::tracing>,
+      public Common::FactoryBase<pomerium::extensions::OpenTelemetryConfig> {
+public:
+  PomeriumOpenTelemetryTracerFactory();
+
+private:
+  // FactoryBase
+  Tracing::DriverSharedPtr
+  createTracerDriverTyped(const pomerium::extensions::OpenTelemetryConfig& proto_config,
+                          Server::Configuration::TracerFactoryContext& context) override;
+};
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/pomerium_otel/config.h
+++ b/source/extensions/tracers/pomerium_otel/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "source/extensions/tracers/pomerium_otel/pomerium_otel.pb.h"
+#include "source/extensions/tracers/pomerium_otel/typeutils.h"
 
 #include "source/extensions/tracers/common/factory_base.h"
 

--- a/source/extensions/tracers/pomerium_otel/config.h
+++ b/source/extensions/tracers/pomerium_otel/config.h
@@ -1,23 +1,11 @@
 #pragma once
 
-#include <string>
-
-#include "source/extensions/tracers/pomerium_otel/typeutils.h"
-
-#include "envoy/config/trace/v3/opentelemetry.pb.h"
-#include "envoy/config/trace/v3/opentelemetry.pb.validate.h"
 #include "source/extensions/tracers/pomerium_otel/pomerium_otel.pb.h"
 
 #include "source/extensions/tracers/common/factory_base.h"
 
-namespace Envoy {
-namespace Extensions {
-namespace Tracers {
-namespace OpenTelemetry {
+namespace Envoy::Extensions::Tracers::OpenTelemetry {
 
-/**
- * Config registration for the OpenTelemetry tracer. @see TracerFactory.
- */
 class PomeriumOpenTelemetryTracerFactory
     : Logger::Loggable<Logger::Id::tracing>,
       public Common::FactoryBase<pomerium::extensions::OpenTelemetryConfig> {
@@ -31,7 +19,4 @@ private:
                           Server::Configuration::TracerFactoryContext& context) override;
 };
 
-} // namespace OpenTelemetry
-} // namespace Tracers
-} // namespace Extensions
-} // namespace Envoy
+} // namespace Envoy::Extensions::Tracers::OpenTelemetry

--- a/source/extensions/tracers/pomerium_otel/pomerium_otel.proto
+++ b/source/extensions/tracers/pomerium_otel/pomerium_otel.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package pomerium.extensions;
+
+import "envoy/config/core/v3/extension.proto";
+import "envoy/config/core/v3/grpc_service.proto";
+import "envoy/config/core/v3/http_service.proto";
+import "udpa/annotations/migrate.proto";
+import "udpa/annotations/status.proto";
+
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+message OpenTelemetryConfig {
+  envoy.config.core.v3.GrpcService                   grpc_service       = 1 [(udpa.annotations.field_migrate).oneof_promotion = "otlp_exporter"];
+  envoy.config.core.v3.HttpService                   http_service       = 3 [(udpa.annotations.field_migrate).oneof_promotion = "otlp_exporter"];
+  string                                             service_name       = 2;
+  repeated envoy.config.core.v3.TypedExtensionConfig resource_detectors = 4;
+  envoy.config.core.v3.TypedExtensionConfig          sampler            = 5;
+}

--- a/source/extensions/tracers/pomerium_otel/pomerium_otel_test.cc
+++ b/source/extensions/tracers/pomerium_otel/pomerium_otel_test.cc
@@ -1,0 +1,124 @@
+#include "source/extensions/tracers/pomerium_otel/config.h"
+#include "source/extensions/tracers/pomerium_otel/span.h"
+
+#include "source/common/tracing/http_tracer_impl.h"
+#include "test/mocks/server/tracer_factory_context.h"
+#include "test/mocks/stream_info/mocks.h"
+#include "test/mocks/thread_local/mocks.h"
+#include "test/mocks/tracing/mocks.h"
+#include "test/mocks/upstream/cluster_manager.h"
+#include "test/test_common/utility.h"
+#include "tracer_impl.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+// constexpr auto traceid_unsampled = "00-11111111111111111111111111111111-2222222222222222-00";
+constexpr std::string_view traceid_sampled =
+    "00-11111111111111111111111111111111-2222222222222222-01";
+
+namespace Envoy::Extensions::Tracers::OpenTelemetry {
+
+using testing::Return;
+
+class PomeriumOtelTest : public testing::Test {
+public:
+  PomeriumOtelTest();
+
+protected:
+  NiceMock<Tracing::MockConfig> config;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  NiceMock<Upstream::MockClusterManager> cluster_manager_;
+
+  Tracing::TestTraceContextImpl trace_context{};
+  std::unique_ptr<PomeriumDriver> driver;
+};
+
+PomeriumOtelTest::PomeriumOtelTest() {
+  cluster_manager_.initializeClusters({"fake-cluster"}, {});
+  cluster_manager_.thread_local_cluster_.cluster_.info_->name_ = "fake-cluster";
+  cluster_manager_.initializeThreadLocalClusters({"fake-cluster"});
+
+  const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    service_name: test-service-name
+    )EOF";
+
+  envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+  TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+  trace_context = {
+      {":method", "GET"},
+      {":protocol", "https://"},
+      {":authority", "foo.example.com"},
+      {":path", "/bar"},
+  };
+  driver = std::make_unique<PomeriumDriver>(opentelemetry_config, context);
+}
+
+TEST_F(PomeriumOtelTest, VariableNameSpan) {
+  const std::string operation_name = "overwritten";
+  Tracing::SpanPtr tracing_span = driver->startSpan(
+      config, trace_context, stream_info, operation_name, {Tracing::Reason::Sampling, true});
+
+  EXPECT_EQ(dynamic_cast<VariableNameSpan*>(tracing_span.get())->name(), operation_name);
+
+  const std::string new_operation_name = "${method} ${protocol}${host}${path}";
+  tracing_span->setOperation(new_operation_name);
+  EXPECT_EQ(dynamic_cast<VariableNameSpan*>(tracing_span.get())->name(),
+            "GET https://foo.example.com/bar");
+}
+
+TEST_F(PomeriumOtelTest, StartSpanWithNoTraceparent) {
+  NiceMock<Random::MockRandomGenerator>& mock_random_generator_ =
+      context.server_factory_context_.api_.random_;
+  ON_CALL(mock_random_generator_, random()).WillByDefault(Return(0xDEADBEEFDEADBEEF));
+
+  Tracing::SpanPtr tracing_span = driver->startSpan(config, trace_context, stream_info, "test",
+                                                    {Tracing::Reason::Sampling, true});
+
+  EXPECT_EQ(tracing_span->getTraceId(), absl::StrCat(Hex::uint64ToHex(0xDEADBEEFDEADBEEF),
+                                                     Hex::uint64ToHex(0xDEADBEEFDEADBEEF)));
+}
+
+TEST_F(PomeriumOtelTest, StartSpanWithTraceparent) {
+  NiceMock<Random::MockRandomGenerator>& mock_random_generator_ =
+      context.server_factory_context_.api_.random_;
+  ON_CALL(mock_random_generator_, random()).WillByDefault(Return(0xDEADBEEFDEADBEEF));
+
+  trace_context.set("x-pomerium-traceparent", traceid_sampled);
+  Tracing::SpanPtr tracing_span = driver->startSpan(config, trace_context, stream_info, "test",
+                                                    {Tracing::Reason::Sampling, true});
+  EXPECT_EQ(tracing_span->getTraceId(), traceid_sampled.substr(3, 32));
+}
+
+TEST_F(PomeriumOtelTest, StartSpanWithTraceID) {
+  NiceMock<Random::MockRandomGenerator>& mock_random_generator_ =
+      context.server_factory_context_.api_.random_;
+  ON_CALL(mock_random_generator_, random()).WillByDefault(Return(0xDEADBEEFDEADBEEF));
+
+  trace_context.set("x-pomerium-traceid", traceid_sampled.substr(3, 32));
+  Tracing::SpanPtr tracing_span = driver->startSpan(config, trace_context, stream_info, "test",
+                                                    {Tracing::Reason::Sampling, true});
+  EXPECT_EQ(tracing_span->getTraceId(), traceid_sampled.substr(3, 32));
+}
+
+TEST_F(PomeriumOtelTest, StartSpanWithSamplingDecisionOff) {
+  trace_context.set("x-pomerium-sampling-decision", "0");
+  Tracing::SpanPtr tracing_span = driver->startSpan(config, trace_context, stream_info, "test",
+                                                    {Tracing::Reason::Sampling, true});
+  EXPECT_FALSE(dynamic_cast<VariableNameSpan*>(tracing_span.get())->sampled());
+}
+
+TEST_F(PomeriumOtelTest, StartSpanWithSamplingDecisionOn) {
+  trace_context.set("x-pomerium-sampling-decision", "1");
+  Tracing::SpanPtr tracing_span = driver->startSpan(config, trace_context, stream_info, "test",
+                                                    {Tracing::Reason::NotTraceable, false});
+  EXPECT_TRUE(dynamic_cast<VariableNameSpan*>(tracing_span.get())->sampled());
+}
+
+} // namespace Envoy::Extensions::Tracers::OpenTelemetry

--- a/source/extensions/tracers/pomerium_otel/pomerium_otel_test.cc
+++ b/source/extensions/tracers/pomerium_otel/pomerium_otel_test.cc
@@ -13,8 +13,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-// constexpr auto traceid_unsampled = "00-11111111111111111111111111111111-2222222222222222-00";
-constexpr std::string_view traceid_sampled =
+constexpr std::string_view example_traceid =
     "00-11111111111111111111111111111111-2222222222222222-01";
 
 namespace Envoy::Extensions::Tracers::OpenTelemetry {
@@ -90,10 +89,10 @@ TEST_F(PomeriumOtelTest, StartSpanWithTraceparent) {
       context.server_factory_context_.api_.random_;
   ON_CALL(mock_random_generator_, random()).WillByDefault(Return(0xDEADBEEFDEADBEEF));
 
-  trace_context.set("x-pomerium-traceparent", traceid_sampled);
+  trace_context.set("x-pomerium-traceparent", example_traceid);
   Tracing::SpanPtr tracing_span = driver->startSpan(config, trace_context, stream_info, "test",
                                                     {Tracing::Reason::Sampling, true});
-  EXPECT_EQ(tracing_span->getTraceId(), traceid_sampled.substr(3, 32));
+  EXPECT_EQ(tracing_span->getTraceId(), example_traceid.substr(3, 32));
 }
 
 TEST_F(PomeriumOtelTest, StartSpanWithTraceID) {
@@ -101,10 +100,10 @@ TEST_F(PomeriumOtelTest, StartSpanWithTraceID) {
       context.server_factory_context_.api_.random_;
   ON_CALL(mock_random_generator_, random()).WillByDefault(Return(0xDEADBEEFDEADBEEF));
 
-  trace_context.set("x-pomerium-traceid", traceid_sampled.substr(3, 32));
+  trace_context.set("x-pomerium-traceid", example_traceid.substr(3, 32));
   Tracing::SpanPtr tracing_span = driver->startSpan(config, trace_context, stream_info, "test",
                                                     {Tracing::Reason::Sampling, true});
-  EXPECT_EQ(tracing_span->getTraceId(), traceid_sampled.substr(3, 32));
+  EXPECT_EQ(tracing_span->getTraceId(), example_traceid.substr(3, 32));
 }
 
 TEST_F(PomeriumOtelTest, StartSpanWithSamplingDecisionOff) {

--- a/source/extensions/tracers/pomerium_otel/span.cc
+++ b/source/extensions/tracers/pomerium_otel/span.cc
@@ -1,4 +1,6 @@
 #include "source/extensions/tracers/pomerium_otel/span.h"
+#include "absl/strings/str_replace.h"
+#include "source/common/common/assert.h"
 
 namespace Envoy::Extensions::Tracers::OpenTelemetry {
 

--- a/source/extensions/tracers/pomerium_otel/span.cc
+++ b/source/extensions/tracers/pomerium_otel/span.cc
@@ -13,6 +13,9 @@ void VariableNameSpan::setTraceId(const absl::string_view& trace_id_hex) {
   span_->setTraceId(trace_id_hex);
 }
 
+std::string VariableNameSpan::name() const { return span_->name(); }
+bool VariableNameSpan::sampled() const { return span_->sampled(); }
+
 void VariableNameSpan::setOperation(absl::string_view operation_name) {
   span_->setOperation(absl::StrReplaceAll(operation_name, substitutions_));
 }

--- a/source/extensions/tracers/pomerium_otel/span.cc
+++ b/source/extensions/tracers/pomerium_otel/span.cc
@@ -1,0 +1,50 @@
+#include "source/extensions/tracers/pomerium_otel/span.h"
+
+namespace Envoy::Extensions::Tracers::OpenTelemetry {
+
+VariableNameSpan::VariableNameSpan(Tracing::SpanPtr&& base, StrSubstitutions substitutions)
+    : span_(dynamic_cast<BaseOtelSpan*>(base.release())), substitutions_(substitutions) {
+  RELEASE_ASSERT(!!span_, "bug: span type is not OpenTelemetry::Span*");
+}
+
+void VariableNameSpan::setTraceId(const absl::string_view& trace_id_hex) {
+  span_->setTraceId(trace_id_hex);
+}
+
+void VariableNameSpan::setOperation(absl::string_view operation_name) {
+  span_->setOperation(absl::StrReplaceAll(operation_name, substitutions_));
+}
+
+void VariableNameSpan::setTag(absl::string_view name, absl::string_view value) {
+  span_->setTag(name, value);
+};
+
+void VariableNameSpan::log(SystemTime timestamp, const std::string& event) {
+  span_->log(timestamp, event);
+};
+
+void VariableNameSpan::finishSpan() { span_->finishSpan(); }
+
+void VariableNameSpan::injectContext(Envoy::Tracing::TraceContext& trace_context,
+                                     const Tracing::UpstreamContext& upstream) {
+  span_->injectContext(trace_context, upstream);
+}
+
+Tracing::SpanPtr VariableNameSpan::spawnChild(const Tracing::Config& config,
+                                              const std::string& name, SystemTime start_time) {
+  return span_->spawnChild(config, name, start_time);
+}
+
+void VariableNameSpan::setSampled(bool sampled) { span_->setSampled(sampled); };
+
+std::string VariableNameSpan::getBaggage(absl::string_view key) { return span_->getBaggage(key); };
+
+void VariableNameSpan::setBaggage(absl::string_view key, absl::string_view value) {
+  span_->setBaggage(key, value);
+};
+
+std::string VariableNameSpan::getTraceId() const { return span_->getTraceId(); }
+
+std::string VariableNameSpan::getSpanId() const { return span_->getSpanId(); }
+
+} // namespace Envoy::Extensions::Tracers::OpenTelemetry

--- a/source/extensions/tracers/pomerium_otel/span.h
+++ b/source/extensions/tracers/pomerium_otel/span.h
@@ -1,8 +1,6 @@
 #pragma once
 #include "envoy/tracing/trace_driver.h"
 #include "source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.h"
-#include "absl/strings/str_replace.h"
-#include "source/common/common/assert.h"
 
 namespace Envoy::Extensions::Tracers::OpenTelemetry {
 

--- a/source/extensions/tracers/pomerium_otel/span.h
+++ b/source/extensions/tracers/pomerium_otel/span.h
@@ -14,6 +14,8 @@ public:
   ~VariableNameSpan() override = default;
 
   void setTraceId(const absl::string_view& trace_id_hex);
+  std::string name() const;
+  bool sampled() const;
 
   void setOperation(absl::string_view operation_name) override;
 

--- a/source/extensions/tracers/pomerium_otel/span.h
+++ b/source/extensions/tracers/pomerium_otel/span.h
@@ -1,0 +1,40 @@
+#pragma once
+#include "envoy/tracing/trace_driver.h"
+#include "source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.h"
+#include "absl/strings/str_replace.h"
+#include "source/common/common/assert.h"
+
+namespace Envoy::Extensions::Tracers::OpenTelemetry {
+
+using BaseOtelSpan = ::Envoy::Extensions::Tracers::OpenTelemetry::Span;
+using BaseOtelSpanPtr = std::unique_ptr<BaseOtelSpan>;
+using StrSubstitutions = std::vector<std::tuple<std::string, std::string>>;
+
+class VariableNameSpan : public Tracing::Span {
+public:
+  VariableNameSpan(Tracing::SpanPtr&& base, StrSubstitutions substitutions);
+  ~VariableNameSpan() override = default;
+
+  void setTraceId(const absl::string_view& trace_id_hex);
+
+  void setOperation(absl::string_view operation_name) override;
+
+  void setTag(absl::string_view name, absl::string_view value) override;
+  void log(SystemTime timestamp, const std::string& event) override;
+  void finishSpan() override;
+  void injectContext(Envoy::Tracing::TraceContext& trace_context,
+                     const Tracing::UpstreamContext& upstream) override;
+  Tracing::SpanPtr spawnChild(const Tracing::Config& config, const std::string& name,
+                              SystemTime start_time) override;
+  void setSampled(bool sampled) override;
+  std::string getBaggage(absl::string_view key) override;
+  void setBaggage(absl::string_view key, absl::string_view value) override;
+  std::string getTraceId() const override;
+  std::string getSpanId() const override;
+
+private:
+  BaseOtelSpanPtr span_;
+  StrSubstitutions substitutions_;
+};
+
+} // namespace Envoy::Extensions::Tracers::OpenTelemetry

--- a/source/extensions/tracers/pomerium_otel/tracer_impl.cc
+++ b/source/extensions/tracers/pomerium_otel/tracer_impl.cc
@@ -1,0 +1,64 @@
+
+#include "source/extensions/tracers/pomerium_otel/tracer_impl.h"
+#include "source/extensions/tracers/pomerium_otel/span.h"
+#include "source/common/tracing/trace_context_impl.h"
+#include "source/common/common/logger.h"
+#include "source/common/http/path_utility.h"
+#include "absl/strings/str_replace.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+const Tracing::TraceContextHandler& pomeriumTraceParentHeader() {
+  CONSTRUCT_ON_FIRST_USE(Tracing::TraceContextHandler, "x-pomerium-traceparent");
+}
+
+const Tracing::TraceContextHandler& pomeriumTraceIDHeader() {
+  CONSTRUCT_ON_FIRST_USE(Tracing::TraceContextHandler, "x-pomerium-traceid");
+}
+
+const Tracing::TraceContextHandler& pomeriumSamplingDecisionHeader() {
+  CONSTRUCT_ON_FIRST_USE(Tracing::TraceContextHandler, "x-pomerium-sampling-decision");
+}
+
+Tracing::SpanPtr PomeriumDriver::startSpan(const Tracing::Config& config,
+                                           Tracing::TraceContext& trace_context,
+                                           const StreamInfo::StreamInfo& stream_info,
+                                           const std::string& operation_name,
+                                           Tracing::Decision tracing_decision) {
+
+  std::vector<std::tuple<std::string, std::string>> substitutions{
+      {"${path}", std::string(Envoy::Http::PathUtil::removeQueryAndFragment(trace_context.path()))},
+      {"${host}", std::string(trace_context.host())},
+      {"${method}", std::string(trace_context.method())},
+      {"${protocol}", std::string(trace_context.protocol())},
+  };
+  auto span = new VariableNameSpan(
+      Driver::startSpan(config, trace_context, stream_info, operation_name, tracing_decision),
+      substitutions);
+
+  if (auto tp = pomeriumTraceParentHeader().get(trace_context);
+      tp.has_value() && tp->size() == 55) {
+    auto new_trace_id = tp.value().substr(3, 32);
+    ENVOY_LOG(trace, "rewriting trace ID {} => {}", span->getTraceId(), new_trace_id);
+    span->setTraceId(new_trace_id);
+  } else if (auto tid = pomeriumTraceIDHeader().get(trace_context);
+             tid.has_value() && tid.value().size() == 32) {
+    auto new_trace_id = tid.value();
+    ENVOY_LOG(trace, "rewriting trace ID (alt) {} => {}", span->getTraceId(), new_trace_id);
+    span->setTraceId(new_trace_id);
+  }
+  if (auto decision = pomeriumSamplingDecisionHeader().get(trace_context); decision.has_value()) {
+    ENVOY_LOG(trace, "forcing sampling decision: {}", decision.value());
+    span->setSampled(decision.value() == "1");
+  }
+
+  return Tracing::SpanPtr(static_cast<Tracing::Span*>(span));
+}
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/pomerium_otel/tracer_impl.cc
+++ b/source/extensions/tracers/pomerium_otel/tracer_impl.cc
@@ -1,15 +1,12 @@
 
 #include "source/extensions/tracers/pomerium_otel/tracer_impl.h"
+
 #include "source/extensions/tracers/pomerium_otel/span.h"
 #include "source/common/tracing/trace_context_impl.h"
 #include "source/common/common/logger.h"
 #include "source/common/http/path_utility.h"
-#include "absl/strings/str_replace.h"
 
-namespace Envoy {
-namespace Extensions {
-namespace Tracers {
-namespace OpenTelemetry {
+namespace Envoy::Extensions::Tracers::OpenTelemetry {
 
 const Tracing::TraceContextHandler& pomeriumTraceParentHeader() {
   CONSTRUCT_ON_FIRST_USE(Tracing::TraceContextHandler, "x-pomerium-traceparent");
@@ -23,13 +20,20 @@ const Tracing::TraceContextHandler& pomeriumSamplingDecisionHeader() {
   CONSTRUCT_ON_FIRST_USE(Tracing::TraceContextHandler, "x-pomerium-sampling-decision");
 }
 
+// workaround for OpenTelemetry::Driver having private inheritance to
+// Logger::Loggable<Logger::Id::tracing>
+static spdlog::logger& logger() {
+  static spdlog::logger& instance = Envoy::Logger::Registry::getLog(Logger::Id::tracing);
+  return instance;
+}
+
 Tracing::SpanPtr PomeriumDriver::startSpan(const Tracing::Config& config,
                                            Tracing::TraceContext& trace_context,
                                            const StreamInfo::StreamInfo& stream_info,
                                            const std::string& operation_name,
                                            Tracing::Decision tracing_decision) {
 
-  std::vector<std::tuple<std::string, std::string>> substitutions{
+  std::vector<std::tuple<std::string, std::string>> name_substitutions{
       {"${path}", std::string(Envoy::Http::PathUtil::removeQueryAndFragment(trace_context.path()))},
       {"${host}", std::string(trace_context.host())},
       {"${method}", std::string(trace_context.method())},
@@ -37,28 +41,27 @@ Tracing::SpanPtr PomeriumDriver::startSpan(const Tracing::Config& config,
   };
   auto span = new VariableNameSpan(
       Driver::startSpan(config, trace_context, stream_info, operation_name, tracing_decision),
-      substitutions);
+      name_substitutions);
 
   if (auto tp = pomeriumTraceParentHeader().get(trace_context);
       tp.has_value() && tp->size() == 55) {
     auto new_trace_id = tp.value().substr(3, 32);
-    ENVOY_LOG(trace, "rewriting trace ID {} => {}", span->getTraceId(), new_trace_id);
+    ENVOY_LOG_TO_LOGGER(logger(), trace, "rewriting trace ID {} => {}", span->getTraceId(),
+                        new_trace_id);
     span->setTraceId(new_trace_id);
   } else if (auto tid = pomeriumTraceIDHeader().get(trace_context);
              tid.has_value() && tid.value().size() == 32) {
     auto new_trace_id = tid.value();
-    ENVOY_LOG(trace, "rewriting trace ID (alt) {} => {}", span->getTraceId(), new_trace_id);
+    ENVOY_LOG_TO_LOGGER(logger(), trace, "rewriting trace ID (alt) {} => {}", span->getTraceId(),
+                        new_trace_id);
     span->setTraceId(new_trace_id);
   }
   if (auto decision = pomeriumSamplingDecisionHeader().get(trace_context); decision.has_value()) {
-    ENVOY_LOG(trace, "forcing sampling decision: {}", decision.value());
+    ENVOY_LOG_TO_LOGGER(logger(), trace, "forcing sampling decision: {}", decision.value());
     span->setSampled(decision.value() == "1");
   }
 
   return Tracing::SpanPtr(static_cast<Tracing::Span*>(span));
 }
 
-} // namespace OpenTelemetry
-} // namespace Tracers
-} // namespace Extensions
-} // namespace Envoy
+} // namespace Envoy::Extensions::Tracers::OpenTelemetry

--- a/source/extensions/tracers/pomerium_otel/tracer_impl.h
+++ b/source/extensions/tracers/pomerium_otel/tracer_impl.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "envoy/tracing/trace_driver.h"
+#include "source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+/**
+ * OpenTelemetry tracing driver.
+ */
+class PomeriumDriver : public Driver {
+public:
+  using Driver::Driver;
+
+  // Tracing::Driver
+  Tracing::SpanPtr startSpan(const Tracing::Config& config, Tracing::TraceContext& trace_context,
+                             const StreamInfo::StreamInfo& stream_info,
+                             const std::string& operation_name,
+                             Tracing::Decision tracing_decision) override;
+
+private:
+};
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/pomerium_otel/tracer_impl.h
+++ b/source/extensions/tracers/pomerium_otel/tracer_impl.h
@@ -3,13 +3,10 @@
 #include "envoy/tracing/trace_driver.h"
 #include "source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.h"
 
-namespace Envoy {
-namespace Extensions {
-namespace Tracers {
-namespace OpenTelemetry {
+namespace Envoy::Extensions::Tracers::OpenTelemetry {
 
 /**
- * OpenTelemetry tracing driver.
+ * Pomerium custom OpenTelemetry tracing driver.
  */
 class PomeriumDriver : public Driver {
 public:
@@ -20,11 +17,6 @@ public:
                              const StreamInfo::StreamInfo& stream_info,
                              const std::string& operation_name,
                              Tracing::Decision tracing_decision) override;
-
-private:
 };
 
-} // namespace OpenTelemetry
-} // namespace Tracers
-} // namespace Extensions
-} // namespace Envoy
+} // namespace Envoy::Extensions::Tracers::OpenTelemetry

--- a/source/extensions/tracers/pomerium_otel/typeutils.h
+++ b/source/extensions/tracers/pomerium_otel/typeutils.h
@@ -4,9 +4,11 @@
 #include "envoy/config/trace/v3/opentelemetry.pb.validate.h"
 #include "source/extensions/tracers/pomerium_otel/pomerium_otel.pb.h"
 
-inline envoy::config::trace::v3::OpenTelemetryConfig
-toBaseConfig(const ::pomerium::extensions::OpenTelemetryConfig& proto_config) {
-  envoy::config::trace::v3::OpenTelemetryConfig base;
+namespace pomerium::extensions {
+
+inline ::envoy::config::trace::v3::OpenTelemetryConfig
+toBaseConfig(const OpenTelemetryConfig& proto_config) {
+  ::envoy::config::trace::v3::OpenTelemetryConfig base;
   if (proto_config.has_grpc_service()) {
     *base.mutable_grpc_service() = proto_config.grpc_service();
   }
@@ -21,9 +23,8 @@ toBaseConfig(const ::pomerium::extensions::OpenTelemetryConfig& proto_config) {
   return base;
 }
 
-namespace pomerium::extensions {
-inline bool Validate(const ::pomerium::extensions::OpenTelemetryConfig& m,
-                     pgv::ValidationMsg* err) {
+inline bool Validate(const OpenTelemetryConfig& m, pgv::ValidationMsg* err) {
   return Validate(toBaseConfig(m), err);
 }
+
 } // namespace pomerium::extensions

--- a/source/extensions/tracers/pomerium_otel/typeutils.h
+++ b/source/extensions/tracers/pomerium_otel/typeutils.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "envoy/config/trace/v3/opentelemetry.pb.h"
+#include "envoy/config/trace/v3/opentelemetry.pb.validate.h"
+#include "source/extensions/tracers/pomerium_otel/pomerium_otel.pb.h"
+
+inline envoy::config::trace::v3::OpenTelemetryConfig
+toBaseConfig(const ::pomerium::extensions::OpenTelemetryConfig& proto_config) {
+  envoy::config::trace::v3::OpenTelemetryConfig base;
+  if (proto_config.has_grpc_service()) {
+    *base.mutable_grpc_service() = proto_config.grpc_service();
+  }
+  if (proto_config.has_http_service()) {
+    *base.mutable_http_service() = proto_config.http_service();
+  }
+  base.set_service_name(proto_config.service_name());
+  base.mutable_resource_detectors()->CopyFrom(proto_config.resource_detectors());
+  if (proto_config.has_sampler()) {
+    *base.mutable_sampler() = proto_config.sampler();
+  }
+  return base;
+}
+
+namespace pomerium::extensions {
+inline bool Validate(const ::pomerium::extensions::OpenTelemetryConfig& m,
+                     pgv::ValidationMsg* err) {
+  return Validate(toBaseConfig(m), err);
+}
+} // namespace pomerium::extensions


### PR DESCRIPTION
This adds a new tracer extension called pomerium_otel, which extends the default opentelemetry tracer and adds a couple of additional pomerium-specific features:

### 1. Trace ID overriding via header
When starting a span:
- If the associated HTTP request contains an `x-pomerium-traceparent` or `x-pomerium-traceid` header (set in the early header mutation extension), the randomly generated trace ID will be replaced with the trace ID contained in the header value.
- If the associated HTTP request contains the `x-pomerium-sampling-decision` header, the sampling decision will be forced on or off, depending on the value of the header ("1" or "0" respectively).

### 2. Route decorator variables
If configured, Envoy will use a route's decorator as the span operation name for spans created from HTTP requests for that route. This extends the otel Span to override its setOperation with logic to substitute the strings `${path}`, `${method}`, `${host}`, or `${protocol}` with the actual values for that request.
