### PR TITLE
common/math: replace sub_sat implementation

### DIFF
--- a/source/common/math.h
+++ b/source/common/math.h
@@ -1,10 +1,13 @@
 #pragma once
 
-#include <numeric> // IWYU pragma: keep
+#include <concepts>
 
-// alias for std::sub_sat, which is available in clang under a different name but not technically
-// part of the standard until C++26.
-template <typename T>
+// https://en.cppreference.com/w/cpp/numeric/sub_sat
+// std::sub_sat is only available in C++26
+template <std::unsigned_integral T>
 constexpr T sub_sat(T x, T y) noexcept {
-  return std::__sub_sat(x, y);
+  if (T result; !__builtin_sub_overflow(x, y, &result)) {
+    return result;
+  }
+  return 0;
 }

--- a/test/common/BUILD
+++ b/test/common/BUILD
@@ -8,6 +8,7 @@ envoy_cc_test(
     srcs = [
         "factory_test.cc",
         "fixed_string_test.cc",
+        "math_test.cc",
         "span_test.cc",
         "status_test.cc",
         "type_traits_test.cc",

--- a/test/common/math_test.cc
+++ b/test/common/math_test.cc
@@ -1,0 +1,15 @@
+#include "source/common/math.h"
+#include "gtest/gtest.h"
+
+namespace test {
+
+TEST(SubSatTest, SubSat) {
+  EXPECT_EQ(1, sub_sat(static_cast<uint32_t>(10), static_cast<uint32_t>(9)));
+  EXPECT_EQ(0, sub_sat(static_cast<uint32_t>(10), static_cast<uint32_t>(10)));
+  EXPECT_EQ(0, sub_sat(static_cast<uint32_t>(10), static_cast<uint32_t>(11)));
+  EXPECT_EQ(0, sub_sat(static_cast<uint32_t>(0), static_cast<uint32_t>(1)));
+  EXPECT_EQ(0, sub_sat(static_cast<uint32_t>(0), static_cast<uint32_t>(0)));
+  EXPECT_EQ(1, sub_sat(static_cast<uint32_t>(1), static_cast<uint32_t>(0)));
+}
+
+} // namespace test


### PR DESCRIPTION
The internal function std::__sub_sat isn't available in clang 18. The implementation is trivial, so we can just write it ourselves.