### PR TITLE
ssh: add pre-computed fingerprint to user auth request

### DIFF
--- a/api/extensions/filters/network/ssh/ssh.pb.go
+++ b/api/extensions/filters/network/ssh/ssh.pb.go
@@ -1740,11 +1740,12 @@ func (*SSHChannelControlAction_Disconnect_) isSSHChannelControlAction_Action() {
 func (*SSHChannelControlAction_HandOff) isSSHChannelControlAction_Action() {}
 
 type PublicKeyMethodRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	PublicKey     []byte                 `protobuf:"bytes,1,opt,name=public_key,json=publicKey,proto3" json:"public_key,omitempty"`
-	PublicKeyAlg  string                 `protobuf:"bytes,2,opt,name=public_key_alg,json=publicKeyAlg,proto3" json:"public_key_alg,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                      protoimpl.MessageState `protogen:"open.v1"`
+	PublicKey                  []byte                 `protobuf:"bytes,1,opt,name=public_key,json=publicKey,proto3" json:"public_key,omitempty"`
+	PublicKeyAlg               string                 `protobuf:"bytes,2,opt,name=public_key_alg,json=publicKeyAlg,proto3" json:"public_key_alg,omitempty"`
+	PublicKeyFingerprintSha256 []byte                 `protobuf:"bytes,3,opt,name=public_key_fingerprint_sha256,json=publicKeyFingerprintSha256,proto3" json:"public_key_fingerprint_sha256,omitempty"` // raw fingerprint, no formatting
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *PublicKeyMethodRequest) Reset() {
@@ -1789,6 +1790,13 @@ func (x *PublicKeyMethodRequest) GetPublicKeyAlg() string {
 		return x.PublicKeyAlg
 	}
 	return ""
+}
+
+func (x *PublicKeyMethodRequest) GetPublicKeyFingerprintSha256() []byte {
+	if x != nil {
+		return x.PublicKeyFingerprintSha256
+	}
+	return nil
 }
 
 type PublicKeyAllowResponse struct {
@@ -2537,11 +2545,12 @@ const file_github_com_pomerium_envoy_custom_api_extensions_filters_network_ssh_s
 	"\x17downstream_channel_info\x18\x02 \x01(\v21.pomerium.extensions.ssh.SSHDownstreamChannelInfoR\x15downstreamChannelInfo\x12]\n" +
 	"\x13downstream_pty_info\x18\x03 \x01(\v2-.pomerium.extensions.ssh.SSHDownstreamPTYInfoR\x11downstreamPtyInfo\x12K\n" +
 	"\rupstream_auth\x18\x04 \x01(\v2&.pomerium.extensions.ssh.AllowResponseR\fupstreamAuthB\b\n" +
-	"\x06action\"]\n" +
+	"\x06action\"\xa0\x01\n" +
 	"\x16PublicKeyMethodRequest\x12\x1d\n" +
 	"\n" +
 	"public_key\x18\x01 \x01(\fR\tpublicKey\x12$\n" +
-	"\x0epublic_key_alg\x18\x02 \x01(\tR\fpublicKeyAlg\"\x7f\n" +
+	"\x0epublic_key_alg\x18\x02 \x01(\tR\fpublicKeyAlg\x12A\n" +
+	"\x1dpublic_key_fingerprint_sha256\x18\x03 \x01(\fR\x1apublicKeyFingerprintSha256\"\x7f\n" +
 	"\x16PublicKeyAllowResponse\x12\x1d\n" +
 	"\n" +
 	"public_key\x18\x01 \x01(\fR\tpublicKey\x12F\n" +

--- a/api/extensions/filters/network/ssh/ssh.proto
+++ b/api/extensions/filters/network/ssh/ssh.proto
@@ -265,8 +265,9 @@ message SSHChannelControlAction {
 }
 
 message PublicKeyMethodRequest {
-  bytes  public_key     = 1;
-  string public_key_alg = 2;
+  bytes  public_key                    = 1;
+  string public_key_alg                = 2;
+  bytes  public_key_fingerprint_sha256 = 3; // raw fingerprint, no formatting
 }
 
 message PublicKeyAllowResponse {

--- a/source/extensions/filters/network/ssh/openssh.cc
+++ b/source/extensions/filters/network/ssh/openssh.cc
@@ -241,6 +241,14 @@ absl::StatusOr<std::string> SSHKey::fingerprint(sshkey_fp_rep representation) co
   return std::string{fp.get()};
 }
 
+bytes SSHKey::rawFingerprint() const {
+  CBytesPtr fp_bytes;
+  size_t fp_len{};
+  auto r = sshkey_fingerprint_raw(key_.get(), SSH_DIGEST_SHA256, std::out_ptr(fp_bytes), &fp_len);
+  ASSERT(r == 0); // only fails on invalid usage or oom
+  return to_bytes(unsafe_forge_span(fp_bytes.get(), fp_len));
+}
+
 std::string_view SSHKey::keyTypeName() const {
   return {namePtr()};
 }

--- a/source/extensions/filters/network/ssh/openssh.h
+++ b/source/extensions/filters/network/ssh/openssh.h
@@ -74,6 +74,7 @@ public:
   // Returns the cert-less equivalent to a certified key type
   static sshkey_types keyTypePlain(sshkey_types type);
 
+  bytes rawFingerprint() const;
   absl::StatusOr<std::string> fingerprint(sshkey_fp_rep representation = SSH_FP_DEFAULT) const;
   std::string_view keyTypeName() const;
   sshkey_types keyType() const;

--- a/source/extensions/filters/network/ssh/service_userauth.cc
+++ b/source/extensions/filters/network/ssh/service_userauth.cc
@@ -108,6 +108,8 @@ absl::Status DownstreamUserAuthService::handleMessage(wire::Message&& msg) {
           PublicKeyMethodRequest method_req;
           method_req.set_public_key(pubkey_req.public_key->data(), pubkey_req.public_key->size());
           method_req.set_public_key_alg(pubkey_req.public_key_alg);
+          auto rawFp = (*userPubKey)->rawFingerprint();
+          method_req.set_public_key_fingerprint_sha256(rawFp.data(), rawFp.size());
           auth_req.mutable_method_request()->PackFrom(method_req);
 
           pomerium::extensions::ssh::ClientMessage clientMsg;

--- a/test/extensions/filters/network/ssh/server_transport_test.cc
+++ b/test/extensions/filters/network/ssh/server_transport_test.cc
@@ -192,6 +192,8 @@ public:
     PublicKeyMethodRequest method_req;
     method_req.set_public_key(pubkeyReq.public_key->data(), pubkeyReq.public_key->size());
     method_req.set_public_key_alg(pubkeyReq.public_key_alg);
+    auto clientKeyFp = clientKey.rawFingerprint();
+    method_req.set_public_key_fingerprint_sha256(clientKeyFp.data(), clientKeyFp.size());
     grpcAuthReq.mutable_method_request()->PackFrom(method_req);
 
     ClientMessage clientMsg;

--- a/test/extensions/filters/network/ssh/service_userauth_test.cc
+++ b/test/extensions/filters/network/ssh/service_userauth_test.cc
@@ -291,6 +291,11 @@ TEST_F(DownstreamUserAuthServiceTest, HandleMessageSshPubKeyValidSignature) {
   ASSERT_TRUE(auth_request.method_request().UnpackTo(&method_req));
   ASSERT_EQ(public_key_blob, to_bytes(method_req.public_key()));
   ASSERT_EQ("ssh-ed25519", method_req.public_key_alg());
+  auto expectedFp = bytes{0x2f, 0x79, 0x3f, 0xa0, 0x9b, 0x9b, 0x6e, 0x54,
+                          0x98, 0xd2, 0x50, 0x7d, 0x52, 0x5b, 0x25, 0xed,
+                          0xe9, 0x83, 0x32, 0x74, 0x4f, 0x2a, 0x6f, 0xfc,
+                          0xb9, 0xd7, 0xf6, 0x71, 0xcc, 0x24, 0xe7, 0xad};
+  ASSERT_EQ(expectedFp, to_bytes(method_req.public_key_fingerprint_sha256()));
 }
 
 TEST_F(DownstreamUserAuthServiceTest, HandleMessageSshKeyboardInteractive) {


### PR DESCRIPTION
Adds a field public_key_fingerprint with the pre-computed raw fingerprint of the public key to PublicKeyMethodRequest, so that pomerium doesn't need to compute it itself. It is passed as raw bytes, so pomerium can format it as needed to use as the session identifier.