### PR TITLE
ci: add parallel build config to coveralls upload

### DIFF
--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -48,3 +48,15 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: bazel-out/_coverage/_coverage_report.dat
           format: lcov
+          parallel: true
+
+  finish:
+    needs: test
+    runs-on:
+      - ubuntu-latest-16-cores${{ matrix.arch == 'arm64' && '-arm64' || '' }}
+    steps:
+      - name: finish parallel build
+        uses: coverallsapp/github-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true

--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -50,7 +50,7 @@ jobs:
           format: lcov
           parallel: true
 
-  finish:
+  upload-coverage:
     needs: test
     runs-on:
       - ubuntu-latest-16-cores${{ matrix.arch == 'arm64' && '-arm64' || '' }}


### PR DESCRIPTION
Coveralls needs specific config to handle matrix builds, to let each build upload coverage.

https://docs.coveralls.io/parallel-builds