### PR TITLE
ssh: build config updates

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,8 +2,8 @@ load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_binary",
 )
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
-load("@rules_foreign_cc//foreign_cc:make.bzl", "make")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -11,11 +11,13 @@ envoy_cc_binary(
     name = "envoy",
     features = select({
         "@platforms//os:macos": [],
+        "@envoy//bazel:asan_build": [],
         "//conditions:default": ["fully_static_link"],
     }),
     repository = "@envoy",
     stamped = True,
     deps = [
+        "//source/extensions/filters/network/ssh:pomerium_ssh",
         "//source/extensions/http/early_header_mutation/trace_context:pomerium_trace_context",
         "//source/extensions/request_id/uuidx:pomerium_uuidx",
         "//source/extensions/tracers/pomerium_otel",
@@ -66,4 +68,13 @@ configure_make(
         "@envoy//bazel:boringcrypto",
         "@envoy//bazel:boringssl",
     ],
+)
+
+refresh_compile_commands(
+    name = "refresh_compile_commands",
+    exclude_headers = "external",
+    targets = {
+        "//:envoy": "",
+        "//test/...": "",
+    },
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,6 +47,7 @@ http_archive(
         "//patches/envoy:0001-revert-deps-drop-BoringSSL-linkstatic-patch-38621.patch",
         "//patches/envoy:0002-bump-dependencies.patch",
         "//patches/envoy:0003-envoy-copts.patch",
+        "//patches/envoy:tmp-fix-upstream-connection-callbacks.patch",
     ],
     sha256 = "3a8254aae4b775e3cc362c753b25a285b9cd248efe6d4efcc492f0ad045a33be",
     strip_prefix = "envoy-" + envoy_version,

--- a/patches/envoy/tmp-fix-upstream-connection-callbacks.patch
+++ b/patches/envoy/tmp-fix-upstream-connection-callbacks.patch
@@ -1,0 +1,16 @@
+diff --git a/source/extensions/filters/network/generic_proxy/router/upstream.cc b/source/extensions/filters/network/generic_proxy/router/upstream.cc
+index 0cbef86bdd..e93d7ee4fd 100644
+--- a/source/extensions/filters/network/generic_proxy/router/upstream.cc
++++ b/source/extensions/filters/network/generic_proxy/router/upstream.cc
+@@ -222,6 +222,11 @@ void BoundGenericUpstream::onEvent(Network::ConnectionEvent event) {
+       encoder_decoder_->onConnectionClose(event);
+     }
+ 
++    // The upstream is already closed, so remove the callback on the downstream conn closing that
++    // triggers the upstream to close. Otherwise this can race with the deferred deletion of the
++    // filter chain and outlive the EncoderDecoder.
++    downstream_conn_.removeConnectionCallbacks(connection_event_watcher_);
++
+     // If the downstream connection is not closed, close it.
+     downstream_conn_.close(Network::ConnectionCloseType::FlushWrite);
+   }


### PR DESCRIPTION
- Updates the //:envoy target to build the ssh extension
- Adds the missing //:refresh_compile_commands target
- Adds the upstream connection callbacks fix patch (still need to submit this upstream)