### PR TITLE
ssh network filter (15/24): add transport_base

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,8 +23,6 @@ build --remote_download_all
 build:coverage --remote_download_all
 build --enable_platform_specific_config
 build:linux --config=libc++20
-build:linux --copt="-Wno-error=thread-safety-reference-return"
-build:linux --copt="-Wno-error=missing-field-initializers"
 build --cxxopt=-std=c++23 --host_cxxopt=-std=c++23
 # The io_bazel_rules_go stdlib target passes a --no-gc-sections linker argument.
 build:linux --copt="-Wno-error=unused-command-line-argument"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,6 +46,7 @@ http_archive(
     patches = [
         "//patches/envoy:0001-revert-deps-drop-BoringSSL-linkstatic-patch-38621.patch",
         "//patches/envoy:0002-bump-dependencies.patch",
+        "//patches/envoy:0003-envoy-copts.patch",
     ],
     sha256 = "3a8254aae4b775e3cc362c753b25a285b9cd248efe6d4efcc492f0ad045a33be",
     strip_prefix = "envoy-" + envoy_version,

--- a/patches/envoy/0003-envoy-copts.patch
+++ b/patches/envoy/0003-envoy-copts.patch
@@ -1,0 +1,12 @@
+diff --git a/bazel/envoy_internal.bzl b/bazel/envoy_internal.bzl
+index 866a00f280..81854f43c9 100644
+--- a/bazel/envoy_internal.bzl
++++ b/bazel/envoy_internal.bzl
+@@ -16,6 +16,7 @@ def envoy_copts(repository, test = False):
+         "-Wformat-security",
+         "-Wvla",
+         "-Wno-deprecated-declarations",
++        "-Wno-missing-designated-field-initializers",
+         "-Wreturn-type",
+     ]
+     _repo = repo_label(repository)

--- a/source/common/type_traits.h
+++ b/source/common/type_traits.h
@@ -19,6 +19,15 @@ struct callable_info<R (T::*)(Arg) const> {
   using arg_type = std::remove_cv_t<arg_type_with_cv>;
 };
 
+template <typename R, typename T>
+struct callable_info<R (T::*)() const> {
+  using return_type = R;
+  using raw_arg_type = void;
+  using arg_type_with_cv_optref = void;
+  using arg_type_with_cv = void;
+  using arg_type = void;
+};
+
 template <typename F>
 using callable_info_t = callable_info<decltype(&std::decay_t<F>::operator())>;
 

--- a/source/extensions/filters/network/ssh/BUILD
+++ b/source/extensions/filters/network/ssh/BUILD
@@ -36,6 +36,7 @@ envoy_cc_library(
         "packet_cipher_etm.h",
         "service.h",
         "transport.h",
+        "transport_base.h",
         "version_exchange.h",
     ],
     copts = [
@@ -57,6 +58,7 @@ envoy_cc_library(
         "@envoy//source/common/common:logger_lib",
         "@envoy//source/common/common:utility_lib",
         "@envoy//source/common/crypto:utility_lib",
+        "@envoy//source/common/event:deferred_task",
         "@envoy//source/common/grpc:async_client_lib",
         "@envoy//source/common/grpc:typed_async_client_lib",
         "@envoy//source/extensions/filters/network/generic_proxy/interface:codec_interface",

--- a/source/extensions/filters/network/ssh/transport_base.h
+++ b/source/extensions/filters/network/ssh/transport_base.h
@@ -1,0 +1,346 @@
+#pragma once
+
+#include <concepts>
+
+#include "source/common/math.h"
+#include "source/common/status.h"
+#include "source/extensions/filters/network/generic_proxy/interface/codec.h"
+
+#include "source/extensions/filters/network/ssh/kex.h"
+#include "source/extensions/filters/network/ssh/kex_alg_curve25519.h"
+#include "source/extensions/filters/network/ssh/packet_cipher_aead.h"
+#include "source/extensions/filters/network/ssh/packet_cipher_etm.h"
+#include "source/extensions/filters/network/ssh/wire/packet.h"
+#include "source/extensions/filters/network/ssh/wire/messages.h"
+#include "source/extensions/filters/network/ssh/version_exchange.h"
+#include "source/extensions/filters/network/ssh/transport.h"
+
+namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
+
+template <typename T>
+struct codec_traits;
+
+template <typename T>
+  requires std::derived_from<T, ServerCodec>
+struct codec_traits<T> {
+  using callbacks_type = ServerCodecCallbacks;
+  static constexpr DirectionTags direction_read = clientKeys;
+  static constexpr DirectionTags direction_write = serverKeys;
+  static constexpr auto kex_mode = KexMode::Server;
+  static constexpr auto version_exchange_mode = VersionExchangeMode::Server;
+  static constexpr std::string_view name = "server";
+};
+
+template <typename T>
+  requires std::derived_from<T, ClientCodec>
+struct codec_traits<T> {
+  using callbacks_type = ClientCodecCallbacks;
+  static constexpr DirectionTags direction_read = serverKeys;
+  static constexpr DirectionTags direction_write = clientKeys;
+  static constexpr auto kex_mode = KexMode::Client;
+  static constexpr std::string_view name = "client";
+  static constexpr auto version_exchange_mode = VersionExchangeMode::Client;
+};
+
+// RFC4344 § 3.1 states:
+//  SSH implementations SHOULD also attempt to rekey before receiving
+//  more than 2**32 packets since the last rekey operation.  The
+//  preferred way to do this is to rekey after receiving more than 2**31
+//  packets since the last rekey operation.
+//
+// Note that because we require strict key exchange, the sequence number is used to determine how
+// many packets have been sent/received.
+static constexpr uint32_t SeqnumRekeyLimit = (static_cast<uint32_t>(1) << 31);
+
+template <typename Codec>
+class TransportBase : public Codec,
+                      public KexCallbacks,
+                      public SshMessageDispatcher,
+                      public SshMessageHandler,
+                      public virtual TransportCallbacks,
+                      public Logger::Loggable<Logger::Id::filter> {
+public:
+  TransportBase(Api::Api& api,
+                std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config)
+      : api_(api), config_(config) {
+    algorithm_factories_.registerType<Curve25519Sha256KexAlgorithmFactory>();
+    cipher_factories_.registerType<Chacha20Poly1305CipherFactory>();
+    cipher_factories_.registerType<AESGCM128CipherFactory>();
+    cipher_factories_.registerType<AESGCM256CipherFactory>();
+    cipher_factories_.registerType<AES128CTRCipherFactory>();
+    cipher_factories_.registerType<AES192CTRCipherFactory>();
+    cipher_factories_.registerType<AES256CTRCipherFactory>();
+  }
+  using Callbacks = codec_traits<Codec>::callbacks_type;
+
+  void setCodecCallbacks(Callbacks& callbacks) override {
+    this->callbacks_ = &callbacks;
+    kex_ = std::make_unique<Kex>(*this, *this, algorithm_factories_, cipher_factories_, codec_traits<Codec>::kex_mode);
+    kex_->registerMessageHandlers(*this);
+    version_exchanger_ = std::make_unique<VersionExchanger>(*this, *kex_, codec_traits<Codec>::version_exchange_mode);
+
+    cipher_ = std::make_unique<PacketCipher>(std::make_unique<NoCipher>(), std::make_unique<NoCipher>());
+    seq_read_ = 0;
+    seq_write_ = 0;
+    read_bytes_remaining_ = cipher_->rekeyAfterBytes(openssh::CipherMode::Read);
+    write_bytes_remaining_ = cipher_->rekeyAfterBytes(openssh::CipherMode::Write);
+  }
+
+  void decode(Envoy::Buffer::Instance& buffer, bool /*end_stream*/) override {
+    while (buffer.length() > 0) {
+      if (!version_exchange_done_) {
+        // This is the only place where readVersion should be called; if the version is read
+        // completely, it must return an OK status with non-zero value, then continue on to set
+        // the version_exchange_done_ flag to true. So, we should not be able to get here unless
+        // versionRead() is false.
+        ASSERT(!version_exchanger_->versionRead());
+        auto n = version_exchanger_->readVersion(buffer);
+        if (!n.ok()) {
+          onDecodingFailure(n.status());
+          return;
+        }
+        if (*n == 0) {
+          ENVOY_LOG(debug, "received incomplete packet; waiting for more data");
+          return;
+        }
+
+        if (!version_exchanger_->versionWritten()) {
+          version_exchanger_->writeVersion(server_version_);
+        }
+        version_exchange_done_ = true;
+        continue;
+      }
+
+      Envoy::Buffer::OwnedImpl dec;
+      auto bytes_read = cipher_->decryptPacket(seq_read_, dec, buffer);
+      if (!bytes_read.ok()) {
+        onDecodingFailure(statusf("failed to decrypt packet: {}", bytes_read.status()));
+        return;
+      }
+      if (*bytes_read == 0) {
+        // Note: sequence number not increased
+        ENVOY_LOG(debug, "received incomplete packet; waiting for more data");
+        return;
+      }
+      // Only increase the sequence number after reading a full packet
+      seq_read_++;
+
+      wire::Message msg;
+      auto packet_len = wire::decodePacket(dec, msg);
+      if (!packet_len.ok()) {
+        onDecodingFailure(statusf("failed to decode packet: {}", packet_len.status()));
+        return;
+      }
+      ENVOY_LOG(trace, "received message: size: {}, type: {}", *packet_len, msg.msg_type());
+      if (auto err = onMessageDecoded(std::move(msg)); !err.ok()) {
+        onDecodingFailure(err);
+        return;
+      }
+
+      // Check if we need to initiate a key re-exchange
+      //
+      // Note: during key re-exchange, if the message we just decoded was the peer's NewKeys, the
+      // onMessageDecoded callback above will have reset seq_read_, read_bytes_remaining_,
+      // and set pending_key_exchange_ to false.
+      read_bytes_remaining_ = sub_sat(read_bytes_remaining_, static_cast<uint64_t>(*bytes_read));
+      if (!pending_key_exchange_ &&
+          (read_bytes_remaining_ == 0 || seq_read_ > SeqnumRekeyLimit)) {
+        ENVOY_LOG(debug, "ssh [{}]: read rekey threshold was reached, initiating key re-exchange (bytes remaining: {}; packets sent: {})",
+                  codec_traits<Codec>::name,
+                  read_bytes_remaining_, seq_read_);
+        if (auto stat = kex_->initiateKex(); !stat.ok()) {
+          onDecodingFailure(statusf("failed to initiate rekey: {}", stat));
+          return;
+        }
+      }
+    }
+  }
+
+  void writeToConnection(Envoy::Buffer::Instance& buf) const final {
+    return callbacks_->writeToConnection(buf);
+  }
+
+  absl::StatusOr<size_t> sendMessageToConnection(wire::Message&& msg) override {
+    if (!pending_key_exchange_) [[likely]] {
+      return sendMessageDirect(std::move(msg));
+    } else {
+      ENVOY_LOG(debug, "queueing message due to pending key exchange: {}", msg.msg_type());
+      enqueueMessage(std::move(msg));
+      return 0uz;
+    }
+  }
+
+  void updatePeerExtInfo(std::optional<wire::ExtInfoMsg> msg) override {
+    peer_ext_info_ = std::move(msg);
+  }
+
+  std::optional<wire::ExtInfoMsg> outgoingExtInfo() final {
+    if (outgoing_ext_info_.has_value()) {
+      std::optional<wire::ExtInfoMsg> out;
+      outgoing_ext_info_.swap(out);
+      return out;
+    }
+    return {};
+  }
+
+  std::optional<wire::ExtInfoMsg> peerExtInfo() const final {
+    return {peer_ext_info_};
+  }
+
+  virtual absl::Status onMessageDecoded(wire::Message&& msg) {
+    return dispatch(std::move(msg));
+  }
+
+  void onVersionExchangeCompleted(const bytes& server_version, const bytes& client_version, const bytes&) override {
+    std::string serverVersionString(reinterpret_cast<const char*>(server_version.data()),
+                                    server_version.size());
+    std::string clientVersionString(reinterpret_cast<const char*>(client_version.data()),
+                                    client_version.size());
+    ENVOY_LOG(debug, "ssh [{}]: stream {}: version exchange complete (server: {}; client: {})",
+              codec_traits<Codec>::name, streamId(), serverVersionString, clientVersionString);
+    if (auto stat = kex_->initiateKex(); !stat.ok()) {
+      onDecodingFailure(stat);
+    }
+  }
+
+  // If overriding (tests only), be sure to call this function in the implementation
+  void onKexInitMsgSent() override {
+    pending_key_exchange_ = true;
+  }
+
+  void onKexStarted(bool initial_kex) override {
+    if (initial_kex) {
+      ENVOY_LOG(debug, "ssh [{}]: starting initial key exchange", codec_traits<Codec>::name);
+    } else {
+      ENVOY_LOG(debug, "ssh [{}]: starting key re-exchange", codec_traits<Codec>::name);
+    }
+  }
+
+  void onKexCompleted(std::shared_ptr<KexResult> kex_result, bool initial_kex) override {
+    ASSERT(pending_key_exchange_);
+    kex_result_ = kex_result;
+
+    cipher_ = kex_->makePacketCipher(codec_traits<Codec>::direction_read,
+                                     codec_traits<Codec>::direction_write,
+                                     codec_traits<Codec>::kex_mode,
+                                     kex_result.get());
+    if (config_->has_rekey_threshold()) {
+      read_bytes_remaining_ = std::max<uint64_t>(256, config_->rekey_threshold());
+      write_bytes_remaining_ = std::max<uint64_t>(256, config_->rekey_threshold());
+      ENVOY_LOG(debug, "ssh [{}]: new read bytes remaining: {}", codec_traits<Codec>::name, read_bytes_remaining_);
+      ENVOY_LOG(debug, "ssh [{}]: new write bytes remaining: {}", codec_traits<Codec>::name, write_bytes_remaining_);
+
+    } else {
+      read_bytes_remaining_ = cipher_->rekeyAfterBytes(openssh::CipherMode::Read);
+      write_bytes_remaining_ = cipher_->rekeyAfterBytes(openssh::CipherMode::Write);
+    }
+
+    pending_key_exchange_ = false;
+
+    if (initial_kex) {
+      ENVOY_LOG(debug, "ssh [{}]: initial key exchange completed", codec_traits<Codec>::name);
+      this->registerMessageHandlers(*static_cast<SshMessageDispatcher*>(this));
+      ENVOY_BUG(pending_messages_.empty(), "extra messages sent before initial key exchange complete");
+      pending_messages_.clear();
+    } else {
+      ENVOY_LOG(debug, "ssh [{}]: key re-exchange completed", codec_traits<Codec>::name);
+
+      if (!pending_messages_.empty()) {
+        ENVOY_LOG(debug, "ssh [{}]: sending {} messages queued during key re-exchange",
+                  codec_traits<Codec>::name, pending_messages_.size());
+        while (!pending_messages_.empty() && !pending_key_exchange_) {
+          auto& msg = pending_messages_.back();
+          if (auto r = sendMessageDirect(std::move(msg)); !r.ok()) {
+            onDecodingFailure(r.status());
+            return;
+          }
+          pending_messages_.pop_back();
+        }
+      }
+    }
+  }
+
+  virtual void onDecodingFailure(absl::Status err) {
+    if (err.ok()) {
+      ENVOY_LOG(info, "ssh [{}]: stream {} closing", codec_traits<Codec>::name, streamId(), err.message());
+    } else {
+      ENVOY_LOG(error, "ssh [{}]: stream {} closing with error: {}", codec_traits<Codec>::name, streamId(), err.message());
+    }
+    callbacks_->onDecodingFailure(err.message());
+  }
+
+  const bytes& sessionId() const final { return kex_result_->session_id; }
+  const pomerium::extensions::ssh::CodecConfig& codecConfig() const final { return *config_; }
+
+protected:
+  bool version_exchange_done_{};
+  bool pending_key_exchange_{};
+  uint32_t seq_read_{};
+  uint32_t seq_write_{};
+  std::unique_ptr<PacketCipher> cipher_;
+  uint64_t read_bytes_remaining_{};
+  uint64_t write_bytes_remaining_{};
+
+  Callbacks* callbacks_;
+  std::unique_ptr<VersionExchanger> version_exchanger_;
+  std::unique_ptr<Kex> kex_;
+  std::shared_ptr<KexResult> kex_result_;
+  std::optional<wire::ExtInfoMsg> outgoing_ext_info_;
+  std::optional<wire::ExtInfoMsg> peer_ext_info_;
+
+  KexAlgorithmFactoryRegistry algorithm_factories_;
+  DirectionalPacketCipherFactoryRegistry cipher_factories_;
+
+  Api::Api& api_;
+  std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config_;
+
+  std::string server_version_{"SSH-2.0-Envoy"};
+
+  uint64_t resetReadSequenceNumber() override {
+    return std::exchange(seq_read_, 0);
+  }
+
+  uint64_t resetWriteSequenceNumber() override {
+    return std::exchange(seq_write_, 0);
+  }
+
+  absl::StatusOr<size_t> sendMessageDirect(wire::Message&& msg) override {
+    Envoy::Buffer::OwnedImpl dec;
+    auto packet_len = wire::encodePacket(dec,
+                                         msg,
+                                         cipher_->blockSize(openssh::CipherMode::Write),
+                                         cipher_->aadSize(openssh::CipherMode::Write));
+    if (!packet_len.ok()) {
+      return statusf("error encoding packet: {}", packet_len.status());
+    }
+    Envoy::Buffer::OwnedImpl enc;
+
+    auto stat = cipher_->encryptPacket(seq_write_++, enc, dec);
+    ASSERT(stat.ok()); // this should not normally fail
+
+    size_t n = enc.length();
+    writeToConnection(enc);
+
+    write_bytes_remaining_ = sub_sat(write_bytes_remaining_,
+                                     static_cast<uint64_t>(*packet_len));
+    if (!pending_key_exchange_ &&
+        (write_bytes_remaining_ == 0 || seq_write_ > SeqnumRekeyLimit)) {
+      ENVOY_LOG(debug, "ssh [{}]: write rekey threshold was reached, initiating key re-exchange (bytes remaining: {}; packets sent: {})",
+                codec_traits<Codec>::name, write_bytes_remaining_, seq_write_);
+      if (auto stat = kex_->initiateKex(); !stat.ok()) {
+        return statusf("failed to initiate rekey: {}", stat);
+      }
+    }
+
+    return n;
+  }
+
+private:
+  std::deque<wire::Message> pending_messages_;
+
+  void enqueueMessage(wire::Message&& msg) {
+    pending_messages_.emplace_front(std::move(msg));
+  }
+};
+
+} // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/source/extensions/filters/network/ssh/version_exchange.cc
+++ b/source/extensions/filters/network/ssh/version_exchange.cc
@@ -1,4 +1,5 @@
 #include "source/extensions/filters/network/ssh/version_exchange.h"
+#include <ranges>
 
 extern "C" {
 #include "openssh/ssh.h"
@@ -36,9 +37,7 @@ static constexpr size_t MaxVersionExchangeBytes = 16384;
 // upstream to send as either an authentication banner message or a disconnect mesage to the
 // downstream client, depending on whether the upstream disconnects after sending the banner.
 absl::StatusOr<size_t> VersionExchanger::readVersion(Envoy::Buffer::Instance& buffer) {
-  if (did_read_version_) {
-    return absl::FailedPreconditionError("version already read");
-  }
+  RELEASE_ASSERT(!did_read_version_, "bug: version already read");
   if (buffer.length() > MaxVersionExchangeBytes) {
     return absl::InvalidArgumentError("no ssh identification string received");
   } else if (buffer.length() < 4) { // "SSH-"
@@ -98,10 +97,8 @@ absl::StatusOr<size_t> VersionExchanger::readVersion(Envoy::Buffer::Instance& bu
   return versionStringEndIndex + 1;
 }
 
-absl::StatusOr<size_t> VersionExchanger::writeVersion(std::string_view ours) {
-  if (did_write_version_) {
-    return absl::FailedPreconditionError("version already written");
-  }
+size_t VersionExchanger::writeVersion(std::string_view ours) {
+  RELEASE_ASSERT(!did_write_version_, "version already written");
   did_write_version_ = true;
 
   our_version_ = to_bytes(ours);

--- a/source/extensions/filters/network/ssh/version_exchange.h
+++ b/source/extensions/filters/network/ssh/version_exchange.h
@@ -32,7 +32,7 @@ public:
   bool versionWritten() { return did_write_version_; }
   bool versionRead() { return did_read_version_; }
 
-  absl::StatusOr<size_t> writeVersion(std::string_view ours);
+  size_t writeVersion(std::string_view ours);
   absl::StatusOr<size_t> readVersion(Envoy::Buffer::Instance& buffer);
 
   absl::Status validateBanner(const bytes& banner) const;

--- a/test/common/type_traits_test.cc
+++ b/test/common/type_traits_test.cc
@@ -16,17 +16,29 @@ TEST(TypeTraitsTest, CallableInfo) {
   auto overload = [&](opt_ref<const Message2> _) {
     return 2;
   };
+  auto no_args = [&]() {
+    return 3;
+  };
 
   EXPECT_STATIC_ASSERT(std::is_same_v<callable_info_t<decltype(non_overload)>::raw_arg_type, const Message1&>);
   EXPECT_STATIC_ASSERT(std::is_same_v<callable_info_t<decltype(non_overload)>::arg_type_with_cv, const Message1>);
   EXPECT_STATIC_ASSERT(std::is_same_v<callable_info_t<decltype(non_overload)>::arg_type, Message1>);
   EXPECT_STATIC_ASSERT(std::is_same_v<callable_info_t<decltype(non_overload)>::arg_type_with_cv_optref, const Message1>);
+  EXPECT_STATIC_ASSERT(std::is_same_v<callable_info_t<decltype(non_overload)>::return_type, int>);
 
   EXPECT_STATIC_ASSERT(std::is_same_v<callable_info_t<decltype(overload)>::raw_arg_type, opt_ref<const Message2>>);
   EXPECT_STATIC_ASSERT(std::is_same_v<callable_info_t<decltype(overload)>::arg_type_with_cv_optref, opt_ref<const Message2>>);
   EXPECT_STATIC_ASSERT(std::is_same_v<callable_info_t<decltype(overload)>::arg_type_with_cv, const Message2>);
   EXPECT_STATIC_ASSERT(std::is_same_v<callable_info_t<decltype(overload)>::arg_type, Message2>);
+  EXPECT_STATIC_ASSERT(std::is_same_v<callable_info_t<decltype(overload)>::return_type, int>);
+
+  EXPECT_STATIC_ASSERT(std::is_same_v<callable_info_t<decltype(no_args)>::raw_arg_type, void>);
+  EXPECT_STATIC_ASSERT(std::is_same_v<callable_info_t<decltype(no_args)>::arg_type_with_cv_optref, void>);
+  EXPECT_STATIC_ASSERT(std::is_same_v<callable_info_t<decltype(no_args)>::arg_type_with_cv, void>);
+  EXPECT_STATIC_ASSERT(std::is_same_v<callable_info_t<decltype(no_args)>::arg_type, void>);
+  EXPECT_STATIC_ASSERT(std::is_same_v<callable_info_t<decltype(no_args)>::return_type, int>);
 }
+
 TEST(TypeTraitsTest, FunctionInfo) {
   class Test {
   public:

--- a/test/extensions/filters/network/ssh/BUILD
+++ b/test/extensions/filters/network/ssh/BUILD
@@ -218,3 +218,20 @@ envoy_cc_test(
         "@envoy//test/extensions/filters/network/generic_proxy/mocks:codec_mocks",
     ],
 )
+
+envoy_cc_test(
+    name = "transport_base_test",
+    srcs = [
+        "transport_base_test.cc",
+    ],
+    repository = "@envoy",
+    deps = [
+        ":test_env_util_lib",
+        ":test_mocks",
+        "//source/extensions/filters/network/ssh:pomerium_ssh",
+        "//test/extensions/filters/network/ssh/wire:wire_test_util",
+        "//test/test_common:test_common_lib",
+        "@envoy//test/extensions/filters/network/generic_proxy/mocks:codec_mocks",
+        "@envoy//test/mocks/buffer:buffer_mocks",
+    ],
+)

--- a/test/extensions/filters/network/ssh/transport_base_test.cc
+++ b/test/extensions/filters/network/ssh/transport_base_test.cc
@@ -1,0 +1,1333 @@
+#include "source/extensions/filters/network/ssh/transport_base.h"
+#include "gtest/gtest.h"
+#include <latch>
+#include "test/extensions/filters/network/generic_proxy/mocks/codec.h"
+#include "test/extensions/filters/network/ssh/test_env_util.h"
+#include "test/extensions/filters/network/ssh/wire/test_field_reflect.h" // IWYU pragma: keep
+#include "test/extensions/filters/network/ssh/test_mocks.h"              // IWYU pragma: keep
+#include "test/test_common/test_common.h"
+#include "test/test_common/utility.h"
+#include "absl/synchronization/notification.h"
+
+namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
+namespace test {
+// NOLINTBEGIN(readability-identifier-naming)
+template <typename T>
+class MockBaseTransport : public TransportBase<T> {
+public:
+  MockBaseTransport(Api::Api& api,
+                    std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config)
+      : TransportBase<T>(api, config),
+        dispatcher_(api.allocateDispatcher(std::string(codec_traits<T>::name))) {
+    SetVersion(fmt::format("SSH-2.0-{}", codec_traits<T>::name));
+  }
+
+  void setupDefaultMocks() {
+    RELEASE_ASSERT(dispatcher_->isThreadSafe(), "test bug: not thread-safe");
+    ON_CALL(*this, onKexStarted(_))
+      .WillByDefault([this](bool initial) {
+        return this->TransportBase<T>::onKexStarted(initial);
+      });
+    ON_CALL(*this, onKexInitMsgSent())
+      .WillByDefault([this]() {
+        return this->TransportBase<T>::onKexInitMsgSent();
+      });
+    ON_CALL(*this, onKexCompleted(_, _))
+      .WillByDefault([this](std::shared_ptr<KexResult> result, bool initial) {
+        return this->TransportBase<T>::onKexCompleted(result, initial);
+      });
+    ON_CALL(*this, onVersionExchangeCompleted(_, _, _))
+      .WillByDefault([this](const bytes& server_version, const bytes& client_version, const bytes& banner) {
+        return this->TransportBase<T>::onVersionExchangeCompleted(server_version, client_version, banner);
+      });
+    ON_CALL(*this, onMessageDecoded(_))
+      .WillByDefault([this](wire::Message&& msg) {
+        return this->TransportBase<T>::onMessageDecoded(std::move(msg));
+      });
+    ON_CALL(*this, sendMessageToConnection(_))
+      .WillByDefault([this](wire::Message&& msg) {
+        return this->TransportBase<T>::sendMessageToConnection(std::move(msg));
+      });
+    ON_CALL(*this, sendMessageDirect(_))
+      .WillByDefault([this](wire::Message&& msg) {
+        return this->TransportBase<T>::sendMessageDirect(std::move(msg));
+      });
+    ON_CALL(*this, updatePeerExtInfo(_))
+      .WillByDefault([this](std::optional<wire::ExtInfoMsg> msg) {
+        return this->TransportBase<T>::updatePeerExtInfo(std::move(msg));
+      });
+    ON_CALL(*this, registerMessageHandlers(_))
+      .WillByDefault([this](SshMessageDispatcher& dispatcher) {
+        dispatcher.registerHandler(wire::SshMessageType::Debug, this);
+        dispatcher.registerHandler(wire::SshMessageType::Ignore, this);
+        dispatcher.registerHandler(wire::SshMessageType::Disconnect, this);
+      });
+    ON_CALL(*this, streamId)
+      .WillByDefault(Return(1));
+  }
+
+  void setCodecCallbacks(codec_traits<T>::callbacks_type& callbacks) override {
+    TransportBase<T>::setCodecCallbacks(callbacks);
+    this->kex_->setHostKeys(*openssh::loadHostKeys(this->codecConfig().host_keys()));
+  }
+
+  using TransportBase<T>::outgoingExtInfo;
+  using TransportBase<T>::peerExtInfo;
+  using TransportBase<T>::seq_read_;
+  using TransportBase<T>::seq_write_;
+  using TransportBase<T>::cipher_;
+  using TransportBase<T>::read_bytes_remaining_;
+  using TransportBase<T>::write_bytes_remaining_;
+
+  MOCK_METHOD(void, updatePeerExtInfo, (std::optional<wire::ExtInfoMsg>), (override));                   // delegates to the base class
+  MOCK_METHOD(void, onKexStarted, (bool), (override));                                                   // delegates to the base class
+  MOCK_METHOD(void, onKexInitMsgSent, (), (override));                                                   // delegates to the base class
+  MOCK_METHOD(void, onKexCompleted, (std::shared_ptr<KexResult>, bool), (override));                     // delegates to the base class
+  MOCK_METHOD(void, onVersionExchangeCompleted, (const bytes&, const bytes&, const bytes&), (override)); // delegates to the base class
+  MOCK_METHOD(absl::Status, onMessageDecoded, (wire::Message&&), (override));                            // delegates to the base class
+  MOCK_METHOD(absl::StatusOr<size_t>, sendMessageToConnection, (wire::Message&&), (override));           // delegates to the base class
+  MOCK_METHOD(absl::StatusOr<size_t>, sendMessageDirect, (wire::Message&&), (override));                 // delegates to the base class
+
+  MOCK_METHOD(EncodingResult, encode, (const StreamFrame&, EncodingContext&));                         // pure virtual, not tested here
+  MOCK_METHOD(ResponseHeaderFramePtr, respond, (Status, std::string_view, const RequestHeaderFrame&)); // pure virtual, not tested here
+
+  MOCK_METHOD(absl::Status, handleMessage, (wire::Message&&));         // pure virtual, used for assertions
+  MOCK_METHOD(void, registerMessageHandlers, (SshMessageDispatcher&)); // mocked
+
+  MOCK_METHOD(void, forward, (wire::Message&&, FrameTags));                   // pure virtual, not tested here
+  MOCK_METHOD(absl::StatusOr<bytes>, signWithHostKey, (bytes_view), (const)); // pure virtual, not tested here
+  MOCK_METHOD(const AuthState&, authState, (), (const));                      // pure virtual, not tested here
+  MOCK_METHOD(AuthState&, authState, ());                                     // pure virtual, not tested here
+  MOCK_METHOD(stream_id_t, streamId, (), (const));                            // mocked
+
+  void SetOutgoingExtInfo(wire::ExtInfoMsg&& msg) {
+    this->outgoing_ext_info_ = std::move(msg);
+  }
+
+  auto StartThread(absl::Duration timeout) {
+    ASSERT_IS_TEST_THREAD();
+    auto opts = Thread::Options{.name_ = fmt::format("{} thread", codec_traits<T>::name)};
+    return this->api_.threadFactory().createThread(
+      [this, timeout] {
+        setupDefaultMocks();
+        auto timer = dispatcher_->createTimer([this] {
+          RELEASE_ASSERT(dispatcher_->isThreadSafe(), "test bug: not thread-safe");
+          Exit();
+          ADD_FAILURE() << "timeout";
+        });
+        timer->enableTimer(absl::ToChronoMilliseconds(timeout));
+        dispatcher_->run(::Envoy::Event::Dispatcher::RunType::RunUntilExit);
+        timer->disableTimer();
+      },
+      opts);
+  }
+
+  size_t InitiateVersionExchange() {
+    RELEASE_ASSERT(dispatcher_->isThreadSafe(), "test bug: not thread-safe");
+    return this->version_exchanger_->writeVersion(this->server_version_);
+  }
+
+  absl::Status InitiateRekey() {
+    RELEASE_ASSERT(dispatcher_->isThreadSafe(), "test bug: not thread-safe");
+    return this->kex_->initiateKex();
+  }
+
+  void Exit() {
+    closed_ = true;
+    if (!dispatcher_->isThreadSafe()) {
+      dispatcher_->post([this] {
+        this->Exit();
+      });
+    } else {
+      dispatcher_->exit();
+    }
+  }
+
+  template <typename F>
+    requires std::is_void_v<callable_arg_type_t<F>>
+  void Post(F fn) {
+    dispatcher_->post([this, fn] {
+      if (closed_) {
+        return;
+      }
+      fn();
+    });
+  }
+
+  template <typename F>
+    requires std::is_invocable_v<F, MockBaseTransport<T>&>
+  void Post(F fn) {
+    dispatcher_->post([this, fn = std::move(fn)] mutable {
+      if (closed_) {
+        return;
+      }
+      fn(*this);
+    });
+  }
+
+  void SetVersion(std::string_view version) {
+    this->server_version_ = version;
+  }
+
+private:
+  std::atomic_bool closed_{false};
+  ::Envoy::Event::DispatcherPtr dispatcher_;
+};
+
+inline absl::Duration defaultTimeout() {
+  if (isDebuggerAttached()) {
+    return absl::Hours(1);
+  }
+  return absl::Seconds(10);
+}
+
+template <typename TestOptions>
+class TransportBaseTest : public testing::Test {
+public:
+  TransportBaseTest()
+      : api_(Api::createApiForTest()),
+        server_config_(std::make_shared<pomerium::extensions::ssh::CodecConfig>()),
+        client_config_(std::make_shared<pomerium::extensions::ssh::CodecConfig>()),
+        server_transport_(*api_, [this] {
+          for (auto keyName : {"rsa_1", "ed25519_1"}) {
+            server_config_->add_host_keys(copyTestdataToWritableTmp(absl::StrCat("regress/unittests/sshkey/testdata/", keyName), 0600));
+          }
+          return server_config_;
+        }()),
+        client_transport_(*api_, [this] {
+          for (auto keyName : {"rsa_2", "ed25519_2"}) {
+            client_config_->add_host_keys(copyTestdataToWritableTmp(absl::StrCat("regress/unittests/sshkey/testdata/", keyName), 0600));
+          }
+          return client_config_;
+        }()) {}
+
+  void SetUp() override {
+    // wire up the transports to send data to each other; each transport runs its own dispatcher on
+    // a separate thread.
+    ON_CALL(server_codec_callbacks_, writeToConnection)
+      .WillByDefault(Invoke([&](Envoy::Buffer::Instance& input) {
+        Buffer::OwnedImpl buffer;
+        buffer.move(input);
+        client_transport_.Post([buffer = std::move(buffer)](auto& self) mutable {
+          self.decode(buffer, false);
+        });
+      }));
+    ON_CALL(client_codec_callbacks_, writeToConnection)
+      .WillByDefault(Invoke([&](Envoy::Buffer::Instance& input) {
+        Buffer::OwnedImpl buffer;
+        buffer.move(input);
+        server_transport_.Post([buffer = std::move(buffer)](auto& self) mutable {
+          self.decode(buffer, false);
+        });
+      }));
+    EXPECT_CALL(server_codec_callbacks_, writeToConnection).Times(AnyNumber());
+    EXPECT_CALL(client_codec_callbacks_, writeToConnection).Times(AnyNumber());
+    server_transport_.setCodecCallbacks(server_codec_callbacks_);
+    client_transport_.setCodecCallbacks(client_codec_callbacks_);
+  }
+
+  void Start() {
+    auto timeout = defaultTimeout();
+    server_thread_ = server_transport_.StartThread(timeout);
+    client_thread_ = client_transport_.StartThread(timeout);
+  }
+
+  void Join() {
+    server_thread_->join();
+    client_thread_->join();
+  }
+
+  // the terms "client" and "server" here are not really accurate - it's more like "initiator" and
+  // "non-initiator" but that is too verbose/error-prone to write.
+  auto& Client() {
+    if constexpr (TestOptions::client_initiates) {
+      return client_transport_;
+    } else {
+      return server_transport_;
+    }
+  }
+
+  auto& Server() {
+    if constexpr (TestOptions::client_initiates) {
+      return server_transport_;
+    } else {
+      return client_transport_;
+    }
+  }
+
+  auto& ClientCallbacks() {
+    if constexpr (TestOptions::client_initiates) {
+      return client_codec_callbacks_;
+    } else {
+      return server_codec_callbacks_;
+    }
+  }
+
+  auto& ServerCallbacks() {
+    if constexpr (TestOptions::client_initiates) {
+      return server_codec_callbacks_;
+    } else {
+      return client_codec_callbacks_;
+    }
+  }
+  auto& ClientConfig() {
+    if constexpr (TestOptions::client_initiates) {
+      return *client_config_;
+    } else {
+      return *server_config_;
+    }
+  }
+
+  auto& ServerConfig() {
+    if constexpr (TestOptions::client_initiates) {
+      return *server_config_;
+    } else {
+      return *client_config_;
+    }
+  }
+
+  void InitiateVersionExchange() {
+    // The constraint that the client initiates the handshake doesn't apply at this abstraction level
+    Client().Post([](auto& t) {
+      t.InitiateVersionExchange();
+    });
+  }
+
+  void VerifyAndClearExpectations() {
+    testing::Mock::VerifyAndClearExpectations(&server_transport_);
+    testing::Mock::VerifyAndClearExpectations(&client_transport_);
+    testing::Mock::VerifyAndClearExpectations(&server_codec_callbacks_);
+    testing::Mock::VerifyAndClearExpectations(&client_codec_callbacks_);
+
+    // restore the writeToConnection expectations, which are exceptions to the strict mock
+    EXPECT_CALL(server_codec_callbacks_, writeToConnection).Times(AnyNumber());
+    EXPECT_CALL(client_codec_callbacks_, writeToConnection).Times(AnyNumber());
+  }
+
+  // Setup code used in key re-exchange tests
+  bool StartAndWaitForInitialKeyExchange() {
+    EXPECT_CALL(this->Client(), onKexStarted(true));
+    EXPECT_CALL(this->Server(), onKexStarted(true));
+
+    absl::Notification serverKexCompleted;
+    absl::Notification clientKexCompleted;
+
+    EXPECT_CALL(this->Client(), onKexCompleted(_, true))
+      .WillOnce(Invoke([this, &clientKexCompleted](std::shared_ptr<KexResult> result, bool initial) {
+        this->Client().TransportBase::onKexCompleted(result, initial);
+        clientKexCompleted.Notify();
+      }));
+    EXPECT_CALL(this->Server(), onKexCompleted(_, true))
+      .WillOnce(Invoke([this, &serverKexCompleted](std::shared_ptr<KexResult> result, bool initial) {
+        this->Server().TransportBase::onKexCompleted(result, initial);
+        serverKexCompleted.Notify();
+      }));
+
+    this->Start();
+    this->InitiateVersionExchange();
+
+    if (!serverKexCompleted.WaitForNotificationWithTimeout(defaultTimeout())) {
+      ADD_FAILURE() << "timed out waiting for server key exchange";
+      return false;
+    }
+    if (!clientKexCompleted.WaitForNotificationWithTimeout(defaultTimeout())) {
+      ADD_FAILURE() << "timed out waiting for client key exchange";
+      return false;
+    }
+
+    this->VerifyAndClearExpectations();
+    return true;
+  }
+
+protected:
+  Api::ApiPtr api_;
+  Thread::ThreadPtr server_thread_;
+  Thread::ThreadPtr client_thread_;
+  std::shared_ptr<pomerium::extensions::ssh::CodecConfig> server_config_;
+  std::shared_ptr<pomerium::extensions::ssh::CodecConfig> client_config_;
+  testing::NiceMock<MockBaseTransport<ServerCodec>> server_transport_;
+  testing::NiceMock<MockBaseTransport<ClientCodec>> client_transport_;
+  testing::StrictMock<MockServerCodecCallbacks> server_codec_callbacks_;
+  testing::StrictMock<MockClientCodecCallbacks> client_codec_callbacks_;
+  openssh::SSHKeyPtr client_auth_key_ = *openssh::SSHKey::generate(KEY_ED25519, 256);
+};
+// NOLINTEND(readability-identifier-naming)
+
+struct ClientInitiatesOptions {
+  static constexpr bool client_initiates = true;
+};
+struct ServerInitiatesOptions {
+  static constexpr bool client_initiates = false;
+};
+using transportBaseTestTypes = testing::Types<ClientInitiatesOptions, ServerInitiatesOptions>;
+
+TYPED_TEST_SUITE(TransportBaseTest, transportBaseTestTypes);
+
+TYPED_TEST(TransportBaseTest, TestHandshake) {
+  EXPECT_CALL(this->Client(), onKexStarted(true));
+  EXPECT_CALL(this->Server(), onKexStarted(true));
+
+  KexResultSharedPtr clientKexResult;
+  KexResultSharedPtr serverKexResult;
+  EXPECT_CALL(this->Client(), onKexCompleted(_, true))
+    .WillOnce(DoAll(SaveArg<0>(&clientKexResult),
+                    Invoke([this](std::shared_ptr<KexResult> result, bool initial) {
+                      this->Client().TransportBase::onKexCompleted(result, initial);
+                      this->Client().Exit();
+                    })));
+  EXPECT_CALL(this->Server(), onKexCompleted(_, true))
+    .WillOnce(DoAll(SaveArg<0>(&serverKexResult),
+                    Invoke([this](std::shared_ptr<KexResult> result, bool initial) {
+                      this->Server().TransportBase::onKexCompleted(result, initial);
+                      this->Server().Exit();
+                    })));
+
+  this->Start();
+  this->InitiateVersionExchange();
+  this->Join();
+  EXPECT_EQ(*clientKexResult, *serverKexResult);
+  EXPECT_EQ(this->Client().sessionId(), clientKexResult->session_id);
+  EXPECT_EQ(this->Server().sessionId(), serverKexResult->session_id);
+}
+
+TYPED_TEST(TransportBaseTest, TestHandshakeWithExtInfo) {
+  wire::ExtInfoMsg info;
+  info.extensions->emplace_back(wire::PingExtension{.version = "0"s});
+  this->Client().SetOutgoingExtInfo(auto(info));
+  this->Server().SetOutgoingExtInfo(auto(info));
+
+  EXPECT_CALL(this->Client(), onKexStarted(true));
+  EXPECT_CALL(this->Server(), onKexStarted(true));
+
+  EXPECT_CALL(this->Client(), updatePeerExtInfo(_))
+    .WillOnce(Invoke([this](std::optional<wire::ExtInfoMsg> msg) {
+      this->Client().TransportBase::updatePeerExtInfo(std::move(msg));
+      this->Client().Exit();
+    }));
+  EXPECT_CALL(this->Server(), updatePeerExtInfo(_))
+    .WillOnce(Invoke([this](std::optional<wire::ExtInfoMsg> msg) {
+      this->Server().TransportBase::updatePeerExtInfo(std::move(msg));
+      this->Server().Exit();
+    }));
+  EXPECT_CALL(this->Client(), onKexCompleted(_, true))
+    .WillOnce(Invoke([this](std::shared_ptr<KexResult> result, bool initial) {
+      this->Client().TransportBase::onKexCompleted(result, initial);
+      EXPECT_OK(this->Client().sendMessageToConnection(*this->Client().outgoingExtInfo()).status());
+    }));
+  EXPECT_CALL(this->Server(), onKexCompleted(_, true))
+    .WillOnce(Invoke([this](std::shared_ptr<KexResult> result, bool initial) {
+      this->Server().TransportBase::onKexCompleted(result, initial);
+      EXPECT_OK(this->Server().sendMessageToConnection(*this->Server().outgoingExtInfo()).status());
+    }));
+
+  this->Start();
+  this->InitiateVersionExchange();
+  this->Join();
+  EXPECT_EQ(info, this->Client().peerExtInfo());
+  EXPECT_EQ(info, this->Server().peerExtInfo());
+  EXPECT_EQ(std::nullopt, this->Client().outgoingExtInfo());
+  EXPECT_EQ(std::nullopt, this->Server().outgoingExtInfo());
+}
+
+TYPED_TEST(TransportBaseTest, TestVersionExchange_InvalidVersion) {
+  EXPECT_CALL(this->ServerCallbacks(), onDecodingFailure("version string contains invalid characters"sv))
+    .WillOnce([this](std::string_view) {
+      this->Client().Exit();
+      this->Server().Exit();
+    });
+  this->Client().SetVersion("SSH-2.0--");
+
+  this->Start();
+  this->InitiateVersionExchange();
+  this->Join();
+}
+
+TYPED_TEST(TransportBaseTest, TestVersionExchangeIncomplete) {
+  EXPECT_CALL(this->ClientCallbacks(), writeToConnection)
+    .WillOnce(Invoke([&](Envoy::Buffer::Instance& input) {
+      // send two buffers,
+      Buffer::OwnedImpl buffer1; // "SSH-2.0-"
+      buffer1.add(input.linearize(input.length()), input.length() / 2);
+      Buffer::OwnedImpl buffer2; // "SSH-2.0-aaaaaa\r\n"
+      buffer2.move(input);
+      this->Server().Post([buffer = std::move(buffer1)](auto& self) mutable {
+        self.decode(buffer, false);
+      });
+      this->Server().Post([buffer = std::move(buffer2)](auto& self) mutable {
+        self.decode(buffer, false);
+      });
+    }));
+  EXPECT_CALL(this->Client(), onVersionExchangeCompleted)
+    .WillOnce(InvokeWithoutArgs([this] {
+      this->Client().Exit();
+    }));
+  EXPECT_CALL(this->Server(), onVersionExchangeCompleted)
+    .WillOnce(InvokeWithoutArgs([this] {
+      this->Server().Exit();
+    }));
+  this->Client().SetVersion("SSH-2.0-aaaaaa");
+
+  this->Start();
+  this->InitiateVersionExchange();
+  this->Join();
+}
+
+TYPED_TEST(TransportBaseTest, TestKexInitFailureAfterVersionExchange) {
+  EXPECT_CALL(this->Client(), onVersionExchangeCompleted);
+  EXPECT_CALL(this->Server(), onVersionExchangeCompleted)
+    .WillOnce(Invoke([this](const bytes& server_version, const bytes& client_version, const bytes& banner) {
+      // the next KexInitMsg sent by the server will return an error
+      IN_SEQUENCE;
+      EXPECT_CALL(this->Server(), sendMessageDirect(MSG(wire::KexInitMsg, _)))
+        .WillOnce(InvokeWithoutArgs([] {
+          return absl::InternalError("test error");
+        }));
+      EXPECT_CALL(this->ServerCallbacks(), onDecodingFailure(HasSubstr("test error"s)))
+        .WillOnce(InvokeWithoutArgs([this] {
+          this->Server().Exit();
+          this->Client().Exit();
+        }));
+      // complete the version exchange, triggering the KexInitMsg to be sent
+      return this->Server().TransportBase::onVersionExchangeCompleted(server_version, client_version, banner);
+    }));
+  this->Client().SetVersion("SSH-2.0-test");
+  this->Start();
+  this->InitiateVersionExchange();
+  this->Join();
+}
+
+TYPED_TEST(TransportBaseTest, TestDecryptPacketFailure) {
+  EXPECT_CALL(this->Client(), onKexStarted(true));
+  EXPECT_CALL(this->Server(), onKexStarted(true));
+  EXPECT_CALL(this->Client(), onKexCompleted(_, true));
+  EXPECT_CALL(this->Server(), onKexCompleted(_, true))
+    .WillOnce(Invoke([this](std::shared_ptr<KexResult> result, bool initial) {
+      this->Server().TransportBase::onKexCompleted(result, initial);
+      this->Client().Post([this](auto& self) {
+        // change the receiver's sequence number, so they will fail to decrypt the packet
+        self.seq_read_++;
+        // then send them a message
+        this->Server().Post([](auto& server) {
+          EXPECT_OK(server.sendMessageToConnection(wire::Message{wire::DebugMsg{}}).status());
+          server.Exit();
+        });
+      });
+    }));
+
+  EXPECT_CALL(this->ClientCallbacks(), onDecodingFailure(HasSubstr("failed to decrypt packet"s)))
+    .WillOnce(InvokeWithoutArgs([this] {
+      this->Client().Exit();
+    }));
+  this->Start();
+  this->InitiateVersionExchange();
+  this->Join();
+}
+
+TYPED_TEST(TransportBaseTest, TestReadIncompletePacket) {
+  EXPECT_CALL(this->Client(), onKexStarted(true));
+  EXPECT_CALL(this->Server(), onKexStarted(true));
+  EXPECT_CALL(this->Server(), onKexCompleted(_, true));
+
+  wire::Message expectedMsg{wire::IgnoreMsg{.data = "foo"_bytes}};
+  EXPECT_CALL(this->Client(), onKexCompleted(_, true))
+    .WillOnce(Invoke([this, expectedMsg](std::shared_ptr<KexResult> result, bool initial) {
+      this->Client().TransportBase::onKexCompleted(result, initial);
+      IN_SEQUENCE;
+      EXPECT_CALL(this->ClientCallbacks(), writeToConnection)
+        .WillOnce(Invoke([&](Envoy::Buffer::Instance& input) {
+          Buffer::OwnedImpl buffer1;
+          buffer1.add(input.linearize(input.length()), input.length() / 2);
+          Buffer::OwnedImpl buffer2;
+          buffer2.move(input);
+          this->Server().Post([buffer = std::move(buffer1)](auto& server) mutable {
+            server.decode(buffer, false);
+          });
+          this->Server().Post([buffer = std::move(buffer2)](auto& server) mutable {
+            server.decode(buffer, false);
+          });
+        }));
+      EXPECT_CALL(this->Server(), onMessageDecoded(MSG(wire::IgnoreMsg, Eq(wire::IgnoreMsg{.data = "foo"_bytes}))))
+        .WillOnce(Invoke([this](wire::Message&&) {
+          this->Server().Exit();
+          this->Client().Exit();
+          return absl::OkStatus();
+        }));
+      EXPECT_OK(this->Client().sendMessageToConnection(auto(expectedMsg)).status());
+    }));
+  this->Start();
+  this->InitiateVersionExchange();
+  this->Join();
+}
+
+TYPED_TEST(TransportBaseTest, TestDecodePacketFailure) {
+  EXPECT_CALL(this->Client(), onKexCompleted(_, true))
+    .WillOnce(Invoke([this](std::shared_ptr<KexResult> result, bool initial) {
+      this->Client().TransportBase::onKexCompleted(result, initial);
+      EXPECT_CALL(this->ServerCallbacks(), onDecodingFailure("failed to decode packet: invalid padding length"sv))
+        .WillOnce(InvokeWithoutArgs([this] {
+          this->Server().Exit();
+          this->Client().Exit();
+        }));
+
+      Buffer::OwnedImpl badPacket;
+      auto msg = wire::Message{wire::IgnoreMsg{.data = "foo"_bytes}};
+      ASSERT_OK(wire::encodePacket(badPacket, msg,
+                                   this->Client().cipher_->blockSize(openssh::CipherMode::Write),
+                                   this->Client().cipher_->aadSize(openssh::CipherMode::Write))
+                  .status());
+      // poke 0 in for the padding length, which will cause an error when decoding
+      unsafe_forge_span(static_cast<uint8_t*>(badPacket.linearize(5)), 5).back() = 0;
+      // encrypt the packet
+      Buffer::OwnedImpl enc;
+      ASSERT_OK(this->Client().cipher_->encryptPacket(this->Client().seq_write_++, enc, badPacket));
+      // send to server
+      this->ClientCallbacks().writeToConnection(enc);
+    }));
+  this->Start();
+  this->InitiateVersionExchange();
+  this->Join();
+}
+
+TYPED_TEST(TransportBaseTest, TestDecodeMessageFailure) {
+  EXPECT_CALL(this->Client(), onKexStarted(true));
+  EXPECT_CALL(this->Server(), onKexStarted(true));
+  EXPECT_CALL(this->Server(), onKexCompleted(_, true));
+
+  wire::Message expectedMsg{wire::IgnoreMsg{.data = "foo"_bytes}};
+  EXPECT_CALL(this->Client(), onKexCompleted(_, true))
+    .WillOnce(Invoke([this, expectedMsg](std::shared_ptr<KexResult> result, bool initial) {
+      this->Client().TransportBase::onKexCompleted(result, initial);
+
+      IN_SEQUENCE;
+      EXPECT_CALL(this->Server(), onMessageDecoded(MSG(wire::IgnoreMsg, Eq(wire::IgnoreMsg{.data = "foo"_bytes}))))
+        .WillOnce(Invoke([](wire::Message&&) {
+          // simulate an error in the handler for this message
+          return absl::InternalError("test error");
+        }));
+      // this should call onDecodingFailure
+      EXPECT_CALL(this->ServerCallbacks(), onDecodingFailure(HasSubstr("test error"s)))
+        .WillOnce(InvokeWithoutArgs([this] {
+          this->Server().Exit();
+          this->Client().Exit();
+        }));
+      EXPECT_OK(this->Client().sendMessageToConnection(auto(expectedMsg)).status());
+    }));
+  this->Start();
+  this->InitiateVersionExchange();
+  this->Join();
+}
+
+TYPED_TEST(TransportBaseTest, OnDecodingFailure) {
+  EXPECT_CALL(this->ClientCallbacks(), onDecodingFailure("test error"));
+  this->Client().onDecodingFailure(absl::InternalError("test error"));
+
+  EXPECT_CALL(this->ClientCallbacks(), onDecodingFailure(""));
+  this->Client().onDecodingFailure(absl::OkStatus());
+}
+
+TYPED_TEST(TransportBaseTest, TestRekeyManual) {
+  EXPECT_CALL(this->Client(), onKexStarted(true));
+  EXPECT_CALL(this->Server(), onKexStarted(true));
+
+  std::latch wait{2};
+  EXPECT_CALL(this->Client(), onKexCompleted(_, true))
+    .WillOnce(Invoke([this, &wait](std::shared_ptr<KexResult> result, bool initial) {
+      this->Client().TransportBase::onKexCompleted(result, initial);
+      wait.count_down();
+    }));
+  EXPECT_CALL(this->Server(), onKexCompleted(_, true))
+    .WillOnce(Invoke([this, &wait](std::shared_ptr<KexResult> result, bool initial) {
+      this->Server().TransportBase::onKexCompleted(result, initial);
+      wait.count_down();
+    }));
+
+  this->Start();
+  this->InitiateVersionExchange();
+
+  wait.wait();
+  this->VerifyAndClearExpectations();
+
+  EXPECT_CALL(this->Client(), onKexStarted(false));
+  EXPECT_CALL(this->Server(), onKexStarted(false));
+  EXPECT_CALL(this->Client(), onKexCompleted(_, false))
+    .WillOnce(Invoke([this](std::shared_ptr<KexResult> result, bool initial) {
+      this->Client().TransportBase::onKexCompleted(result, initial);
+      this->Client().Exit();
+    }));
+  EXPECT_CALL(this->Server(), onKexCompleted(_, false))
+    .WillOnce(Invoke([this](std::shared_ptr<KexResult> result, bool initial) {
+      this->Server().TransportBase::onKexCompleted(result, initial);
+      this->Server().Exit();
+    }));
+
+  this->Client().Post([](auto& self) {
+    EXPECT_OK(self.InitiateRekey());
+  });
+  this->Join();
+}
+
+TYPED_TEST(TransportBaseTest, TestRekeyWithQueuedMessages) {
+  if (!this->StartAndWaitForInitialKeyExchange()) {
+    return;
+  }
+
+  absl::Notification serverDone{};
+  absl::Notification clientDone{};
+
+  this->Client().Post([&clientDone](auto& client) {
+    // Each of these sequences is thread-local, so there are two separate sequences set up on
+    // each peer's respective thread.
+    // Note: "this->Client()" can be either the server or client transport, so the order of the
+    // KexEcdh messages is slightly different.
+    IN_SEQUENCE;
+    /*C->S*/ EXPECT_CALL(client, sendMessageToConnection(MSG(wire::DebugMsg, FIELD_EQ(message, "client->server unqueued message 1"s))));
+    /*C->S*/ EXPECT_CALL(client, sendMessageDirect(MSG(wire::DebugMsg, FIELD_EQ(message, "client->server unqueued message 1"s))));
+    /*C->S*/ EXPECT_CALL(client, sendMessageToConnection(MSG(wire::DebugMsg, FIELD_EQ(message, "client->server unqueued message 2"s))));
+    /*C->S*/ EXPECT_CALL(client, sendMessageDirect(MSG(wire::DebugMsg, FIELD_EQ(message, "client->server unqueued message 2"s))));
+    /*C->|*/ EXPECT_CALL(client, sendMessageToConnection(MSG(wire::DebugMsg, FIELD_EQ(message, "client->server queued message 1"s))));
+    /*C->|*/ EXPECT_CALL(client, sendMessageToConnection(MSG(wire::DebugMsg, FIELD_EQ(message, "client->server queued message 2"s))));
+    /*C->S*/ EXPECT_CALL(client, sendMessageDirect(MSG(wire::KexInitMsg, _)));
+    /*C<-S*/ EXPECT_CALL(client, onMessageDecoded(MSG(wire::DebugMsg, FIELD_EQ(message, "server->client unqueued message 1"s))));
+    /*C<-S*/ EXPECT_CALL(client, onMessageDecoded(MSG(wire::DebugMsg, FIELD_EQ(message, "server->client unqueued message 2"s))));
+    /*C<-S*/ EXPECT_CALL(client, onMessageDecoded(MSG(wire::KexInitMsg, _)));
+    EXPECT_CALL(client, onKexStarted(false));
+    if constexpr (TypeParam::client_initiates) {
+      /*C->S*/ EXPECT_CALL(client, sendMessageDirect(MSG(wire::KexEcdhInitMsg, _)));
+      /*C<-S*/ EXPECT_CALL(client, onMessageDecoded(MSG(wire::KexEcdhReplyMsg, _)));
+    } else {
+      /*C<-S*/ EXPECT_CALL(client, onMessageDecoded(MSG(wire::KexEcdhInitMsg, _)));
+      /*C->S*/ EXPECT_CALL(client, sendMessageDirect(MSG(wire::KexEcdhReplyMsg, _)));
+    }
+    /*C->S*/ EXPECT_CALL(client, sendMessageDirect(MSG(wire::NewKeysMsg, _)));
+    /*C<-S*/ EXPECT_CALL(client, onMessageDecoded(MSG(wire::NewKeysMsg, _)));
+    EXPECT_CALL(client, onKexCompleted(_, false));
+    /*|->S*/ EXPECT_CALL(client, sendMessageDirect(MSG(wire::DebugMsg, FIELD_EQ(message, "client->server queued message 1"s))));
+    /*|->S*/ EXPECT_CALL(client, sendMessageDirect(MSG(wire::DebugMsg, FIELD_EQ(message, "client->server queued message 2"s))));
+    /*C<-S*/ EXPECT_CALL(client, onMessageDecoded(MSG(wire::DebugMsg, FIELD_EQ(message, "server->client queued message 1"s))));
+    /*C<-S*/ EXPECT_CALL(client, onMessageDecoded(MSG(wire::DebugMsg, FIELD_EQ(message, "server->client queued message 2"s))))
+      .WillOnce(InvokeWithoutArgs([&clientDone] mutable {
+        clientDone.Notify();
+        return absl::OkStatus();
+      }));
+  });
+
+  this->Server().Post([&serverDone](auto& server) {
+    IN_SEQUENCE;
+    /*S<-C*/ EXPECT_CALL(server, onMessageDecoded(MSG(wire::DebugMsg, FIELD_EQ(message, "client->server unqueued message 1"s))));
+    /*S<-C*/ EXPECT_CALL(server, onMessageDecoded(MSG(wire::DebugMsg, FIELD_EQ(message, "client->server unqueued message 2"s))));
+    /*S<-C*/ EXPECT_CALL(server, onMessageDecoded(MSG(wire::KexInitMsg, _)));
+    EXPECT_CALL(server, onKexStarted(false));
+    /*S->C*/ EXPECT_CALL(server, sendMessageToConnection(MSG(wire::DebugMsg, FIELD_EQ(message, "server->client unqueued message 1"s))));
+    /*S->C*/ EXPECT_CALL(server, sendMessageDirect(MSG(wire::DebugMsg, FIELD_EQ(message, "server->client unqueued message 1"s))));
+    /*S->C*/ EXPECT_CALL(server, sendMessageToConnection(MSG(wire::DebugMsg, FIELD_EQ(message, "server->client unqueued message 2"s))));
+    /*S->C*/ EXPECT_CALL(server, sendMessageDirect(MSG(wire::DebugMsg, FIELD_EQ(message, "server->client unqueued message 2"s))));
+    /*S->|*/ EXPECT_CALL(server, sendMessageToConnection(MSG(wire::DebugMsg, FIELD_EQ(message, "server->client queued message 1"s))));
+    /*S->|*/ EXPECT_CALL(server, sendMessageToConnection(MSG(wire::DebugMsg, FIELD_EQ(message, "server->client queued message 2"s))));
+    /*S->C*/ EXPECT_CALL(server, sendMessageDirect(MSG(wire::KexInitMsg, _)));
+    if constexpr (TypeParam::client_initiates) {
+      /*S<-C*/ EXPECT_CALL(server, onMessageDecoded(MSG(wire::KexEcdhInitMsg, _)));
+      /*S->C*/ EXPECT_CALL(server, sendMessageDirect(MSG(wire::KexEcdhReplyMsg, _)));
+    } else {
+      /*S<-C*/ EXPECT_CALL(server, sendMessageDirect(MSG(wire::KexEcdhInitMsg, _)));
+      /*S->C*/ EXPECT_CALL(server, onMessageDecoded(MSG(wire::KexEcdhReplyMsg, _)));
+    }
+    /*S->C*/ EXPECT_CALL(server, sendMessageDirect(MSG(wire::NewKeysMsg, _)));
+    /*S<-C*/ EXPECT_CALL(server, onMessageDecoded(MSG(wire::NewKeysMsg, _)));
+    EXPECT_CALL(server, onKexCompleted(_, false));
+    /*|->C*/ EXPECT_CALL(server, sendMessageDirect(MSG(wire::DebugMsg, FIELD_EQ(message, "server->client queued message 1"s))));
+    /*|->C*/ EXPECT_CALL(server, sendMessageDirect(MSG(wire::DebugMsg, FIELD_EQ(message, "server->client queued message 2"s))));
+    /*S<-C*/ EXPECT_CALL(server, onMessageDecoded(MSG(wire::DebugMsg, FIELD_EQ(message, "client->server queued message 1"s))));
+    /*S<-C*/ EXPECT_CALL(server, onMessageDecoded(MSG(wire::DebugMsg, FIELD_EQ(message, "client->server queued message 2"s))))
+      .WillOnce(InvokeWithoutArgs([&serverDone] mutable {
+        serverDone.Notify();
+        return absl::OkStatus();
+      }));
+  });
+
+  EXPECT_CALL(this->Client(), onKexInitMsgSent())
+    .WillOnce(InvokeWithoutArgs([this] {
+      // sneak in messages before our KexInit (this callback fires before actually sending it)
+      // to check that that they are not queued since they are sent before our KexInit.
+      ASSERT_OK(this->Client().sendMessageToConnection(wire::DebugMsg{.message = "client->server unqueued message 1"s}).status());
+      ASSERT_OK(this->Client().sendMessageToConnection(wire::DebugMsg{.message = "client->server unqueued message 2"s}).status());
+
+      // Calling the base class onKexInitMsgSent is important here - it sets the flag that causes
+      // newly-sent messages to become queued. Note that onKexStarted(false) signals something
+      // else entirely: that the peer has sent their KexInit message, and we must not allow anything
+      // else from them other than key-exchange related messages until they send NewKeys. We can
+      // receive any messages from the peer after sending our own KexInit (starting the re-exchange)
+      // until receiving their KexInit.
+      this->Client().TransportBase::onKexInitMsgSent();
+
+      // after starting the re-exchange on the client side, send a couple messages
+      // these should only be queued, not sent - the matching EXPECT_CALLs occur below
+      ASSERT_OK(this->Client().sendMessageToConnection(wire::DebugMsg{.message = "client->server queued message 1"s}).status());
+      ASSERT_OK(this->Client().sendMessageToConnection(wire::DebugMsg{.message = "client->server queued message 2"s}).status());
+    }));
+  EXPECT_CALL(this->Server(), onKexInitMsgSent())
+    .WillOnce(InvokeWithoutArgs([this] {
+      // same sequence on the server
+
+      ASSERT_OK(this->Server().sendMessageToConnection(wire::DebugMsg{.message = "server->client unqueued message 1"s}).status());
+      ASSERT_OK(this->Server().sendMessageToConnection(wire::DebugMsg{.message = "server->client unqueued message 2"s}).status());
+
+      this->Server().TransportBase::onKexInitMsgSent();
+
+      ASSERT_OK(this->Server().sendMessageToConnection(wire::DebugMsg{.message = "server->client queued message 1"s}).status());
+      ASSERT_OK(this->Server().sendMessageToConnection(wire::DebugMsg{.message = "server->client queued message 2"s}).status());
+    }));
+
+  this->Client().Post([](auto& self) {
+    EXPECT_OK(self.InitiateRekey());
+  });
+
+  // verify the queued messages have been received
+  if (!serverDone.WaitForNotificationWithTimeout(defaultTimeout())) {
+    ADD_FAILURE() << "timed out waiting for server to receive queued messages";
+  }
+  if (!clientDone.WaitForNotificationWithTimeout(defaultTimeout())) {
+    ADD_FAILURE() << "timed out waiting for server to receive queued messages";
+  }
+  this->Server().Exit();
+  this->Client().Exit();
+  this->Join();
+}
+
+TYPED_TEST(TransportBaseTest, TestSimultaneousRekeyOnRWThresholds) {
+  this->ClientConfig().set_rekey_threshold(16384);
+  this->ServerConfig().set_rekey_threshold(16384);
+
+  if (!this->StartAndWaitForInitialKeyExchange()) {
+    return;
+  }
+
+  // send a bunch of messages
+  absl::Notification lastMessage;
+  this->Client().Post([&lastMessage](auto& client) {
+    ASSERT_EQ(16384, client.write_bytes_remaining_);
+    while (client.write_bytes_remaining_ > 1044) { // number of bytes encrypted, less than 1060
+      wire::IgnoreMsg msg;
+      msg.data->resize(1024);
+      auto n = client.sendMessageToConnection(std::move(msg));
+      ASSERT_OK(n.status());
+      EXPECT_EQ(1060, *n);
+    }
+    // the next message will trigger a rekey
+    lastMessage.Notify();
+  });
+  lastMessage.WaitForNotificationWithTimeout(defaultTimeout());
+  ASSERT_GT(this->Client().write_bytes_remaining_, 0);
+  ASSERT_GT(this->Server().read_bytes_remaining_, 0);
+
+  auto* const old_cipher = std::to_address(this->Client().cipher_);
+
+  this->Client().Post([](auto& client) {
+    EXPECT_CALL(client, sendMessageDirect(AllOf(Not(MSG(wire::IgnoreMsg, _)),
+                                                Not(MSG(wire::KexInitMsg, _)))))
+      .Times(AnyNumber());
+    EXPECT_CALL(client, onMessageDecoded(AllOf(Not(MSG(wire::IgnoreMsg, _)),
+                                               Not(MSG(wire::KexInitMsg, _)))))
+      .Times(AnyNumber());
+
+    IN_SEQUENCE;
+    EXPECT_CALL(client, sendMessageDirect(MSG(wire::IgnoreMsg, _)));  // (1) triggers re-kex by write threshold
+    EXPECT_CALL(client, onKexInitMsgSent());                          // (2) client starts kex init
+    EXPECT_CALL(client, sendMessageDirect(MSG(wire::KexInitMsg, _))); // (3)
+    EXPECT_CALL(client, onMessageDecoded(MSG(wire::KexInitMsg, _)));  // (9) client receives the server's kex init
+    EXPECT_CALL(client, onKexStarted(false));                         // (10)
+  });
+
+  this->Server().Post([](auto& server) {
+    EXPECT_CALL(server, sendMessageDirect(AllOf(Not(MSG(wire::IgnoreMsg, _)),
+                                                Not(MSG(wire::KexInitMsg, _)))))
+      .Times(AnyNumber());
+    EXPECT_CALL(server, onMessageDecoded(AllOf(Not(MSG(wire::IgnoreMsg, _)),
+                                               Not(MSG(wire::KexInitMsg, _)))))
+      .Times(AnyNumber());
+
+    IN_SEQUENCE;
+    EXPECT_CALL(server, onMessageDecoded(MSG(wire::IgnoreMsg, _)));   // (4) triggers re-kex by read threshold
+    EXPECT_CALL(server, onKexInitMsgSent());                          // (5) server also starts kex init
+    EXPECT_CALL(server, sendMessageDirect(MSG(wire::KexInitMsg, _))); // (6)
+    EXPECT_CALL(server, onMessageDecoded(MSG(wire::KexInitMsg, _)));  // (7) server receives the client's kex init
+    EXPECT_CALL(server, onKexStarted(false));                         // (8)
+  });
+
+  EXPECT_CALL(this->Client(), onKexCompleted(_, false))
+    .WillOnce(Invoke([&](std::shared_ptr<KexResult> result, bool initial) {
+      this->Client().TransportBase::onKexCompleted(result, initial);
+      // this resets the cipher ^
+      auto* const new_cipher = std::to_address(this->Client().cipher_);
+      EXPECT_NE(old_cipher, new_cipher);
+      EXPECT_EQ(16384, this->Client().write_bytes_remaining_);
+      this->Client().Exit();
+      this->Server().Exit();
+    }));
+  this->Client().Post([this](auto& client) {
+    wire::IgnoreMsg msg;
+    // write a message that will trigger the client's write threshold and the server's read threshold
+    // at the same time
+    msg.data->resize(std::max(this->Client().write_bytes_remaining_,
+                              this->Server().read_bytes_remaining_));
+    ASSERT_OK(client.sendMessageToConnection(std::move(msg)).status());
+  });
+
+  this->Join();
+}
+
+TYPED_TEST(TransportBaseTest, TestRekeyOnReadThreshold) {
+  // Only set server rekey threshold; client's remains the default. The client will be sending lots
+  // of messages to the server, but the server won't send messages back.
+  this->ServerConfig().set_rekey_threshold(16384);
+
+  if (!this->StartAndWaitForInitialKeyExchange()) {
+    return;
+  }
+
+  absl::Notification lastMessage;
+  // first 15 messages are dropped
+  testing::Sequence seq;
+  EXPECT_CALL(this->Server(), onMessageDecoded(MSG(wire::IgnoreMsg, _)))
+    .Times(14)
+    .InSequence(seq);
+  EXPECT_CALL(this->Server(), onMessageDecoded(MSG(wire::IgnoreMsg, _)))
+    .InSequence(seq)
+    .WillOnce(InvokeWithoutArgs([this, &lastMessage] {
+      // 15th message
+      // read_bytes_remaining_ is decremented after this to be under the threshold
+      EXPECT_EQ(1808, this->Server().read_bytes_remaining_);
+      lastMessage.Notify();
+      return absl::OkStatus();
+    }));
+
+  for (int i = 0; i < 15; i++) {
+    this->Client().Post([](auto& client) {
+      wire::IgnoreMsg msg;
+      msg.data->resize(1024);
+      ASSERT_OK(client.sendMessageToConnection(std::move(msg)).status());
+    });
+  }
+  lastMessage.WaitForNotificationWithTimeout(defaultTimeout());
+
+  this->VerifyAndClearExpectations();
+
+  this->Client().Post([](auto& client) {
+    EXPECT_CALL(client, sendMessageDirect(AllOf(Not(MSG(wire::IgnoreMsg, _)),
+                                                Not(MSG(wire::KexInitMsg, _)))))
+      .Times(AnyNumber());
+    EXPECT_CALL(client, onMessageDecoded(AllOf(Not(MSG(wire::IgnoreMsg, _)),
+                                               Not(MSG(wire::KexInitMsg, _)))))
+      .Times(AnyNumber());
+
+    IN_SEQUENCE;
+    EXPECT_CALL(client, sendMessageDirect(MSG(wire::IgnoreMsg, _)));  // (1) client sends 16th msg
+    EXPECT_CALL(client, onMessageDecoded(MSG(wire::KexInitMsg, _)));  // (5) client receives the server's kex init
+    EXPECT_CALL(client, onKexStarted(false));                         // (6)
+    EXPECT_CALL(client, onKexInitMsgSent());                          // (7) client starts kex init
+    EXPECT_CALL(client, sendMessageDirect(MSG(wire::KexInitMsg, _))); // (8)
+  });
+
+  this->Server().Post([](auto& server) {
+    EXPECT_CALL(server, sendMessageDirect(AllOf(Not(MSG(wire::IgnoreMsg, _)),
+                                                Not(MSG(wire::KexInitMsg, _)))))
+      .Times(AnyNumber());
+    EXPECT_CALL(server, onMessageDecoded(AllOf(Not(MSG(wire::IgnoreMsg, _)),
+                                               Not(MSG(wire::KexInitMsg, _)))))
+      .Times(AnyNumber());
+
+    IN_SEQUENCE;
+    EXPECT_CALL(server, onMessageDecoded(MSG(wire::IgnoreMsg, _)));   // (2) triggers re-kex by read threshold
+    EXPECT_CALL(server, onKexInitMsgSent());                          // (3) server starts kex init
+    EXPECT_CALL(server, sendMessageDirect(MSG(wire::KexInitMsg, _))); // (4)
+    EXPECT_CALL(server, onMessageDecoded(MSG(wire::KexInitMsg, _)));  // (9) server receives the client's kex init
+    EXPECT_CALL(server, onKexStarted(false));                         // (10)
+  });
+
+  EXPECT_CALL(this->Server(), onKexCompleted(_, false))
+    .WillOnce(Invoke([&](std::shared_ptr<KexResult> result, bool initial) {
+      this->Server().TransportBase::onKexCompleted(result, initial);
+      EXPECT_EQ(16384, this->Server().read_bytes_remaining_);
+      this->Client().Exit();
+      this->Server().Exit();
+    }));
+  this->Client().Post([](auto& client) {
+    wire::IgnoreMsg msg;
+    msg.data->resize(1024);
+    ASSERT_OK(client.sendMessageToConnection(std::move(msg)).status());
+  });
+
+  this->Join();
+}
+
+TYPED_TEST(TransportBaseTest, TestRekeyOnWriteThreshold) {
+  // Only set client rekey threshold; server's remains the default.
+  this->ClientConfig().set_rekey_threshold(16384);
+
+  if (!this->StartAndWaitForInitialKeyExchange()) {
+    return;
+  }
+
+  absl::Notification lastMessage;
+  testing::Sequence seq;
+  EXPECT_CALL(this->Client(), sendMessageToConnection(MSG(wire::IgnoreMsg, _)))
+    .Times(14)
+    .InSequence(seq);
+  EXPECT_CALL(this->Client(), sendMessageToConnection(MSG(wire::IgnoreMsg, _)))
+    .InSequence(seq)
+    .WillOnce(Invoke([this, &lastMessage](wire::Message&& msg) {
+      // 15th message
+      auto n = this->Client().TransportBase::sendMessageToConnection(std::move(msg));
+      EXPECT_OK(n.status());
+      EXPECT_EQ(724, this->Client().write_bytes_remaining_);
+      lastMessage.Notify();
+      return n;
+    }));
+
+  for (int i = 0; i < 15; i++) {
+    this->Client().Post([](auto& client) {
+      wire::IgnoreMsg msg;
+      msg.data->resize(1024);
+      ASSERT_OK(client.sendMessageToConnection(std::move(msg)).status());
+    });
+  }
+  lastMessage.WaitForNotificationWithTimeout(defaultTimeout());
+
+  this->VerifyAndClearExpectations();
+
+  this->Client().Post([](auto& client) {
+    EXPECT_CALL(client, sendMessageDirect(AllOf(Not(MSG(wire::IgnoreMsg, _)),
+                                                Not(MSG(wire::KexInitMsg, _)))))
+      .Times(AnyNumber());
+    EXPECT_CALL(client, onMessageDecoded(AllOf(Not(MSG(wire::IgnoreMsg, _)),
+                                               Not(MSG(wire::KexInitMsg, _)))))
+      .Times(AnyNumber());
+
+    IN_SEQUENCE;
+    EXPECT_CALL(client, sendMessageDirect(MSG(wire::IgnoreMsg, _)));  // (1) triggers re-kex by write threshold
+    EXPECT_CALL(client, onKexInitMsgSent());                          // (2) client starts kex init
+    EXPECT_CALL(client, sendMessageDirect(MSG(wire::KexInitMsg, _))); // (3) client sends kex init
+    EXPECT_CALL(client, onMessageDecoded(MSG(wire::KexInitMsg, _)));  // (9) client receives the server's kex init
+    EXPECT_CALL(client, onKexStarted(false));                         // (10)
+  });
+
+  this->Server().Post([](auto& server) {
+    EXPECT_CALL(server, sendMessageDirect(AllOf(Not(MSG(wire::IgnoreMsg, _)),
+                                                Not(MSG(wire::KexInitMsg, _)))))
+      .Times(AnyNumber());
+    EXPECT_CALL(server, onMessageDecoded(AllOf(Not(MSG(wire::IgnoreMsg, _)),
+                                               Not(MSG(wire::KexInitMsg, _)))))
+      .Times(AnyNumber());
+
+    IN_SEQUENCE;
+    EXPECT_CALL(server, onMessageDecoded(MSG(wire::IgnoreMsg, _)));   // (4)
+    EXPECT_CALL(server, onMessageDecoded(MSG(wire::KexInitMsg, _)));  // (5) server receives the client's kex init
+    EXPECT_CALL(server, onKexStarted(false));                         // (6)
+    EXPECT_CALL(server, onKexInitMsgSent());                          // (7) server starts kex init
+    EXPECT_CALL(server, sendMessageDirect(MSG(wire::KexInitMsg, _))); // (8)
+  });
+
+  EXPECT_CALL(this->Client(), onKexCompleted(_, false))
+    .WillOnce(Invoke([&](std::shared_ptr<KexResult> result, bool initial) {
+      this->Client().TransportBase::onKexCompleted(result, initial);
+      EXPECT_EQ(16384, this->Client().write_bytes_remaining_);
+      this->Client().Exit();
+      this->Server().Exit();
+    }));
+  this->Client().Post([](auto& client) {
+    wire::IgnoreMsg msg;
+    msg.data->resize(1024);
+    ASSERT_OK(client.sendMessageToConnection(std::move(msg)).status());
+  });
+
+  this->Join();
+}
+
+TYPED_TEST(TransportBaseTest, TestSimultaneousRekeyOnSeqNumThreshold) {
+  if (!this->StartAndWaitForInitialKeyExchange()) {
+    return;
+  }
+
+  // Instead of sending 2 billion messages, cheat a bit.
+  // We hard-code the sequence number limit for both client and server, so in this test both sides
+  // will always trigger the re-key at the same time
+  this->Client().Post([](auto& client) {
+    client.seq_write_ = SeqnumRekeyLimit;
+  });
+  this->Server().Post([](auto& server) {
+    server.seq_read_ = SeqnumRekeyLimit;
+  });
+
+  this->Client().Post([](auto& client) {
+    EXPECT_CALL(client, sendMessageDirect(AllOf(Not(MSG(wire::IgnoreMsg, _)),
+                                                Not(MSG(wire::KexInitMsg, _)))))
+      .Times(AnyNumber());
+    EXPECT_CALL(client, onMessageDecoded(AllOf(Not(MSG(wire::IgnoreMsg, _)),
+                                               Not(MSG(wire::KexInitMsg, _)))))
+      .Times(AnyNumber());
+
+    IN_SEQUENCE;
+    EXPECT_CALL(client, sendMessageDirect(MSG(wire::IgnoreMsg, _)));  // (1) triggers re-kex by write seqnum threshold
+    EXPECT_CALL(client, onKexInitMsgSent());                          // (2) client starts kex init
+    EXPECT_CALL(client, sendMessageDirect(MSG(wire::KexInitMsg, _))); // (3)
+    EXPECT_CALL(client, onMessageDecoded(MSG(wire::KexInitMsg, _)));  // (9) client receives the server's kex init
+    EXPECT_CALL(client, onKexStarted(false));                         // (10)
+  });
+
+  this->Server().Post([](auto& server) {
+    EXPECT_CALL(server, sendMessageDirect(AllOf(Not(MSG(wire::IgnoreMsg, _)),
+                                                Not(MSG(wire::KexInitMsg, _)))))
+      .Times(AnyNumber());
+    EXPECT_CALL(server, onMessageDecoded(AllOf(Not(MSG(wire::IgnoreMsg, _)),
+                                               Not(MSG(wire::KexInitMsg, _)))))
+      .Times(AnyNumber());
+
+    IN_SEQUENCE;
+    EXPECT_CALL(server, onMessageDecoded(MSG(wire::IgnoreMsg, _)));   // (4) triggers re-kex by read seqnum threshold
+    EXPECT_CALL(server, onKexInitMsgSent());                          // (5) server also starts kex init
+    EXPECT_CALL(server, sendMessageDirect(MSG(wire::KexInitMsg, _))); // (6)
+    EXPECT_CALL(server, onMessageDecoded(MSG(wire::KexInitMsg, _)));  // (7) server receives the client's kex init
+    EXPECT_CALL(server, onKexStarted(false));                         // (8)
+  });
+
+  EXPECT_CALL(this->Client(), onKexCompleted(_, false))
+    .WillOnce(Invoke([&](std::shared_ptr<KexResult> result, bool initial) {
+      this->Client().TransportBase::onKexCompleted(result, initial);
+      EXPECT_EQ(this->Server().seq_read_, 0);
+      EXPECT_EQ(this->Server().seq_write_, 0);
+      EXPECT_EQ(this->Client().seq_read_, 0);
+      EXPECT_EQ(this->Client().seq_write_, 0);
+      this->Client().Exit();
+      this->Server().Exit();
+    }));
+  this->Client().Post([](auto& client) {
+    ASSERT_OK(client.sendMessageToConnection(wire::Message{wire::IgnoreMsg{}}).status());
+  });
+
+  this->Join();
+}
+
+TYPED_TEST(TransportBaseTest, TestInitiateKexFailedOnWriteRekey) {
+  if (!this->StartAndWaitForInitialKeyExchange()) {
+    return;
+  }
+
+  this->Client().Post([](auto& client) {
+    client.seq_write_ = SeqnumRekeyLimit;
+  });
+  this->Server().Post([](auto& server) {
+    server.seq_read_ = SeqnumRekeyLimit;
+  });
+
+  this->Client().Post([](auto& client) {
+    IN_SEQUENCE;
+    EXPECT_CALL(client, sendMessageDirect(MSG(wire::IgnoreMsg, _)));
+    EXPECT_CALL(client, sendMessageDirect(MSG(wire::KexInitMsg, _)))
+      .WillOnce(InvokeWithoutArgs([] {
+        return absl::InternalError("test error");
+      }));
+  });
+
+  this->Client().Post([this](auto& client) {
+    ASSERT_EQ(absl::InternalError("failed to initiate rekey: test error"),
+              client.sendMessageToConnection(wire::Message{wire::IgnoreMsg{}}).status());
+    // the failure here happens synchronously; server never receives the message
+    this->Client().Exit();
+    this->Server().Exit();
+  });
+
+  this->Join();
+}
+
+TYPED_TEST(TransportBaseTest, TestInitiateKexFailedOnReadRekey) {
+  if (!this->StartAndWaitForInitialKeyExchange()) {
+    return;
+  }
+
+  this->Client().Post([](auto& client) {
+    client.seq_write_ = SeqnumRekeyLimit;
+  });
+  this->Server().Post([](auto& server) {
+    server.seq_read_ = SeqnumRekeyLimit;
+  });
+
+  this->Client().Post([](auto& client) {
+    IN_SEQUENCE;
+    EXPECT_CALL(client, sendMessageDirect(MSG(wire::IgnoreMsg, _)));
+    EXPECT_CALL(client, sendMessageDirect(MSG(wire::KexInitMsg, _)));
+  });
+
+  this->Server().Post([](auto& server) {
+    EXPECT_CALL(server, sendMessageDirect(MSG(wire::KexInitMsg, _)))
+      .WillOnce(InvokeWithoutArgs([] {
+        return absl::InternalError("test error");
+      }));
+  });
+
+  EXPECT_CALL(this->ServerCallbacks(), onDecodingFailure("failed to initiate rekey: test error"))
+    .WillOnce(InvokeWithoutArgs([this] {
+      this->Server().Exit();
+      this->Client().Exit();
+    }));
+
+  this->Client().Post([](auto& client) {
+    ASSERT_OK(client.sendMessageToConnection(wire::Message{wire::IgnoreMsg{}}).status());
+  });
+
+  this->Join();
+}
+
+TYPED_TEST(TransportBaseTest, TestErrorSendingQueuedMessagesAfterRekey) {
+  if (!this->StartAndWaitForInitialKeyExchange()) {
+    return;
+  }
+  this->Client().Post([](auto& client) {
+    client.seq_write_ = SeqnumRekeyLimit;
+  });
+  this->Server().Post([](auto& server) {
+    server.seq_read_ = SeqnumRekeyLimit;
+  });
+
+  this->Client().Post([](auto& client) {
+    EXPECT_CALL(client, onMessageDecoded(AllOf(
+                          Not(MSG(wire::DebugMsg, _)),
+                          Not(MSG(wire::IgnoreMsg, _)))))
+      .Times(AnyNumber());
+    EXPECT_CALL(client, sendMessageDirect(AllOf(
+                          Not(MSG(wire::DebugMsg, _)),
+                          Not(MSG(wire::IgnoreMsg, _)))))
+      .Times(AnyNumber());
+
+    IN_SEQUENCE;
+    EXPECT_CALL(client, sendMessageDirect(MSG(wire::IgnoreMsg, _)));
+
+    EXPECT_CALL(client, onKexInitMsgSent())
+      .WillOnce(InvokeWithoutArgs([&client] {
+        client.TransportBase::onKexInitMsgSent();
+        ASSERT_OK(client.sendMessageToConnection(wire::DebugMsg{.message = "client->server queued message"s}).status());
+      }));
+    EXPECT_CALL(client, sendMessageDirect(Not(MSG(wire::DebugMsg, _))))
+      .Times(AnyNumber());
+    EXPECT_CALL(client, sendMessageDirect(MSG(wire::DebugMsg, _)))
+      .WillOnce(InvokeWithoutArgs([] {
+        return absl::InternalError("test error");
+      }));
+  });
+
+  this->Server().Post([](auto& server) {
+    EXPECT_CALL(server, onMessageDecoded(AllOf(
+                          Not(MSG(wire::DebugMsg, _)),
+                          Not(MSG(wire::IgnoreMsg, _)))))
+      .Times(AnyNumber());
+    EXPECT_CALL(server, sendMessageDirect(AllOf(
+                          Not(MSG(wire::DebugMsg, _)),
+                          Not(MSG(wire::IgnoreMsg, _)))))
+      .Times(AnyNumber());
+
+    IN_SEQUENCE;
+    EXPECT_CALL(server, onMessageDecoded(MSG(wire::IgnoreMsg, _)));
+
+    EXPECT_CALL(server, onKexInitMsgSent())
+      .WillOnce(InvokeWithoutArgs([&server] {
+        server.TransportBase::onKexInitMsgSent();
+        ASSERT_OK(server.sendMessageToConnection(wire::DebugMsg{.message = "server->client queued message"s}).status());
+      }));
+
+    EXPECT_CALL(server, sendMessageDirect(MSG(wire::DebugMsg, _)))
+      .WillOnce(InvokeWithoutArgs([] {
+        return absl::InternalError("test error");
+      }));
+  });
+
+  EXPECT_CALL(this->ClientCallbacks(), onDecodingFailure("test error"))
+    .WillOnce(InvokeWithoutArgs([this] {
+      this->Client().Exit();
+    }));
+  EXPECT_CALL(this->ServerCallbacks(), onDecodingFailure("test error"))
+    .WillOnce(InvokeWithoutArgs([this] {
+      this->Server().Exit();
+    }));
+
+  this->Client().Post([](auto& client) {
+    ASSERT_OK(client.sendMessageToConnection(wire::Message{wire::IgnoreMsg{}}).status());
+  });
+  this->Join();
+}
+
+TYPED_TEST(TransportBaseTest, TestRekeyTriggeredDuringQueueReplay) {
+  // This tests the following scenario: a key re-exchange is triggered, and several messages are
+  // subsequently placed in the queue. Once the key exchange is completed, the transport begins
+  // replaying the queued messages. While doing so, it exhausts the rekey limit and must pause
+  // to begin another key exchange. Once _that_ key exchange is done, it may continue where it
+  // left off replaying the queued messages.
+
+  // One way to test this is by setting the rekey limit very low.
+  this->ClientConfig().set_rekey_threshold(256); // this is the minimum
+
+  if (!this->StartAndWaitForInitialKeyExchange()) {
+    return;
+  }
+
+  absl::Notification allQueuedMsgsSent;
+  this->Server().Post([this, &allQueuedMsgsSent](auto& server) {
+    EXPECT_CALL(server, onMessageDecoded(Not(MSG(wire::IgnoreMsg, _))))
+      .Times(AnyNumber());
+
+    testing::Sequence seq;
+    EXPECT_CALL(server, onMessageDecoded(MSG(wire::IgnoreMsg, FIELD_EQ(data, bytes(256, 0)))))
+      .InSequence(seq)
+      .WillOnce(InvokeWithoutArgs([&allQueuedMsgsSent] {
+        // delay the first re-exchange until all 100 messages have been enqueued
+        // (this makes it easier to configure the expected call sequence)
+        allQueuedMsgsSent.WaitForNotification();
+        return absl::OkStatus();
+      }));
+    for (uint8_t i = 1; i < 99; i++) {
+      EXPECT_CALL(server, onMessageDecoded(MSG(wire::IgnoreMsg, FIELD_EQ(data, bytes(256, i)))))
+        .InSequence(seq);
+    }
+    EXPECT_CALL(server, onMessageDecoded(MSG(wire::IgnoreMsg, FIELD_EQ(data, bytes(256, 99)))))
+      .InSequence(seq)
+      .WillOnce(InvokeWithoutArgs([this] {
+        this->Client().Exit();
+        this->Server().Exit();
+        return absl::OkStatus();
+      }));
+  });
+  this->Client().Post([](auto& client) {
+    testing::Sequence seq;
+    EXPECT_CALL(client, sendMessageDirect(Not(MSG(wire::IgnoreMsg, _))))
+      .Times(AnyNumber());
+    for (uint8_t i = 0; i < 100; i++) {
+      EXPECT_CALL(client, sendMessageDirect(MSG(wire::IgnoreMsg, FIELD_EQ(data, bytes(256, i)))))
+        .InSequence(seq);
+      if (i != 99) {
+        EXPECT_CALL(client, onKexStarted(false))
+          .InSequence(seq);
+        EXPECT_CALL(client, onKexCompleted(_, false))
+          .InSequence(seq);
+      }
+    }
+  });
+  this->Client().Post([&allQueuedMsgsSent](auto& client) {
+    for (uint8_t i = 0; i < 100; i++) {
+      ASSERT_OK(client.sendMessageToConnection(wire::Message{wire::IgnoreMsg{.data = bytes(256, i)}}).status());
+    }
+    allQueuedMsgsSent.Notify();
+  });
+  this->Join();
+}
+
+TYPED_TEST(TransportBaseTest, TestErrorEncodingPacket) {
+  this->Start();
+  this->Client().Post([this](auto& client) {
+    wire::Message msg{wire::IgnoreMsg{.data = bytes(wire::MaxPacketSize + 1, 0)}};
+    EXPECT_EQ(absl::AbortedError("error encoding packet: message size too large"),
+              client.sendMessageDirect(std::move(msg)).status());
+    this->Client().Exit();
+    this->Server().Exit();
+  });
+  this->Join();
+}
+
+} // namespace test
+} // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/test/extensions/filters/network/ssh/wire/test_field_reflect.h
+++ b/test/extensions/filters/network/ssh/wire/test_field_reflect.h
@@ -142,6 +142,13 @@ struct fmt::formatter<wire::sub_message<Options...>> : formatter<string_view> {
   }
 };
 
+namespace wire {
+template <typename... Options>
+std::ostream& operator<<(std::ostream& os, const wire::sub_message<Options...>& msg) {
+  return os << fmt::to_string(msg);
+}
+} // namespace wire
+
 template <typename... Args>
 struct fmt::formatter<wire::OverloadSet<Args...>> : formatter<string_view> {
   auto format(const wire::OverloadSet<Args...>&, format_context& ctx) const
@@ -151,6 +158,13 @@ struct fmt::formatter<wire::OverloadSet<Args...>> : formatter<string_view> {
   }
 };
 
+namespace wire {
+template <typename... Args>
+std::ostream& operator<<(std::ostream& os, const OverloadSet<Args...>& msg) {
+  return os << fmt::to_string(msg);
+}
+} // namespace wire
+
 template <>
 struct fmt::formatter<wire::Message> : formatter<decltype(wire::Message::message)> {
   auto format(const wire::Message& f, format_context& ctx) const
@@ -158,6 +172,12 @@ struct fmt::formatter<wire::Message> : formatter<decltype(wire::Message::message
     return formatter<decltype(f.message)>::format(f.message, ctx);
   }
 };
+
+namespace wire {
+std::ostream& operator<<(std::ostream& os, const Message& msg) {
+  return os << fmt::to_string(msg);
+}
+} // namespace wire
 
 TEST_FIELDS(DisconnectMsg,
             reason_code,

--- a/test/test_common/test_common.h
+++ b/test/test_common/test_common.h
@@ -108,17 +108,24 @@ using testing::A;
 using testing::AllOf;
 using testing::AllOfArray;
 using testing::An;
+using testing::AnyNumber;
 using testing::AnyOf;
 using testing::AnyOfArray;
+using testing::Contains;
 using testing::DoAll;
 using testing::Eq;
+using testing::Expectation;
 using testing::Field;
+using testing::HasSubstr;
 using testing::InSequence;
 using testing::Invoke;
+using testing::InvokeWithoutArgs;
 using testing::NiceMock;
+using testing::Not;
 using testing::NotNull;
 using testing::Property;
 using testing::Return;
+using testing::ReturnRef;
 using testing::SaveArg;
 using testing::Types;
 using testing::VariantWith;
@@ -126,6 +133,17 @@ using testing::WhenDynamicCastTo;
 
 using Envoy::EnvoyException;
 namespace Buffer = Envoy::Buffer;
+
+inline bool isDebuggerAttached() {
+  std::ifstream status{"/proc/self/status"};
+  std::string line;
+  while (std::getline(status, line)) {
+    if (line.starts_with("TracerPid:\t")) {
+      return line[11] != '0';
+    }
+  }
+  return false;
+}
 
 // =================================================================================================
 // code below vendored from envoy test/test_common/utility.h, which pulls in too many dependencies


### PR DESCRIPTION
- adds the base transport protocol logic
- couple of small supporting modifications to version exchanger and common/type_traits
- updates envoy global copts to disable the `missing-designated-field-initializers` warning, which is not an issue in C++20
- transport.h no longer has a dependency to packet_cipher.h (CipherState was removed)