### PR TITLE
patch memory leak in openssh configure script test

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -119,6 +119,9 @@ filegroup(
         # Links in the no-op security key implementation used in some openssh tests. We use libssh
         # standalone, but disable the security key feature, so the symbols are left undefined.
         "//patches/openssh:0003-ssh-sk-null.patch",
+        # Avoid a memory leak in a test program in the configure script that would otherwise
+        # disable P-521 elliptic key support in asan builds.
+        "//patches/openssh:0004-configure-asan.patch",
     ],
 )
 

--- a/patches/openssh/0004-configure-asan.patch
+++ b/patches/openssh/0004-configure-asan.patch
@@ -1,0 +1,15 @@
+diff --git a/configure.ac b/configure.ac
+index ee77a0484..00730cfb0 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -3219,7 +3219,9 @@ if test "x$openssl" = "xyes" ; then
+ 			]],[[
+ 			EC_KEY *e = EC_KEY_new_by_curve_name(NID_secp521r1);
+ 			const EVP_MD *m = EVP_sha512(); /* We need this too */
+-			exit(e == NULL || m == NULL);
++			int status = e == NULL || m == NULL;
++			EC_KEY_free(e);
++			exit(status);
+ 			]])],
+ 			[ AC_MSG_RESULT([yes])
+ 			  enable_nistp521=1 ],

--- a/test/extensions/filters/network/ssh/kex_test.cc
+++ b/test/extensions/filters/network/ssh/kex_test.cc
@@ -262,9 +262,7 @@ public:
     client_host_keys_.push_back(*openssh::SSHKey::generate(KEY_ED25519, 256));
     client_host_keys_.push_back(*openssh::SSHKey::generate(KEY_ECDSA, 256));
     client_host_keys_.push_back(*openssh::SSHKey::generate(KEY_ECDSA, 384));
-#ifdef OPENSSL_HAS_NISTP521
     client_host_keys_.push_back(*openssh::SSHKey::generate(KEY_ECDSA, 521));
-#endif
     client_host_keys_.push_back(*openssh::SSHKey::generate(KEY_RSA, 2048));
 
     algorithm_factories_.registerType<Curve25519Sha256KexAlgorithmFactory>();
@@ -285,9 +283,7 @@ public:
     hostKeys.push_back(*openssh::SSHKey::generate(KEY_ED25519, 256));
     hostKeys.push_back(*openssh::SSHKey::generate(KEY_ECDSA, 256));
     hostKeys.push_back(*openssh::SSHKey::generate(KEY_ECDSA, 384));
-#ifdef OPENSSL_HAS_NISTP521
     hostKeys.push_back(*openssh::SSHKey::generate(KEY_ECDSA, 521));
-#endif
     hostKeys.push_back(*openssh::SSHKey::generate(KEY_RSA, 2048));
 
     std::unordered_map<std::string, bytes> hostKeyBlobs;
@@ -413,9 +409,7 @@ protected:
         "ssh-ed25519",
         "ecdsa-sha2-nistp256",
         "ecdsa-sha2-nistp384",
-#ifdef OPENSSL_HAS_NISTP521
         "ecdsa-sha2-nistp521",
-#endif
         "rsa-sha2-256",
         "rsa-sha2-512",
       };
@@ -689,9 +683,7 @@ TEST_F(AlgorithmNegotiationTest, NoCommonHostKey) {
                   "ssh-ed25519",
                   "ecdsa-sha2-nistp256",
                   "ecdsa-sha2-nistp384",
-#ifdef OPENSSL_HAS_NISTP521
                   "ecdsa-sha2-nistp521",
-#endif
                   "rsa-sha2-256",
                   "rsa-sha2-512",
                 })));

--- a/test/extensions/filters/network/ssh/openssh_test.cc
+++ b/test/extensions/filters/network/ssh/openssh_test.cc
@@ -193,13 +193,9 @@ TEST(SSHKeyTest, Generate) {
   EXPECT_OK(r.status());
   EXPECT_EQ(KEY_ECDSA, (*r)->keyType());
 
-  // XXX: this detection fails in openssh for asan builds, so the nistp-521 curves are disabled.
-  // non-asan builds detect this fine though.
-#ifdef OPENSSL_HAS_NISTP521
   r = SSHKey::generate(KEY_ECDSA, 521);
   EXPECT_OK(r.status());
   EXPECT_EQ(KEY_ECDSA, (*r)->keyType());
-#endif
 
   r = SSHKey::generate(KEY_ED25519, 256);
   EXPECT_OK(r.status());
@@ -277,9 +273,7 @@ INSTANTIATE_TEST_SUITE_P(SSHKeyTest, SSHKeyTestSuite,
                            {KEY_RSA, 2048},
                            {KEY_ECDSA, 256},
                            {KEY_ECDSA, 384},
-#ifdef OPENSSL_HAS_NISTP521
                            {KEY_ECDSA, 521},
-#endif
                            {KEY_ED25519, 256},
                          }));
 
@@ -381,9 +375,7 @@ INSTANTIATE_TEST_SUITE_P(SSHKeyCertTest, SSHKeyCertTestSuite,
                            {KEY_RSA, 2048},
                            {KEY_ECDSA, 256},
                            {KEY_ECDSA, 384},
-#ifdef OPENSSL_HAS_NISTP521
                            {KEY_ECDSA, 521},
-#endif
                            {KEY_ED25519, 256},
                          }));
 
@@ -582,10 +574,8 @@ INSTANTIATE_TEST_SUITE_P(SSHKeyPropertiesTest, SSHKeyPropertiesTestSuite,
                            {KEY_ECDSA_CERT, 256},
                            {KEY_ECDSA, 384},
                            {KEY_ECDSA_CERT, 384},
-#ifdef OPENSSL_HAS_NISTP521
                            {KEY_ECDSA, 521},
                            {KEY_ECDSA_CERT, 521},
-#endif
                            {KEY_ED25519, 256},
                            {KEY_ED25519_CERT, 256},
                          }));


### PR DESCRIPTION
Enable P-521 elliptic key support in asan builds, by patching the test program in the openssh configure script. The test program generates a P-521 key but does not free it, causing an asan build of this program to exit with a non-zero status code. This causes the configure script to conclude incorrectly that the P-521 algorithm is not supported.

With this patch, we can remove the #ifdef OPENSSL_HAS_NISTP521 checks in the unit tests.