### PR TITLE
wire: add conditional explicit specifier to Message constructor

### DIFF
--- a/test/extensions/filters/network/ssh/wire/messages_bench_test.cc
+++ b/test/extensions/filters/network/ssh/wire/messages_bench_test.cc
@@ -15,7 +15,7 @@ static wire::KexInitMsg init_msg = [] {
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BenchmarkMessageMove(benchmark::State& state) {
-  Message m1 = init_msg;
+  Message m1{init_msg};
   Message m2;
   bool b{false};
   for (auto _ : state) {
@@ -31,7 +31,7 @@ BENCHMARK(BenchmarkMessageMove);
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BenchmarkMessageCopy(benchmark::State& state) {
-  Message m1 = init_msg;
+  Message m1{init_msg};
   for (auto _ : state) {
     benchmark::DoNotOptimize(auto(m1));
   }

--- a/test/extensions/filters/network/ssh/wire/messages_test.cc
+++ b/test/extensions/filters/network/ssh/wire/messages_test.cc
@@ -176,7 +176,7 @@ TEST(MessagesTest, Message_RoundTrip) {
   EXPECT_TRUE(extInfo.hasExtension<PingExtension>());
   EXPECT_FALSE(extInfo.hasExtension<ServerSigAlgsExtension>());
 
-  wire::Message msg = extInfo; // copy
+  wire::Message msg(extInfo); // copy
 
   Envoy::Buffer::OwnedImpl tmp;
   auto n = msg.encode(tmp);


### PR DESCRIPTION
This makes a small adjustment how concrete messages are converted to wire::Message, requiring the caller to explicitly specify whether they want to copy or move the message in cases where it could be ambiguous.