### PR TITLE
ssh: make hash algorithm part of KexAlgorithm implementation instead of using openssh lookup

### DIFF
--- a/source/extensions/filters/network/ssh/kex_alg.h
+++ b/source/extensions/filters/network/ssh/kex_alg.h
@@ -74,6 +74,7 @@ public:
   virtual const MessageTypeList& clientInitMessageTypes() const PURE;
   virtual wire::Message buildServerReply(const KexResult&) PURE;
   virtual const MessageTypeList& serverReplyMessageTypes() const PURE;
+  constexpr virtual HashFunction hash_algorithm() const PURE;
 
 protected:
   const HandshakeMagics* magics_;
@@ -92,8 +93,7 @@ protected:
     wire::writeBignum(exchangeHash, shared_secret);
 
     auto exchangeHashBuf = linearizeToSpan(exchangeHash);
-    auto hash_alg = kex_hash_from_name(algs_->kex.c_str());
-    openssh::Hash hash(hash_alg);
+    openssh::Hash hash(hash_algorithm());
     hash.write(exchangeHashBuf);
     auto digest = hash.sum();
     exchangeHash.drain(exchangeHash.length());

--- a/test/extensions/filters/network/ssh/kex_alg_test.cc
+++ b/test/extensions/filters/network/ssh/kex_alg_test.cc
@@ -74,6 +74,7 @@ public:
     static MessageTypeList list;
     return list;
   }
+  constexpr HashFunction hash_algorithm() const override { return SHA256; }
 
   using KexAlgorithm::computeClientResult;
   using KexAlgorithm::computeExchangeHash;


### PR DESCRIPTION
It doesn't make much sense to look up the hash alg from inside KexAlgorithm, since implementations (e.g. curve25519-sha256) have the hash algorithm as an intrinsic property of the kex algorithm. Also makes it hard to mock out algorithms that don't exist in openssh.