### PR TITLE
add randomBytes() to test_common.h

### DIFF
--- a/test/extensions/filters/network/ssh/BUILD
+++ b/test/extensions/filters/network/ssh/BUILD
@@ -188,7 +188,6 @@ envoy_cc_test(
         "//source/extensions/filters/network/ssh:pomerium_ssh",
         "//test/extensions/filters/network/ssh/wire:wire_test_util",
         "//test/test_common:test_common_lib",
-        "@com_google_absl//absl/random:random",
         "@envoy//test/mocks/api:api_mocks",
         "@envoy//test/test_common:utility_lib",
     ],

--- a/test/extensions/filters/network/ssh/kex_alg_curve25519_test.cc
+++ b/test/extensions/filters/network/ssh/kex_alg_curve25519_test.cc
@@ -35,17 +35,6 @@ public:
   Algorithms algs_;
 };
 
-static absl::BitGen rng;
-
-inline bytes randomBytes(size_t size) {
-  bytes b;
-  b.resize(size);
-  for (size_t i = 0; i < b.size(); i++) {
-    b[i] = absl::Uniform<uint8_t>(rng);
-  }
-  return b;
-}
-
 TEST_F(KexAlgCurve25519TestSuite, ClientInitMessageTypes) {
   EXPECT_EQ(KexAlgorithm::MessageTypeList{wire::SshMessageType::KexECDHInit}, alg_->clientInitMessageTypes());
 }

--- a/test/extensions/filters/network/ssh/kex_alg_test.cc
+++ b/test/extensions/filters/network/ssh/kex_alg_test.cc
@@ -1,6 +1,5 @@
 #include "source/extensions/filters/network/ssh/kex_alg.h"
 #include "test/extensions/filters/network/ssh/wire/test_field_reflect.h"
-#include "test/extensions/filters/network/ssh/wire/test_util.h"
 #include "test/test_common/test_common.h"
 #include "gtest/gtest.h"
 
@@ -80,17 +79,6 @@ public:
   using KexAlgorithm::computeExchangeHash;
   using KexAlgorithm::computeServerResult;
 };
-
-static absl::BitGen rng;
-
-inline bytes randomBytes(size_t size) {
-  bytes b;
-  b.resize(size);
-  for (size_t i = 0; i < b.size(); i++) {
-    b[i] = absl::Uniform<uint8_t>(rng);
-  }
-  return b;
-}
 
 /*
 From https://datatracker.ietf.org/doc/html/rfc5656#section-4:

--- a/test/extensions/filters/network/ssh/openssh_test.cc
+++ b/test/extensions/filters/network/ssh/openssh_test.cc
@@ -10,7 +10,6 @@
 #include "test/extensions/filters/network/ssh/wire/test_field_reflect.h"
 
 #pragma clang unsafe_buffer_usage begin
-#include "absl/random/random.h"
 #include "absl/strings/str_split.h"
 #pragma clang unsafe_buffer_usage end
 
@@ -587,17 +586,6 @@ static const auto cipherInfo = std::unordered_map<std::string, std::tuple<uint32
 };
 
 class SSHCipherTestSuite : public testing::TestWithParam<std::tuple<std::string, bytes, bytes>> {};
-
-static absl::BitGen rng;
-
-inline bytes randomBytes(size_t size) {
-  bytes b;
-  b.resize(size);
-  for (size_t i = 0; i < b.size(); i++) {
-    b[i] = absl::Uniform<uint8_t>(rng);
-  }
-  return b;
-}
 
 TEST_P(SSHCipherTestSuite, Init) {
   for (auto mode : {CipherMode::Read, CipherMode::Write}) {

--- a/test/extensions/filters/network/ssh/packet_cipher_etm_test.cc
+++ b/test/extensions/filters/network/ssh/packet_cipher_etm_test.cc
@@ -7,19 +7,8 @@
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 namespace test {
 
-static absl::BitGen rng;
-
-inline bytes randomBytes(size_t size) {
-  bytes b;
-  b.resize(size);
-  for (size_t i = 0; i < b.size(); i++) {
-    b[i] = absl::Uniform<uint8_t>(rng);
-  }
-  return b;
-}
-
 struct CipherParameters {
-  const char *const alg;
+  const char* const alg;
   size_t keySize;
 };
 
@@ -105,8 +94,8 @@ TEST_P(ETMPacketCipherTest, DecryptIncompletePacket) {
 TEST_P(ETMPacketCipherTest, DecryptBadCiphertext) {
   Buffer::OwnedImpl buffer;
   buffer.writeBEInt(uint32_t(64));
-  buffer.add( "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
-  buffer.add( "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+  buffer.add("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+  buffer.add("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
 
   Buffer::OwnedImpl decrypted;
   auto r = read_cipher_->decryptPacket(0, decrypted, buffer);
@@ -115,31 +104,31 @@ TEST_P(ETMPacketCipherTest, DecryptBadCiphertext) {
 }
 
 std::vector<CipherParameters> AllETMCipherParameters{
-  { .alg = CipherAES128CTR,
-    .keySize = 16 },
-  { .alg = CipherAES192CTR,
-    .keySize = 24 },
-  { .alg = CipherAES256CTR,
-    .keySize = 32 },
+  {.alg = CipherAES128CTR,
+   .keySize = 16},
+  {.alg = CipherAES192CTR,
+   .keySize = 24},
+  {.alg = CipherAES256CTR,
+   .keySize = 32},
 };
 
 INSTANTIATE_TEST_SUITE_P(ETMPacketCipherTestSuite, ETMPacketCipherTest,
-  testing::Combine(testing::ValuesIn(AllETMCipherParameters),
-                   testing::ValuesIn(SupportedMACs)));
+                         testing::Combine(testing::ValuesIn(AllETMCipherParameters),
+                                          testing::ValuesIn(SupportedMACs)));
 
 TEST(ETMPacketCipherTest, NonETM) {
-    DerivedKeys keys{
-      .iv = bytes(16),
-      .key = bytes(16),
-      .mac = bytes(32),
-    };
-    DirectionAlgorithms algs{
-      .cipher = "aes128-ctr",
-      .mac = "hmac-sha2-256", // non-ETM MAC algorithm
-      .compression = "",
-    };
+  DerivedKeys keys{
+    .iv = bytes(16),
+    .key = bytes(16),
+    .mac = bytes(32),
+  };
+  DirectionAlgorithms algs{
+    .cipher = "aes128-ctr",
+    .mac = "hmac-sha2-256", // non-ETM MAC algorithm
+    .compression = "",
+  };
   EXPECT_THROW_WITH_MESSAGE(
-    ETMPacketCipher(keys, algs, openssh::CipherMode::Read);,
+    ETMPacketCipher(keys, algs, openssh::CipherMode::Read),
     EnvoyException,
     "unsupported mac algorithm (hmac-sha2-256): only etm mac algorithms are supported");
 }
@@ -165,7 +154,6 @@ TEST(ETMPacketCipherFactoryTest, Factory) {
 
   ASSERT_THAT(factories.factoryForName("aes256-ctr").get(),
               WhenDynamicCastTo<AES256CTRCipherFactory*>(NotNull()));
-
 
   for (auto params : AllETMCipherParameters) {
     auto factory = factories.factoryForName(params.alg);

--- a/test/extensions/filters/network/ssh/service_userauth_test.cc
+++ b/test/extensions/filters/network/ssh/service_userauth_test.cc
@@ -1,4 +1,3 @@
-#include "absl/random/random.h"
 #include "gtest/gtest.h"
 #include "test/test_common/utility.h"
 
@@ -17,17 +16,6 @@ TEST(UserAuthServiceTest, SplitUsername) {
   ASSERT_EQ((std::pair{"foo", "bar"}), detail::splitUsername("foo@bar"));
   ASSERT_EQ((std::pair{"foo@bar", "baz"}), detail::splitUsername("foo@bar@baz"));
   ASSERT_EQ((std::pair{"foo\0@bar\0"s, "baz"s}), detail::splitUsername("foo\0@bar\0@baz"s));
-}
-
-static absl::BitGen rng;
-
-inline bytes randomBytes(size_t size) {
-  bytes b;
-  b.resize(size);
-  for (size_t i = 0; i < b.size(); i++) {
-    b[i] = absl::Uniform<uint8_t>(rng);
-  }
-  return b;
 }
 
 class TestSshMessageDispatcher : public SshMessageDispatcher {
@@ -49,7 +37,7 @@ public:
 
     transport_ = std::make_unique<testing::StrictMock<MockDownstreamTransportCallbacks>>();
     EXPECT_CALL(*transport_, codecConfig())
-        .WillRepeatedly(ReturnRef(codecCfg));
+      .WillRepeatedly(ReturnRef(codecCfg));
 
     api_ = std::make_unique<testing::StrictMock<Api::MockApi>>();
     service_ = std::make_unique<DownstreamUserAuthService>(*transport_, *api_);
@@ -301,7 +289,7 @@ TEST_F(DownstreamUserAuthServiceTest, HandleMessageSshKeyboardInteractive) {
 }
 
 TEST_F(DownstreamUserAuthServiceTest, HandleMessageSshKeyboardInteractiveResponse) {
-  wire::UserAuthInfoResponseMsg resp {
+  wire::UserAuthInfoResponseMsg resp{
     .responses = string_list{"response-one", "response-two"},
   };
 
@@ -502,7 +490,7 @@ public:
 
     transport_ = std::make_unique<testing::StrictMock<MockTransportCallbacks>>();
     EXPECT_CALL(*transport_, codecConfig())
-        .WillRepeatedly(ReturnRef(codecCfg));
+      .WillRepeatedly(ReturnRef(codecCfg));
 
     api_ = std::make_unique<testing::StrictMock<Api::MockApi>>();
     service_ = std::make_unique<UpstreamUserAuthService>(*transport_, *api_);
@@ -537,13 +525,13 @@ TEST_F(UpstreamUserAuthServiceTest, RegisterSsh) {
 }
 
 TEST_F(UpstreamUserAuthServiceTest, RequestService) {
-    wire::ServiceRequestMsg expectedRequest{ .service_name = "ssh-userauth"s };
-    wire::Message msg{expectedRequest};
-    EXPECT_CALL(*transport_, sendMessageToConnection(Eq(msg)))
-      .WillOnce(Return(0));
+  wire::ServiceRequestMsg expectedRequest{.service_name = "ssh-userauth"s};
+  wire::Message msg{expectedRequest};
+  EXPECT_CALL(*transport_, sendMessageToConnection(Eq(msg)))
+    .WillOnce(Return(0));
 
-    auto r = service_->requestService();
-    EXPECT_OK(r);
+  auto r = service_->requestService();
+  EXPECT_OK(r);
 }
 
 TEST_F(UpstreamUserAuthServiceTest, OnServiceAcceptedBadAuthState) {
@@ -589,7 +577,7 @@ TEST_F(UpstreamUserAuthServiceTest, OnServiceAcceptedValidSignature) {
 
   // Verify that the signature is valid for the public key presented.
   const auto& pubkey_req = req.message.get<wire::UserAuthRequestMsg>()
-    .request.get<wire::PubKeyUserAuthRequestMsg>();
+                             .request.get<wire::PubKeyUserAuthRequestMsg>();
   auto key = openssh::SSHKey::fromPublicKeyBlob(pubkey_req.public_key);
   ASSERT_OK(key.status());
 

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -17,6 +17,7 @@ envoy_cc_test_library(
     repository = "@envoy",
     deps = [
         "//source/common:common_lib",
+        "@com_google_absl//absl/random",
         "@envoy//test/test_common:logging_lib",
     ],
 )

--- a/test/test_common/test_common.h
+++ b/test/test_common/test_common.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include "source/common/optref.h"
+#include "source/common/types.h"
 #include "source/common/type_traits.h"
 #pragma clang unsafe_buffer_usage begin
 #include "source/common/buffer/buffer_impl.h" // IWYU pragma: keep
-#include "absl/status/statusor.h"             // IWYU pragma: keep
+#include "absl/random/random.h"
+#include "absl/status/statusor.h" // IWYU pragma: keep
 
 #if defined(NDEBUG) || defined(ENVOY_CONFIG_COVERAGE)
 #include "test/test_common/logging.h"
@@ -102,6 +104,17 @@ WhenResolvedAs(const testing::Matcher<T>& inner_matcher) {
 // constexpr code with coverage.
 #define EXPECT_STATIC_ASSERT(...) \
   EXPECT_STATIC_ASSERT_IMPL_((__VA_ARGS__))
+
+static absl::BitGen rng;
+
+inline bytes randomBytes(size_t size) {
+  bytes b;
+  b.resize(size);
+  for (size_t i = 0; i < b.size(); i++) {
+    b[i] = absl::Uniform<uint8_t>(rng);
+  }
+  return b;
+}
 
 using testing::_; // NOLINT(bugprone-reserved-identifier)
 using testing::A;


### PR DESCRIPTION
Extract the duplicated `randomBytes()` function to test_common.h.

Fix some formatting issues.