### PR TITLE
ci: add a workflow to run tests on linux

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,3 +26,5 @@ build:linux --config=libc++20
 build:linux --copt="-Wno-error=thread-safety-reference-return"
 build:linux --copt="-Wno-error=missing-field-initializers"
 build --cxxopt=-std=c++23 --host_cxxopt=-std=c++23
+# The io_bazel_rules_go stdlib target passes a --no-gc-sections linker argument.
+build:linux --copt="-Wno-error=unused-command-line-argument"

--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -1,0 +1,42 @@
+name: Test (Linux)
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ['x64', 'arm64']
+    runs-on:
+      - ubuntu-latest-4-cores-${{ matrix.arch }}
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: disable man-db auto update
+        if: ${{ runner.environment == 'github-hosted' }}
+        run: sudo rm -f /var/lib/man-db/auto-update
+
+        # github actions ubuntu 24.04 comes with clang-18 but NOT libc++
+      - name: install dependencies
+        run: sudo apt-get install -y autoconf curl libtool patch python3-pip unzip virtualenv libc++-18-dev
+
+      - name: setup bazel
+        uses: bazel-contrib/setup-bazel@e8776f58fb6a6e9055cbaf1b38c52ccc5247e9c4
+        with:
+          bazelisk-version: 1.25.0
+          bazelisk-cache: true
+          disk-cache: bazel-linux-${{ matrix.arch }}
+          repository-cache: true
+
+      - name: test
+        run: bazel test //...

--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -28,7 +28,10 @@ jobs:
 
         # github actions ubuntu 24.04 comes with clang-18 but NOT libc++
       - name: install dependencies
-        run: sudo apt-get install -y autoconf curl libtool patch python3-pip unzip virtualenv libc++-18-dev
+        run: |
+          sudo apt-get install -y autoconf curl libtool patch python3-pip unzip virtualenv libc++-18-dev lcov
+          sudo update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-18 100
+          sudo update-alternatives --install /usr/bin/llvm-profdata llvm-profdata /usr/bin/llvm-profdata-18 100
 
       - name: setup bazel
         uses: bazel-contrib/setup-bazel@e8776f58fb6a6e9055cbaf1b38c52ccc5247e9c4
@@ -39,11 +42,12 @@ jobs:
           repository-cache: true
 
       - name: test
-        run: bazel coverage //test/...
+        run: VALIDATE_COVERAGE=false tools/run_envoy_bazel_coverage.sh
 
       - name: upload to coveralls
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
         if: matrix.arch == 'x64'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: bazel-out/_coverage/_coverage_report.dat
+          file: generated/coverage/coverage.dat
+          format: lcov

--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ['x64', 'arm64']
+        arch: ["x64", "arm64"]
     runs-on:
       - ubuntu-latest-16-cores${{ matrix.arch == 'arm64' && '-arm64' || '' }}
 
@@ -39,4 +39,10 @@ jobs:
           repository-cache: true
 
       - name: test
-        run: bazel test //...
+        run: bazel coverage //test/...
+
+      - name: upload to coveralls
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: bazel-out/_coverage/_coverage_report.dat

--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -43,6 +43,7 @@ jobs:
 
       - name: upload to coveralls
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
+        if: matrix.arch == 'x64'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: bazel-out/_coverage/_coverage_report.dat

--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         arch: ['x64', 'arm64']
     runs-on:
-      - ubuntu-latest-4-cores-${{ matrix.arch }}
+      - ubuntu-latest-16-cores${{ matrix.arch == 'arm64' && '-arm64' || '' }}
 
     steps:
       - name: checkout

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ compile_commands.json
 .vscode
 .cache
 user.bazelrc
+generated/

--- a/api/extensions/filters/network/ssh/BUILD
+++ b/api/extensions/filters/network/ssh/BUILD
@@ -9,6 +9,7 @@ proto_library(
     srcs = ["ssh.proto"],
     deps = [
         "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:struct_proto",
         "@com_google_protobuf//:timestamp_proto",
         "@com_google_protobuf//:wrappers_proto",
         "@envoy_api//envoy/config/core/v3:pkg",

--- a/tools/run_envoy_bazel_coverage.sh
+++ b/tools/run_envoy_bazel_coverage.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+LLVM_VERSION=${LLVM_VERSION:-"Ubuntu18.1.3"}
+CLANG_VERSION=$(clang --version | grep version | sed -e 's/\ *clang version \([0-9.]*\).*/\1/')
+LLVM_COV_VERSION=$(llvm-cov --version | grep version | sed -e 's/\ *LLVM version \([0-9.]*\).*/\1/')
+LLVM_PROFDATA_VERSION=$(llvm-profdata show --version | grep version | sed -e 's/\ *LLVM version \(.*\)/\1/')
+
+if [ "${CLANG_VERSION}" != "${LLVM_VERSION}" ]; then
+    echo "clang version ${CLANG_VERSION} does not match expected ${LLVM_VERSION}"
+    exit 1
+fi
+
+if [ "${LLVM_COV_VERSION}" != "${LLVM_VERSION}" ]; then
+    echo "llvm-cov version ${LLVM_COV_VERSION} does not match expected ${LLVM_VERSION}"
+    exit 1
+fi
+
+if [ "${LLVM_PROFDATA_VERSION}" != "${LLVM_VERSION}" ]; then
+    echo "llvm-profdata version ${LLVM_PROFDATA_VERSION} does not match expected ${LLVM_VERSION}"
+    exit 1
+fi
+
+[[ -z "${SRCDIR}" ]] && SRCDIR="${PWD}"
+[[ -z "${VALIDATE_COVERAGE}" ]] && VALIDATE_COVERAGE=true
+[[ -z "${FUZZ_COVERAGE}" ]] && FUZZ_COVERAGE=false
+[[ -z "${COVERAGE_THRESHOLD}" ]] && COVERAGE_THRESHOLD=100.0
+COVERAGE_TARGET="${COVERAGE_TARGET:-}"
+read -ra BAZEL_BUILD_OPTIONS <<<"${BAZEL_BUILD_OPTION_LIST:-}"
+read -ra BAZEL_GLOBAL_OPTIONS <<<"${BAZEL_GLOBAL_OPTION_LIST:-}"
+
+echo "Starting run_envoy_bazel_coverage.sh..."
+echo "    PWD=$(pwd)"
+echo "    SRCDIR=${SRCDIR}"
+echo "    VALIDATE_COVERAGE=${VALIDATE_COVERAGE}"
+
+# This is the target that will be run to generate coverage data. It can be overridden by consumer
+# projects that want to run coverage on a different/combined target.
+# Command-line arguments take precedence over ${COVERAGE_TARGET}.
+if [[ $# -gt 0 ]]; then
+    COVERAGE_TARGETS=("$@")
+elif [[ -n "${COVERAGE_TARGET}" ]]; then
+    COVERAGE_TARGETS=("${COVERAGE_TARGET}")
+else
+    COVERAGE_TARGETS=(//test/...)
+fi
+
+BAZEL_COVERAGE_OPTIONS=(--heap_dump_on_oom)
+
+if [[ -n "${BAZEL_GRPC_LOG}" ]]; then
+    BAZEL_COVERAGE_OPTIONS+=(--remote_grpc_log="${BAZEL_GRPC_LOG}")
+fi
+
+if [[ "${FUZZ_COVERAGE}" == "true" ]]; then
+    # Filter targets to just fuzz tests.
+    _targets=$(bazel query "${BAZEL_GLOBAL_OPTIONS[@]}" --noshow_loading_progress --noshow_progress "attr('tags', 'fuzz_target', ${COVERAGE_TARGETS[*]})")
+    COVERAGE_TARGETS=()
+    while read -r line; do COVERAGE_TARGETS+=("$line"); done \
+        <<<"$_targets"
+    BAZEL_COVERAGE_OPTIONS+=(
+        "--config=fuzz-coverage")
+else
+    BAZEL_COVERAGE_OPTIONS+=(
+        "--config=test-coverage")
+fi
+
+# Output unusually long logs due to trace logging.
+BAZEL_COVERAGE_OPTIONS+=("--experimental_ui_max_stdouterr_bytes=80000000")
+BAZEL_OUTPUT_BASE="$(bazel info "${BAZEL_BUILD_OPTIONS[@]}" output_base)"
+
+echo "Running bazel coverage with:"
+echo "  Options: ${BAZEL_BUILD_OPTIONS[*]} ${BAZEL_COVERAGE_OPTIONS[*]}"
+echo "  Targets: ${COVERAGE_TARGETS[*]}"
+
+bazel coverage "${BAZEL_BUILD_OPTIONS[@]}" "${BAZEL_COVERAGE_OPTIONS[@]}" "${COVERAGE_TARGETS[@]}"
+
+echo "Collecting profile and testlogs"
+if [[ -n "${ENVOY_BUILD_PROFILE}" ]]; then
+    cp -f "$BAZEL_OUTPUT_BASE/command.profile.gz" "${ENVOY_BUILD_PROFILE}/coverage.profile.gz" || true
+fi
+
+if [[ -n "${ENVOY_BUILD_DIR}" ]]; then
+    if [[ -e "${ENVOY_BUILD_DIR}/testlogs.tar.zst" ]]; then
+        rm -f "${ENVOY_BUILD_DIR}/testlogs.tar.zst"
+    fi
+    find bazel-testlogs/ -name test.log |
+        tar cf - -T - |
+        bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/zstd -- \
+            - -T0 -o "${ENVOY_BUILD_DIR}/testlogs.tar.zst"
+    echo "Profile/testlogs collected: ${ENVOY_BUILD_DIR}/testlogs.tar.zst"
+fi
+
+COVERAGE_DIR="${SRCDIR}/generated/coverage"
+if [[ ${FUZZ_COVERAGE} == "true" ]]; then
+    COVERAGE_DIR="${SRCDIR}"/generated/fuzz_coverage
+fi
+
+rm -rf "${COVERAGE_DIR}"
+mkdir -p "${COVERAGE_DIR}"
+
+if [[ ! -e bazel-out/_coverage/_coverage_report.dat ]]; then
+    echo "No coverage report found (bazel-out/_coverage/_coverage_report.dat)" >&2
+    exit 1
+elif [[ ! -s bazel-out/_coverage/_coverage_report.dat ]]; then
+    echo "Coverage report is empty (bazel-out/_coverage/_coverage_report.dat)" >&2
+    exit 1
+else
+    COVERAGE_DATA="${COVERAGE_DIR}/coverage.dat"
+    cp bazel-out/_coverage/_coverage_report.dat "${COVERAGE_DATA}"
+fi
+
+COVERAGE_VALUE="$(genhtml --prefix "${PWD}" --output "${COVERAGE_DIR}" "${COVERAGE_DATA}" | tee /dev/stderr | grep lines... | cut -d ' ' -f 4)"
+COVERAGE_VALUE=${COVERAGE_VALUE%?}
+
+echo "Compressing coveraged data"
+if [[ "${FUZZ_COVERAGE}" == "true" ]]; then
+    if [[ -n "${ENVOY_FUZZ_COVERAGE_ARTIFACT}" ]]; then
+        tar cf - -C "${COVERAGE_DIR}" --transform 's/^\./fuzz_coverage/' . |
+            bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/zstd -- \
+                - -T0 -o "${ENVOY_FUZZ_COVERAGE_ARTIFACT}"
+    fi
+elif [[ -n "${ENVOY_COVERAGE_ARTIFACT}" ]]; then
+    if [[ -e "${ENVOY_COVERAGE_ARTIFACT}" ]]; then
+        rm "${ENVOY_COVERAGE_ARTIFACT}"
+    fi
+
+    tar cf - -C "${COVERAGE_DIR}" --transform 's/^\./coverage/' . |
+        bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/zstd -- \
+            - -T0 -o "${ENVOY_COVERAGE_ARTIFACT}"
+fi
+
+if [[ "$VALIDATE_COVERAGE" == "true" ]]; then
+    if [[ "${FUZZ_COVERAGE}" == "true" ]]; then
+        COVERAGE_THRESHOLD=23.75
+    fi
+    COVERAGE_FAILED=$(echo "${COVERAGE_VALUE}<${COVERAGE_THRESHOLD}" | bc)
+    if [[ "${COVERAGE_FAILED}" -eq 1 ]]; then
+        echo "##vso[task.setvariable variable=COVERAGE_FAILED]${COVERAGE_FAILED}"
+        echo "ERROR: Code coverage ${COVERAGE_VALUE} is lower than limit of ${COVERAGE_THRESHOLD}" >&2
+        exit 1
+    else
+        echo "Code coverage ${COVERAGE_VALUE} is good and higher than limit of ${COVERAGE_THRESHOLD}"
+    fi
+fi
+
+if [[ -e ./test/per_file_coverage.sh ]]; then
+    # We want to allow per_file_coverage to fail without exiting this script.
+    set +e
+    if [[ "$VALIDATE_COVERAGE" == "true" ]] && [[ "${FUZZ_COVERAGE}" == "false" ]]; then
+        echo "Checking per-extension coverage"
+        output=$(./test/per_file_coverage.sh)
+        response=$?
+
+        if [ $response -ne 0 ]; then
+            echo Per-extension coverage failed:
+            echo "$output"
+            COVERAGE_FAILED=1
+            echo "##vso[task.setvariable variable=COVERAGE_FAILED]${COVERAGE_FAILED}"
+            exit 1
+        fi
+        echo Per-extension coverage passed.
+        echo "$output"
+    fi
+else
+    echo "No per-file-coverage file found"
+fi
+echo "HTML coverage report is in ${COVERAGE_DIR}/index.html"

--- a/tools/run_envoy_bazel_coverage.sh
+++ b/tools/run_envoy_bazel_coverage.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+# Copyright The Envoy Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e -o pipefail
 
 LLVM_VERSION=${LLVM_VERSION:-"Ubuntu18.1.3"}


### PR DESCRIPTION
Add a CI check to run `bazel test //...` on Linux.

This is loosely based on https://github.com/pomerium/envoy-build/blob/main/.github/workflows/build-linux.yaml.