### PR TITLE
ssh: add limit on auth failures and 'none' auth requests

### DIFF
--- a/source/extensions/filters/network/ssh/service_userauth.cc
+++ b/source/extensions/filters/network/ssh/service_userauth.cc
@@ -120,6 +120,11 @@ absl::Status DownstreamUserAuthService::handleMessage(wire::Message&& msg) {
           return absl::OkStatus();
         },
         [&](const wire::NoneAuthRequestMsg&) {
+          if (none_auth_handled_) {
+            // "none" auth is only allowed once
+            return absl::InvalidArgumentError("invalid auth request");
+          }
+          none_auth_handled_ = true;
           wire::UserAuthFailureMsg failure;
           failure.methods = {"publickey"s};
           return transport_.sendMessageToConnection(std::move(failure)).status();
@@ -208,6 +213,13 @@ absl::Status DownstreamUserAuthService::handleMessage(Grpc::ResponsePtr<ServerMe
       auto methods = deny.methods();
       if (methods.empty()) {
         return absl::PermissionDeniedError("");
+      }
+      if (!deny.partial()) {
+        auth_failure_count_++;
+        if (auth_failure_count_ >= MaxFailedAuthAttempts) {
+          ENVOY_LOG(warn, "max auth attempts exceeded, disconnecting");
+          return absl::PermissionDeniedError("too many authentication failures");
+        }
       }
       wire::UserAuthFailureMsg failure;
       failure.partial = deny.partial();

--- a/source/extensions/filters/network/ssh/service_userauth.h
+++ b/source/extensions/filters/network/ssh/service_userauth.h
@@ -8,6 +8,9 @@
 
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 
+// TODO: configurable?
+static constexpr int MaxFailedAuthAttempts = 6; // DEFAULT_AUTH_FAIL_MAX (openssh/servconf.h)
+
 class UserAuthService : public virtual Service,
                         public Logger::Loggable<Logger::Id::filter> {
 public:
@@ -37,6 +40,8 @@ public:
 private:
   DownstreamTransportCallbacks& transport_;
   std::optional<std::string> pending_service_auth_;
+  int auth_failure_count_{};
+  bool none_auth_handled_{};
 };
 
 class UpstreamUserAuthService final : public UserAuthService,


### PR DESCRIPTION
- Adds a limit of 6 auth failure attempts before disconnecting
- Ensures the "none" auth request can only be sent once.