### PR TITLE
ssh network filter (3/24): add packet cipher abstractions and common logic

### DIFF
--- a/source/extensions/filters/network/ssh/BUILD
+++ b/source/extensions/filters/network/ssh/BUILD
@@ -11,9 +11,11 @@ envoy_cc_library(
     name = "pomerium_ssh",
     srcs = [
         "openssh.cc",
+        "packet_cipher.cc",
     ],
     hdrs = [
         "openssh.h",
+        "packet_cipher.h",
     ],
     copts = [
         "-Wimplicit-fallthrough",

--- a/source/extensions/filters/network/ssh/packet_cipher.cc
+++ b/source/extensions/filters/network/ssh/packet_cipher.cc
@@ -1,0 +1,81 @@
+#include "source/extensions/filters/network/ssh/packet_cipher.h"
+#include "source/extensions/filters/network/ssh/wire/common.h"
+
+namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
+
+PacketCipher::PacketCipher(std::unique_ptr<DirectionalPacketCipher> read,
+                           std::unique_ptr<DirectionalPacketCipher> write)
+    : read_(std::move(read)),
+      write_(std::move(write)) {}
+
+absl::Status PacketCipher::encryptPacket(uint32_t seqnum, Envoy::Buffer::Instance& out,
+                                         Envoy::Buffer::Instance& in) {
+  return write_->encryptPacket(seqnum, out, in);
+}
+
+absl::StatusOr<size_t> PacketCipher::decryptPacket(uint32_t seqnum, Envoy::Buffer::Instance& out,
+                                                   Envoy::Buffer::Instance& in) {
+  return read_->decryptPacket(seqnum, out, in);
+}
+
+size_t PacketCipher::rekeyAfterBytes(openssh::CipherMode mode) {
+  // RFC4344 § 3.2 states:
+  //  Let L be the block length (in bits) of an SSH encryption method's
+  //  block cipher (e.g., 128 for AES).  If L is at least 128, then, after
+  //  rekeying, an SSH implementation SHOULD NOT encrypt more than 2**(L/4)
+  //  blocks before rekeying again.
+  switch (auto sz = blockSize(mode); sz) {
+  case 8:
+    // cont.:
+    //  If L is less than 128, [...] rekey at least once for every gigabyte
+    //  of transmitted data.
+    return (1uz << 30);
+  case 16:
+    return 16uz * (1uz << 32);
+  default:
+    // 8 and 16 are the only valid block sizes for the algorithms supported by openssh
+    throw EnvoyException(fmt::format("invalid block size: {}", sz));
+  }
+}
+
+size_t PacketCipher::blockSize(openssh::CipherMode mode) {
+  switch (mode) {
+  case openssh::CipherMode::Read:
+    return read_->blockSize();
+  case openssh::CipherMode::Write:
+    return write_->blockSize();
+  }
+  throw EnvoyException("unknown mode");
+}
+
+size_t PacketCipher::aadSize(openssh::CipherMode mode) {
+  switch (mode) {
+  case openssh::CipherMode::Read:
+    return read_->aadLen();
+  case openssh::CipherMode::Write:
+    return write_->aadLen();
+  }
+  throw EnvoyException("unknown mode");
+}
+
+absl::StatusOr<size_t> NoCipher::decryptPacket(uint32_t /*seqnum*/, Envoy::Buffer::Instance& out,
+                                               Envoy::Buffer::Instance& in) {
+  uint32_t packlen = in.peekBEInt<uint32_t>();
+  if (packlen < wire::MinPacketSize || packlen > wire::MaxPacketSize) {
+    return absl::InvalidArgumentError("invalid packet size");
+  }
+  uint32_t need = packlen + 4;
+  if (in.length() < need) {
+    return 0; // incomplete packet
+  }
+  out.move(in, need);
+  return need;
+}
+
+absl::Status NoCipher::encryptPacket(uint32_t /*seqnum*/, Envoy::Buffer::Instance& out,
+                                     Envoy::Buffer::Instance& in) {
+  out.move(in);
+  return absl::OkStatus();
+}
+
+} // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/source/extensions/filters/network/ssh/packet_cipher.h
+++ b/source/extensions/filters/network/ssh/packet_cipher.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <cstdint>
+
+#pragma clang unsafe_buffer_usage begin
+#include "envoy/buffer/buffer.h"
+#pragma clang unsafe_buffer_usage end
+#include "source/common/factory.h"
+#include "source/extensions/filters/network/ssh/openssh.h"
+
+namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
+
+class DirectionalPacketCipher {
+public:
+  virtual ~DirectionalPacketCipher() = default;
+  // Decrypts one packet from the input buffer and writes the plaintext to the output buffer.
+  // Drains bytes from the input buffer.
+  // Returns the number of bytes *decrypted*, which will usually be less than the number of
+  // bytes read.
+  virtual absl::StatusOr<size_t> decryptPacket(uint32_t seqnum, Envoy::Buffer::Instance& out,
+                                               Envoy::Buffer::Instance& in) PURE;
+  virtual absl::Status encryptPacket(uint32_t seqnum, Envoy::Buffer::Instance& out,
+                                     Envoy::Buffer::Instance& in) PURE;
+  virtual size_t blockSize() const PURE;
+  virtual size_t aadLen() const PURE;
+};
+
+using iv_type = bytes;
+using key_type = bytes;
+using mac_type = bytes;
+
+struct DerivedKeys {
+  bytes iv;
+  bytes key;
+  bytes mac;
+};
+
+class DirectionalPacketCipherFactory {
+public:
+  virtual ~DirectionalPacketCipherFactory() = default;
+  virtual std::vector<std::pair<std::string, priority_t>> names() const PURE;
+  virtual std::unique_ptr<DirectionalPacketCipher> create(const DerivedKeys& keys,
+                                                          const DirectionAlgorithms& algs,
+                                                          openssh::CipherMode mode) const PURE;
+  virtual size_t ivSize() const PURE;
+  virtual size_t keySize() const PURE;
+};
+
+class DirectionalPacketCipherFactoryRegistry : public PriorityAwareFactoryRegistry<DirectionalPacketCipherFactory,
+                                                                                   DirectionalPacketCipher,
+                                                                                   const DerivedKeys&,
+                                                                                   const DirectionAlgorithms&,
+                                                                                   openssh::CipherMode> {};
+using DirectionalPacketCipherFactoryPtr = std::unique_ptr<DirectionalPacketCipherFactory>;
+
+class PacketCipher {
+public:
+  PacketCipher(std::unique_ptr<DirectionalPacketCipher> read,
+               std::unique_ptr<DirectionalPacketCipher> write);
+
+  absl::Status encryptPacket(uint32_t seqnum, Envoy::Buffer::Instance& out,
+                             Envoy::Buffer::Instance& in);
+  absl::StatusOr<size_t> decryptPacket(uint32_t seqnum, Envoy::Buffer::Instance& out,
+                                       Envoy::Buffer::Instance& in);
+  size_t blockSize(openssh::CipherMode mode);
+  size_t aadSize(openssh::CipherMode mode);
+  size_t rekeyAfterBytes(openssh::CipherMode mode);
+
+private:
+  std::unique_ptr<DirectionalPacketCipher> read_;
+  std::unique_ptr<DirectionalPacketCipher> write_;
+};
+
+class NoCipher final : public DirectionalPacketCipher {
+public:
+  NoCipher() = default;
+  absl::StatusOr<size_t> decryptPacket(uint32_t /*seqnum*/, Envoy::Buffer::Instance& out,
+                                       Envoy::Buffer::Instance& in) override;
+  absl::Status encryptPacket(uint32_t /*seqnum*/, Envoy::Buffer::Instance& out,
+                             Envoy::Buffer::Instance& in) override;
+  size_t blockSize() const override {
+    // Minimum block size is 8 according to RFC4253 § 6
+    return 8;
+  }
+  size_t aadLen() const override { return 0; }
+};
+
+} // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/test/extensions/filters/network/ssh/BUILD
+++ b/test/extensions/filters/network/ssh/BUILD
@@ -1,5 +1,6 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_mock",
     "envoy_cc_test",
     "envoy_package",
 )
@@ -7,6 +8,17 @@ load(
 licenses(["notice"])  # Apache 2
 
 envoy_package()
+
+envoy_cc_mock(
+    name = "test_mocks",
+    srcs = ["test_mocks.cc"],
+    hdrs = ["test_mocks.h"],
+    repository = "@envoy",
+    deps = [
+        "//:openssh",
+        "//source/extensions/filters/network/ssh:pomerium_ssh",
+    ],
+)
 
 envoy_cc_test(
     name = "openssh_test",
@@ -21,5 +33,18 @@ envoy_cc_test(
         "//source/extensions/filters/network/ssh:pomerium_ssh",
         "//test/extensions/filters/network/ssh/wire:wire_test_util",
         "@envoy//test/test_common:environment_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "packet_cipher_test",
+    srcs = [
+        "packet_cipher_test.cc",
+    ],
+    repository = "@envoy",
+    deps = [
+        ":test_mocks",
+        "//source/extensions/filters/network/ssh:pomerium_ssh",
+        "//test/extensions/filters/network/ssh/wire:wire_test_util",
     ],
 )

--- a/test/extensions/filters/network/ssh/packet_cipher_test.cc
+++ b/test/extensions/filters/network/ssh/packet_cipher_test.cc
@@ -1,0 +1,186 @@
+#include "source/extensions/filters/network/ssh/packet_cipher.h"
+#include "source/extensions/filters/network/ssh/wire/messages.h"
+#include "source/extensions/filters/network/ssh/wire/packet.h"
+#include "test/extensions/filters/network/ssh/test_mocks.h"
+#include "test/extensions/filters/network/ssh/wire/test_field_reflect.h"
+#include "test/test_common/test_common.h"
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
+namespace test {
+
+class PacketCipherTest : public testing::Test {
+public:
+  void SetUp() {
+    read_ = std::make_unique<testing::StrictMock<MockDirectionalPacketCipher>>();
+    write_ = std::make_unique<testing::StrictMock<MockDirectionalPacketCipher>>();
+  }
+
+protected:
+  std::unique_ptr<testing::StrictMock<MockDirectionalPacketCipher>> read_;
+  std::unique_ptr<testing::StrictMock<MockDirectionalPacketCipher>> write_;
+};
+
+TEST_F(PacketCipherTest, EncryptPacket) {
+  EXPECT_CALL(*write_, encryptPacket(0, _, _));
+
+  PacketCipher cipher(std::move(read_), std::move(write_));
+  Buffer::OwnedImpl buf;
+  EXPECT_OK(cipher.encryptPacket(0, buf, buf));
+}
+
+TEST_F(PacketCipherTest, DecryptPacket) {
+  EXPECT_CALL(*read_, decryptPacket(0, _, _))
+    .WillOnce(Return(0));
+
+  PacketCipher cipher(std::move(read_), std::move(write_));
+  Buffer::OwnedImpl buf;
+  EXPECT_OK(cipher.decryptPacket(0, buf, buf).status());
+}
+
+TEST_F(PacketCipherTest, BlockSizeRead) {
+  EXPECT_CALL(*read_, blockSize())
+    .WillOnce(Return(32));
+
+  PacketCipher cipher(std::move(read_), std::move(write_));
+  Buffer::OwnedImpl buf;
+  EXPECT_EQ(32, cipher.blockSize(openssh::CipherMode::Read));
+}
+
+TEST_F(PacketCipherTest, BlockSizeWrite) {
+  EXPECT_CALL(*write_, blockSize())
+    .WillOnce(Return(32));
+
+  PacketCipher cipher(std::move(read_), std::move(write_));
+  Buffer::OwnedImpl buf;
+  EXPECT_EQ(32, cipher.blockSize(openssh::CipherMode::Write));
+}
+
+TEST_F(PacketCipherTest, BlockSizeInvalid) {
+  PacketCipher cipher(std::move(read_), std::move(write_));
+  Buffer::OwnedImpl buf;
+  EXPECT_THROW_WITH_MESSAGE(cipher.blockSize(openssh::CipherMode(99)),
+                            EnvoyException,
+                            "unknown mode");
+}
+
+TEST_F(PacketCipherTest, AadSizeRead) {
+  EXPECT_CALL(*read_, aadLen())
+    .WillOnce(Return(32));
+
+  PacketCipher cipher(std::move(read_), std::move(write_));
+  Buffer::OwnedImpl buf;
+  EXPECT_EQ(32, cipher.aadSize(openssh::CipherMode::Read));
+}
+
+TEST_F(PacketCipherTest, AadSizeWrite) {
+  EXPECT_CALL(*write_, aadLen())
+    .WillOnce(Return(32));
+
+  PacketCipher cipher(std::move(read_), std::move(write_));
+  Buffer::OwnedImpl buf;
+  EXPECT_EQ(32, cipher.aadSize(openssh::CipherMode::Write));
+}
+
+TEST_F(PacketCipherTest, AadSizeInvalid) {
+  PacketCipher cipher(std::move(read_), std::move(write_));
+  Buffer::OwnedImpl buf;
+  EXPECT_THROW_WITH_MESSAGE(cipher.aadSize(openssh::CipherMode(99)),
+                            EnvoyException,
+                            "unknown mode");
+}
+
+class RekeyAfterBytesTest : public PacketCipherTest,
+                            public testing::WithParamInterface<std::tuple<openssh::CipherMode, std::tuple<size_t, std::optional<size_t>>>> {};
+
+INSTANTIATE_TEST_SUITE_P(
+  RekeyAfterBytesTestSuite, RekeyAfterBytesTest,
+  testing::Combine(testing::Values(openssh::CipherMode::Read, openssh::CipherMode::Write),
+                   testing::ValuesIn(std::vector<std::tuple<size_t, std::optional<size_t>>>{
+                     {8uz, 1uz << 30},
+                     {16uz, 16 * (1uz << ((16uz * 8) / 4))},
+                     {32uz, std::nullopt},
+                     {64uz, std::nullopt},
+                     {4uz, std::nullopt},
+                     {2uz, std::nullopt},
+                     {0uz, std::nullopt},
+                   })));
+
+TEST_P(RekeyAfterBytesTest, RekeyAfterBytes_Read) {
+  auto [mode, params] = GetParam();
+  auto [block_size, expected] = params;
+
+  EXPECT_CALL((mode == openssh::CipherMode::Read ? *read_ : *write_), blockSize())
+    .WillOnce(Return(block_size));
+  PacketCipher cipher(std::move(read_), std::move(write_));
+  if (expected.has_value()) {
+    EXPECT_EQ(expected.value(), cipher.rekeyAfterBytes(mode));
+  } else {
+    EXPECT_THROW_WITH_MESSAGE(cipher.rekeyAfterBytes(mode),
+                              EnvoyException,
+                              fmt::format("invalid block size: {}", block_size));
+  }
+}
+
+TEST(NoCipherTest, EncryptDecryptPacket) {
+  wire::KexInitMsg msg;
+  wire::test::populateFields(msg);
+
+  NoCipher no_cipher;
+  Buffer::OwnedImpl buffer;
+  ASSERT_OK(wire::encodePacket(buffer, msg, no_cipher.blockSize(), no_cipher.aadLen()).status());
+
+  auto packetData = buffer.toString();
+
+  Buffer::OwnedImpl encrypted; // not really encrypted
+  ASSERT_OK(no_cipher.encryptPacket(0, encrypted, buffer));
+  ASSERT_EQ(packetData, encrypted.toString());
+
+  Buffer::OwnedImpl decrypted;
+  auto r = no_cipher.decryptPacket(0, decrypted, encrypted);
+  ASSERT_OK(r.status());
+  ASSERT_EQ(packetData.size(), *r);
+}
+
+TEST(NoCipherTest, PacketTooLarge) {
+  NoCipher no_cipher;
+  Buffer::OwnedImpl buffer;
+  // encodePacket won't encode an invalid packet size, but we can just write the length manually
+  buffer.writeBEInt<uint32_t>(wire::MaxPacketSize + 1);
+
+  Buffer::OwnedImpl out;
+  auto r = no_cipher.decryptPacket(0, out, buffer);
+  EXPECT_EQ(absl::InvalidArgumentError("invalid packet size"), r.status());
+}
+
+TEST(NoCipherTest, PacketTooSmall) {
+  NoCipher no_cipher;
+  Buffer::OwnedImpl buffer;
+  ASSERT_TRUE(wire::MinPacketSize > 0); // sanity check
+  buffer.writeBEInt<uint32_t>(wire::MinPacketSize - 1);
+
+  Buffer::OwnedImpl out;
+  auto r = no_cipher.decryptPacket(0, out, buffer);
+  EXPECT_EQ(absl::InvalidArgumentError("invalid packet size"), r.status());
+}
+
+TEST(NoCipherTest, IncompletePacket) {
+  NoCipher no_cipher;
+  Buffer::OwnedImpl buffer;
+  buffer.writeBEInt<uint32_t>(50);
+
+  Buffer::OwnedImpl out;
+  auto r = no_cipher.decryptPacket(0, out, buffer);
+  EXPECT_OK(r.status());
+  EXPECT_EQ(0, *r);
+}
+
+TEST(NoCipherTest, Constants) {
+  NoCipher no_cipher;
+  EXPECT_EQ(8, no_cipher.blockSize());
+  EXPECT_EQ(0, no_cipher.aadLen());
+}
+
+} // namespace test
+} // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/test/extensions/filters/network/ssh/test_mocks.cc
+++ b/test/extensions/filters/network/ssh/test_mocks.cc
@@ -1,0 +1,10 @@
+#include "test/extensions/filters/network/ssh/test_mocks.h"
+
+namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
+namespace test {
+
+MockDirectionalPacketCipher::MockDirectionalPacketCipher() {}
+MockDirectionalPacketCipher::~MockDirectionalPacketCipher() {}
+
+} // namespace test
+} // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/test/extensions/filters/network/ssh/test_mocks.h
+++ b/test/extensions/filters/network/ssh/test_mocks.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "source/extensions/filters/network/ssh/packet_cipher.h"
+
+#pragma clang unsafe_buffer_usage begin
+#include "envoy/buffer/buffer.h"
+#include "absl/status/statusor.h"
+#pragma clang unsafe_buffer_usage end
+
+#include "gmock/gmock.h" // IWYU pragma: keep
+
+namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
+namespace test {
+
+class MockDirectionalPacketCipher : public DirectionalPacketCipher {
+public:
+  MockDirectionalPacketCipher();
+  virtual ~MockDirectionalPacketCipher();
+
+  MOCK_METHOD(absl::StatusOr<size_t>, decryptPacket, (uint32_t, Envoy::Buffer::Instance&, Envoy::Buffer::Instance&));
+  MOCK_METHOD(absl::Status, encryptPacket, (uint32_t, Envoy::Buffer::Instance&, Envoy::Buffer::Instance&));
+  MOCK_METHOD(size_t, blockSize, (), (const));
+  MOCK_METHOD(size_t, aadLen, (), (const));
+};
+
+} // namespace test
+} // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec


### PR DESCRIPTION
This adds the DirectionalPacketCipher abstractions, PacketCipher type (a concrete container for two DirectionalPacketCiphers, one of each direction), and the 'NoCipher' unencrypted directional cipher implementation.