### PR TITLE
ssh: add sub_message::has_value() method

### DIFF
--- a/source/extensions/filters/network/ssh/wire/field.h
+++ b/source/extensions/filters/network/ssh/wire/field.h
@@ -238,6 +238,10 @@ struct sub_message {
   template <size_t I>
   constexpr decltype(auto) get(this auto& self) { return std::get<I>(*self.oneof); }
 
+  constexpr bool has_value() const {
+    return oneof.has_value();
+  }
+
   template <typename T>
   constexpr bool holds_alternative() const {
     return oneof.has_value() && std::holds_alternative<T>(*oneof);

--- a/test/extensions/filters/network/ssh/wire/field_test.cc
+++ b/test/extensions/filters/network/ssh/wire/field_test.cc
@@ -406,6 +406,7 @@ TEST(SubMessageTest, Decode) {
   EXPECT_TRUE(r.ok()) << r.status().ToString();
   EXPECT_EQ(len, *r);
   EXPECT_EQ(0, buffer.length());
+  EXPECT_TRUE(msg.request.has_value());
   EXPECT_TRUE(msg.request.holds_alternative<TestSubMsg1>());
   EXPECT_EQ(msg1, msg.request.get<TestSubMsg1>());
 
@@ -423,6 +424,7 @@ TEST(SubMessageTest, Decode) {
   EXPECT_TRUE(r.ok()) << r.status().ToString();
   EXPECT_EQ(len, *r);
   EXPECT_EQ(0, buffer.length());
+  EXPECT_TRUE(msg.request.has_value());
   EXPECT_TRUE(msg.request.holds_alternative<TestSubMsg2>());
   EXPECT_EQ(msg2, msg.request.get<TestSubMsg2>());
 }
@@ -443,6 +445,7 @@ TEST(SubMessageTest, Decode_Unknown) {
   EXPECT_TRUE(r.ok()) << r.status().ToString();
   EXPECT_EQ(len, *r);
   EXPECT_EQ(0, buffer.length());
+  EXPECT_FALSE(msg.request.has_value());
   EXPECT_FALSE(msg.request.holds_alternative<TestSubMsg1>());
   EXPECT_FALSE(msg.request.holds_alternative<TestSubMsg2>());
 


### PR DESCRIPTION
Add a `has_value()` method on the `sub_message` struct to return whether it holds one of the known message types.