### PR TITLE
ci: fix upload-coverage job to run on ubuntu-latest

### DIFF
--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -53,7 +53,7 @@ jobs:
   upload-coverage:
     needs: test
     runs-on:
-      - ubuntu-latest-16-cores${{ matrix.arch == 'arm64' && '-arm64' || '' }}
+      - ubuntu-latest
     steps:
       - name: finish parallel build
         uses: coverallsapp/github-action@v1


### PR DESCRIPTION
I thought that github would just reuse the runner if the runs-on constraint was the same, but that turns out not to be the case.