### PR TITLE
ssh: upstream server-sig-algs support

### DIFF
--- a/source/extensions/filters/network/ssh/openssh.h
+++ b/source/extensions/filters/network/ssh/openssh.h
@@ -46,6 +46,8 @@ static constexpr auto ExtensionPermitPortForwarding = "permit-port-forwarding";
 static constexpr auto ExtensionPermitPty = "permit-pty";
 static constexpr auto ExtensionPermitUserRc = "permit-user-rc";
 
+static constexpr uint32_t DefaultRSAKeySize = 3072;
+
 class SSHKey {
 public:
   SSHKey(const SSHKey&) = delete;
@@ -82,8 +84,8 @@ public:
   std::unique_ptr<SSHKey> toPublicKey() const;
   absl::StatusOr<std::string> formatPrivateKey(sshkey_private_format format = SSHKEY_PRIVATE_OPENSSH) const;
   std::string formatPublicKey() const;
-  absl::StatusOr<bytes> sign(bytes_view payload) const;
-  absl::Status verify(bytes_view signature, bytes_view payload);
+  absl::StatusOr<bytes> sign(bytes_view payload, std::string alg = "") const;
+  absl::Status verify(bytes_view signature, bytes_view payload, std::string alg = "");
 
   const struct sshkey* sshkeyForTest() const { return key_.get(); };
 
@@ -97,6 +99,9 @@ private:
 };
 
 using SSHKeyPtr = std::unique_ptr<SSHKey>;
+
+// Returns the corresponding "plain" signing algorithm, or nullopt if unknown or unsupported.
+std::optional<std::string> certSigningAlgorithmToPlain(const std::string& alg);
 
 absl::StatusOr<std::vector<openssh::SSHKeyPtr>> loadHostKeys(std::ranges::range auto const& filenames) {
   std::vector<openssh::SSHKeyPtr> out;

--- a/source/extensions/filters/network/ssh/service_userauth.h
+++ b/source/extensions/filters/network/ssh/service_userauth.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <tuple>
+
 #include "source/extensions/filters/network/ssh/wire/messages.h"
 #include "source/extensions/filters/network/ssh/grpc_client_impl.h"
 #include "source/extensions/filters/network/ssh/service.h"
@@ -44,6 +46,9 @@ private:
   bool none_auth_handled_{};
 };
 
+// (algorithm, key type, key size in bits)
+using key_params_t = std::tuple<std::string, sshkey_types, uint32_t>;
+
 class UpstreamUserAuthService final : public UserAuthService,
                                       public UpstreamService {
 public:
@@ -54,6 +59,8 @@ public:
   absl::Status onServiceAccepted() override;
 
 private:
+  key_params_t getUpstreamKeyParams();
+
   openssh::SSHKeyPtr ca_user_key_;
   std::unique_ptr<wire::UserAuthRequestMsg> pending_req_;
   bool ext_info_received_{};

--- a/source/extensions/filters/network/ssh/wire/messages.h
+++ b/source/extensions/filters/network/ssh/wire/messages.h
@@ -632,6 +632,16 @@ struct ExtInfoMsg final : Msg<SshMessageType::ExtInfo> {
     return false;
   }
 
+  template <typename T>
+  std::optional<T> getExtension() const {
+    for (const auto& ext : *extensions) {
+      if (ext.extension.holds_alternative<T>()) {
+        return {ext.extension.get<T>()};
+      }
+    }
+    return std::nullopt;
+  }
+
   constexpr auto operator<=>(const ExtInfoMsg&) const = default;
   absl::StatusOr<size_t> decode(Envoy::Buffer::Instance& buffer, size_t payload_size) noexcept;
   absl::StatusOr<size_t> encode(Envoy::Buffer::Instance& buffer) const noexcept;

--- a/test/extensions/filters/network/ssh/wire/messages_test.cc
+++ b/test/extensions/filters/network/ssh/wire/messages_test.cc
@@ -288,6 +288,24 @@ TEST(MessagesTest, EncodeEmpty) {
   ASSERT_EQ(0, buf.length());
 }
 
+TEST(ExtInfoMsgTest, GetExtension) {
+  wire::ExtInfoMsg extInfo{};
+  EXPECT_FALSE(extInfo.getExtension<ServerSigAlgsExtension>().has_value());
+  EXPECT_FALSE(extInfo.getExtension<PingExtension>().has_value());
+
+  wire::PingExtension pingExt{};
+  wire::test::populateFields(pingExt);
+  extInfo.extensions->emplace_back(auto(pingExt));
+  EXPECT_FALSE(extInfo.getExtension<ServerSigAlgsExtension>().has_value());
+  EXPECT_EQ(std::optional{pingExt}, extInfo.getExtension<PingExtension>());
+
+  wire::ServerSigAlgsExtension serverSigAlgs;
+  wire::test::populateFields(serverSigAlgs);
+  extInfo.extensions->emplace_back(auto(serverSigAlgs));
+  EXPECT_EQ(std::optional{serverSigAlgs}, extInfo.getExtension<ServerSigAlgsExtension>());
+  EXPECT_EQ(std::optional{pingExt}, extInfo.getExtension<PingExtension>());
+}
+
 template <typename T>
 class TopLevelMessagesTestSuite : public testing::Test {
 public:


### PR DESCRIPTION
When making a userauth request to an upstream server, check for the server-sig-algs extension, and generate one of the server's preferred keys (if supported).