### PR TITLE
ci: use clang-19 with envoy setup script

### DIFF
--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -26,12 +26,10 @@ jobs:
         if: ${{ runner.environment == 'github-hosted' }}
         run: sudo rm -f /var/lib/man-db/auto-update
 
-        # github actions ubuntu 24.04 comes with clang-18 but NOT libc++
-      - name: install dependencies
+      - name: setup clang
         run: |
-          sudo apt-get install -y autoconf curl libtool patch python3-pip unzip virtualenv libc++-18-dev lcov
-          sudo update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-18 100
-          sudo update-alternatives --install /usr/bin/llvm-profdata llvm-profdata /usr/bin/llvm-profdata-18 100
+          sudo apt -y install virtualenv lcov llvm-19 llvm-19-linker-tools llvm-19-runtime llvm-19-tools libllvm19 clang-19 clang-tidy-19 clang-tools-19 libclang1-19 libclang-cpp19 libc++-19-dev libc++abi1-19 lld-19
+          tools/setup_clang.sh /usr/lib/llvm-19
 
       - name: setup bazel
         uses: bazel-contrib/setup-bazel@e8776f58fb6a6e9055cbaf1b38c52ccc5247e9c4
@@ -42,12 +40,11 @@ jobs:
           repository-cache: true
 
       - name: test
-        run: VALIDATE_COVERAGE=false tools/run_envoy_bazel_coverage.sh
+        run: bazel coverage //test/...
 
       - name: upload to coveralls
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
-        if: matrix.arch == 'x64'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: generated/coverage/coverage.dat
+          file: bazel-out/_coverage/_coverage_report.dat
           format: lcov

--- a/tools/run_envoy_bazel_coverage.sh
+++ b/tools/run_envoy_bazel_coverage.sh
@@ -16,7 +16,7 @@
 
 set -e -o pipefail
 
-LLVM_VERSION=${LLVM_VERSION:-"Ubuntu18.1.3"}
+LLVM_VERSION=${LLVM_VERSION:-"Ubuntu19.1.1"}
 CLANG_VERSION=$(clang --version | grep version | sed -e 's/\ *clang version \([0-9.]*\).*/\1/')
 LLVM_COV_VERSION=$(llvm-cov --version | grep version | sed -e 's/\ *LLVM version \([0-9.]*\).*/\1/')
 LLVM_PROFDATA_VERSION=$(llvm-profdata show --version | grep version | sed -e 's/\ *LLVM version \(.*\)/\1/')

--- a/tools/setup_clang.sh
+++ b/tools/setup_clang.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Copyright The Envoy Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+BAZELRC_FILE="${BAZELRC_FILE:-./clang.bazelrc}"
+
+LLVM_PREFIX=$1
+LLVM_CONFIG="${LLVM_PREFIX}/bin/llvm-config"
+
+if [[ ! -e "${LLVM_CONFIG}" ]]; then
+  echo "Error: cannot find local llvm-config in ${LLVM_PREFIX}."
+  exit 1
+fi
+
+LLVM_VERSION="$("${LLVM_CONFIG}" --version)"
+LLVM_LIBDIR="$("${LLVM_CONFIG}" --libdir)"
+LLVM_TARGET="$("${LLVM_CONFIG}" --host-target)"
+PATH="$("${LLVM_CONFIG}" --bindir):${PATH}"
+
+RT_LIBRARY_PATH="${LLVM_LIBDIR}/clang/${LLVM_VERSION}/lib/${LLVM_TARGET}"
+
+cat <<EOF >"${BAZELRC_FILE}"
+# Generated file, do not edit. If you want to disable clang, just delete this file.
+build:clang --host_action_env=PATH=${PATH} --action_env=PATH=${PATH}
+
+build:clang --action_env=LLVM_CONFIG=${LLVM_CONFIG} --host_action_env=LLVM_CONFIG=${LLVM_CONFIG}
+build:clang --repo_env=LLVM_CONFIG=${LLVM_CONFIG}
+build:clang --linkopt=-L${LLVM_LIBDIR}
+build:clang --linkopt=-Wl,-rpath,${LLVM_LIBDIR}
+
+build:clang-asan --linkopt=-L${RT_LIBRARY_PATH}
+EOF


### PR DESCRIPTION
Switching to clang-19 for CI builds for better C++23 support, including:
- constexpr std::variant
- Full support for [P2448R2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2448r2.html)
- Full support for [deducing this](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0847r7.html)
- std::out_ptr

Envoy has a setup script that I vendored in which can configure a non-default clang toolchain.