### PR TITLE
ssh: add downstream server-sig-algs extension

### DIFF
--- a/source/extensions/filters/network/ssh/server_transport.cc
+++ b/source/extensions/filters/network/ssh/server_transport.cc
@@ -41,6 +41,9 @@ SshServerTransport::SshServerTransport(Api::Api& api,
   wire::ExtInfoMsg extInfo;
   extInfo.extensions->emplace_back(wire::PingExtension{.version = "0"s});
   extInfo.extensions->emplace_back(wire::ExtInfoInAuthExtension{.version = "0"s});
+  extInfo.extensions->emplace_back(wire::ServerSigAlgsExtension{
+    .public_key_algorithms_accepted = DownstreamUserAuthService::SupportedSigningAlgorithms,
+  });
   outgoing_ext_info_ = std::move(extInfo);
 };
 

--- a/source/extensions/filters/network/ssh/service_userauth.cc
+++ b/source/extensions/filters/network/ssh/service_userauth.cc
@@ -245,6 +245,15 @@ absl::Status DownstreamUserAuthService::handleMessage(Grpc::ResponsePtr<ServerMe
   }
 }
 
+const string_list DownstreamUserAuthService::SupportedSigningAlgorithms = {
+  "ssh-ed25519",
+  "ecdsa-sha2-nistp256",
+  "ecdsa-sha2-nistp384",
+  "ecdsa-sha2-nistp521",
+  "rsa-sha2-512",
+  "rsa-sha2-256",
+};
+
 UpstreamUserAuthService::UpstreamUserAuthService(TransportCallbacks& callbacks, Api::Api& api)
     : UserAuthService(callbacks, api) {
   {

--- a/source/extensions/filters/network/ssh/service_userauth.h
+++ b/source/extensions/filters/network/ssh/service_userauth.h
@@ -34,6 +34,8 @@ public:
   void registerMessageHandlers(StreamMgmtServerMessageDispatcher& dispatcher) override;
   absl::Status handleMessage(Grpc::ResponsePtr<ServerMessage>&& message) override;
 
+  static const string_list SupportedSigningAlgorithms;
+
 private:
   DownstreamTransportCallbacks& transport_;
   std::optional<std::string> pending_service_auth_;

--- a/test/extensions/filters/network/ssh/server_transport_test.cc
+++ b/test/extensions/filters/network/ssh/server_transport_test.cc
@@ -314,6 +314,17 @@ TEST_F(ServerTransportTest, InitialExtInfo) {
       [](const wire::ExtInfoInAuthExtension& ext) {
         ASSERT_EQ("0", ext.version);
       },
+      [](const wire::ServerSigAlgsExtension& ext) {
+        ASSERT_EQ((string_list{
+                    "ssh-ed25519",
+                    "ecdsa-sha2-nistp256",
+                    "ecdsa-sha2-nistp384",
+                    "ecdsa-sha2-nistp521",
+                    "rsa-sha2-512",
+                    "rsa-sha2-256",
+                  }),
+                  ext.public_key_algorithms_accepted);
+      },
       []<typename T>(const T&) {
         FAIL() << "unexpected extension: " << T::submsg_key << " (this test likely needs to be updated)";
       });


### PR DESCRIPTION
Advertise supported signing algorithms by sending the `server-sig-algs` extension to downstream connections.