### PR TITLE
version exchange: remove crlf suffix from version before passing to callback

### DIFF
--- a/test/extensions/filters/network/ssh/server_transport_test.cc
+++ b/test/extensions/filters/network/ssh/server_transport_test.cc
@@ -89,8 +89,8 @@ public:
     ASSERT_OK(wire::encodePacket(input_buffer_, kex_init_, 8, 0).status());
     transport_.decode(input_buffer_, false);
     HandshakeMagics magics{
-      .client_version = "SSH-2.0-TestClient\r\n"_bytes,
-      .server_version = "SSH-2.0-Envoy\r\n"_bytes,
+      .client_version = "SSH-2.0-TestClient"_bytes,
+      .server_version = "SSH-2.0-Envoy"_bytes,
       .client_kex_init = *wire::encodeTo<bytes>(kex_init_),
       .server_kex_init = *wire::encodeTo<bytes>(serverKexInit),
     };
@@ -977,8 +977,8 @@ TEST_F(ServerTransportTest, HandleRekey) {
   wire::KexInitMsg serverKexInit;
   ASSERT_OK(ReadMsg(serverKexInit));
   HandshakeMagics magics{
-    .client_version = "SSH-2.0-TestClient\r\n"_bytes,
-    .server_version = "SSH-2.0-Envoy\r\n"_bytes,
+    .client_version = "SSH-2.0-TestClient"_bytes,
+    .server_version = "SSH-2.0-Envoy"_bytes,
     .client_kex_init = *wire::encodeTo<bytes>(kex_init_),
     .server_kex_init = *wire::encodeTo<bytes>(serverKexInit),
   };

--- a/test/extensions/filters/network/ssh/version_exchange_test.cc
+++ b/test/extensions/filters/network/ssh/version_exchange_test.cc
@@ -68,19 +68,19 @@ public:
 
     const auto& [params, terminator, mode, order, split] = GetParam();
     const auto& [banner, version, status] = params;
-    bytes versionWithTerm = version;
-    replaceTerm(versionWithTerm, terminator);
+    bytes versionWithoutTerm = version;
+    replaceTerm(versionWithoutTerm, {});
     switch (mode) {
     case VersionExchangeMode::Server:
       EXPECT_CALL(transport_, writeToConnection(BufferStringEqual("ignored\r\n"s)));
       if (order == WriteFirst) {
         ASSERT_EQ(9, vex_.writeVersion("ignored"));
         if (status.ok()) {
-          EXPECT_CALL(vex_callbacks_, onVersionExchangeCompleted("ignored\r\n"_bytes, versionWithTerm, bytes{}));
+          EXPECT_CALL(vex_callbacks_, onVersionExchangeCompleted("ignored"_bytes, versionWithoutTerm, bytes{}));
         }
       } else {
         if (status.ok()) {
-          EXPECT_CALL(vex_callbacks_, onVersionExchangeCompleted("ignored\r\n"_bytes, versionWithTerm, bytes{}));
+          EXPECT_CALL(vex_callbacks_, onVersionExchangeCompleted("ignored"_bytes, versionWithoutTerm, bytes{}));
         }
         ASSERT_EQ(9, vex_.writeVersion("ignored"));
       }
@@ -90,11 +90,11 @@ public:
       if (order == WriteFirst) {
         ASSERT_EQ(9, vex_.writeVersion("ignored"));
         if (status.ok()) {
-          EXPECT_CALL(vex_callbacks_, onVersionExchangeCompleted(versionWithTerm, "ignored\r\n"_bytes, banner));
+          EXPECT_CALL(vex_callbacks_, onVersionExchangeCompleted(versionWithoutTerm, "ignored"_bytes, banner));
         }
       } else {
         if (status.ok()) {
-          EXPECT_CALL(vex_callbacks_, onVersionExchangeCompleted(versionWithTerm, "ignored\r\n"_bytes, banner));
+          EXPECT_CALL(vex_callbacks_, onVersionExchangeCompleted(versionWithoutTerm, "ignored"_bytes, banner));
         }
         ASSERT_EQ(9, vex_.writeVersion("ignored"));
       }


### PR DESCRIPTION
This was refactored at some point to _include_ the trailing \r\n in the final version exchange strings passed to the callback. IIRC the thinking was that if the client only sent \n and not \r\n (since we are lenient about it), this difference would need to be kept track of, but I don't think that is actually the case. The logic to compute the exchange hash wasn't updated though, leading to the session identifier being incorrect, but it's less confusing if we just remove the suffix right away.