### PR TITLE
wire: decoding empty length-prefixed lists should not error

### DIFF
--- a/source/extensions/filters/network/ssh/wire/encoding.h
+++ b/source/extensions/filters/network/ssh/wire/encoding.h
@@ -269,7 +269,9 @@ size_t read_opt(Envoy::Buffer::Instance& buffer, T& value, size_t limit) { // NO
   detail::check_incompatible_options<(ListSizePrefixed | ListLengthPrefixed), Opt>();
 
   if (limit == 0) {
-    if constexpr (Opt & (LengthPrefixed | ListSizePrefixed | ListLengthPrefixed)) {
+    // A list with LengthPrefixed elements can read 0 bytes (an empty list), but if the list itself
+    // needs a length or size prefix, it is required.
+    if constexpr (Opt & (ListSizePrefixed | ListLengthPrefixed)) {
       throw Envoy::EnvoyException("short read");
     } else {
       return 0;


### PR DESCRIPTION
Decoding an empty list with the LengthPrefixed option was an error, but it should not be. 

There is one message with a field that is encoded like this (HostKeysProveRequestMsg), and while it doesn't make much sense to ask the server to prove 0 keys, the empty message was not being decoded correctly and erroring in the wrong place.