### PR TITLE
ssh: additional validation and limits for public key auth requests

### DIFF
--- a/source/extensions/filters/network/ssh/service_userauth.h
+++ b/source/extensions/filters/network/ssh/service_userauth.h
@@ -44,6 +44,7 @@ private:
   std::optional<std::string> pending_service_auth_;
   int auth_failure_count_{};
   bool none_auth_handled_{};
+  std::unordered_set<std::string> previous_attempted_keys_;
 };
 
 // (algorithm, key type, key size in bits)


### PR DESCRIPTION
This adds a few extra checks during public key auth:
- the public key algorithm name must match the given key (an incorrect algorithm name would have still failed, but only after a signature was given, during verification. This check will cause it to fail earlier with a more obvious error message)
- the same key cannot be attempted more than once
- a maximum of 10 public keys can be attempted