### PR TITLE
do not set fully_static_link on macOS

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -7,7 +7,10 @@ package(default_visibility = ["//visibility:public"])
 
 envoy_cc_binary(
     name = "envoy",
-    features = ["fully_static_link"],
+    features = select({
+        "@platforms//os:macos": [],
+        "//conditions:default": ["fully_static_link"],
+    }),
     repository = "@envoy",
     stamped = True,
     deps = [


### PR DESCRIPTION
It looks like this feature is not compatible with Xcode 16.3: linking fails with the error `ld: library 'crt0.o' not found`.