### PR TITLE
ssh: replace duplicate public key check with a fixed limit on auth requests

### DIFF
--- a/source/extensions/filters/network/ssh/service_userauth.h
+++ b/source/extensions/filters/network/ssh/service_userauth.h
@@ -12,6 +12,7 @@ namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 
 // TODO: configurable?
 static constexpr int MaxFailedAuthAttempts = 6; // DEFAULT_AUTH_FAIL_MAX (openssh/servconf.h)
+static constexpr int MaxAllowedAuthRequests = 40;
 
 class UserAuthService : public virtual Service,
                         public Logger::Loggable<Logger::Id::filter> {
@@ -42,9 +43,9 @@ public:
 private:
   DownstreamTransportCallbacks& transport_;
   std::optional<std::string> pending_service_auth_;
+  int auth_request_count_{};
   int auth_failure_count_{};
   bool none_auth_handled_{};
-  std::unordered_map<std::string, bool> previous_attempted_keys_; // fingerprint => has_signature
 };
 
 // (algorithm, key type, key size in bits)

--- a/test/extensions/filters/network/ssh/service_userauth_test.cc
+++ b/test/extensions/filters/network/ssh/service_userauth_test.cc
@@ -66,16 +66,11 @@ public:
     service_ = std::make_unique<DownstreamUserAuthService>(*transport_, *api_);
   }
 
-  void SendValidPubKeyRequest(pomerium::extensions::ssh::ClientMessage* out_mgmt_request = nullptr, bytes* out_public_key_blob = nullptr) { // NOLINT
+  wire::UserAuthRequestMsg BuildValidPubKeyRequest() { // NOLINT
     auto privKeyPath = copyTestdataToWritableTmp("regress/unittests/sshkey/testdata/ed25519_1", 0600);
-    auto key = openssh::SSHKey::fromPrivateKeyFile(privKeyPath);
-    ASSERT_OK(key.status());
+    auto key = *openssh::SSHKey::fromPrivateKeyFile(privKeyPath);
 
-    auto publicKeyBlob = (*key)->toPublicKeyBlob();
-    if (out_public_key_blob != nullptr) {
-      *out_public_key_blob = publicKeyBlob;
-    }
-    bytes session_id = "SESSION-ID"_bytes;
+    auto publicKeyBlob = key->toPublicKeyBlob();
 
     wire::UserAuthRequestMsg req;
     req.username = "foo@bar"s;
@@ -86,6 +81,15 @@ public:
       .public_key = publicKeyBlob,
       .signature = to_bytes(absl::HexStringToBytes("0000000b7373682d6564323535313900000040bf1e4e617a3a1b72dd2d5c066d349e95df08b8d1b0f1f338349fc0db45e89fd0050c42f763dab4512d4b1e5cb109eff77a3cb094a3b7c3aa9a8b2f43c1d9f207")),
     };
+    return req;
+  }
+  void SendValidPubKeyRequest(pomerium::extensions::ssh::ClientMessage* out_mgmt_request = nullptr, bytes* out_public_key_blob = nullptr) { // NOLINT
+    auto req = BuildValidPubKeyRequest();
+    if (out_public_key_blob != nullptr) {
+      *out_public_key_blob = *req.request.get<wire::PubKeyUserAuthRequestMsg>().public_key;
+    }
+
+    static const bytes session_id = "SESSION-ID"_bytes;
     EXPECT_CALL(*transport_, sessionId())
       .WillOnce(ReturnRef(session_id));
     if (out_mgmt_request != nullptr) {
@@ -278,8 +282,8 @@ TEST_F(DownstreamUserAuthServiceTest, HandleMessageSshPubKeyAlgorithmRsa) {
   }
 }
 
-TEST_F(DownstreamUserAuthServiceTest, HandleMessageSshPubKey_TooManyAttempts) {
-  for (int i = 0; i < 11; i++) {
+TEST_F(DownstreamUserAuthServiceTest, HandleMessageSshPubKey_TooManyAttempts_NoSignatureRequests) {
+  for (int i = 0; i <= 40; i++) {
     wire::UserAuthRequestMsg req;
     req.username = "foo@bar"s;
     req.service_name = "ssh-connection"s;
@@ -289,8 +293,8 @@ TEST_F(DownstreamUserAuthServiceTest, HandleMessageSshPubKey_TooManyAttempts) {
       .public_key = (*openssh::SSHKey::generate(KEY_ED25519, 256))->toPublicKeyBlob(),
     };
 
-    if (i == 10) {
-      ASSERT_EQ(absl::InvalidArgumentError("too many attempts"),
+    if (i == 40) {
+      ASSERT_EQ(absl::InvalidArgumentError("too many auth attempts"),
                 service_->handleMessage(wire::Message{req}));
       break;
     }
@@ -308,94 +312,28 @@ TEST_F(DownstreamUserAuthServiceTest, HandleMessageSshPubKey_TooManyAttempts) {
   }
 }
 
-class DuplicatePublicKeyAttemptsTest : public DownstreamUserAuthServiceTest {
-public:
-  void SetUp() {
-    static const auto session_id = "SESSION-ID"_bytes;
-    EXPECT_CALL(*transport_, sessionId())
-      .WillRepeatedly(ReturnRef(session_id));
-
-    auto privKeyPath = copyTestdataToWritableTmp("regress/unittests/sshkey/testdata/ed25519_1", 0600);
-    auto key = openssh::SSHKey::fromPrivateKeyFile(privKeyPath);
-    ASSERT_OK(key.status());
-
-    without_signature_ = wire::UserAuthRequestMsg{
-      .username = "foo@bar"s,
-      .service_name = "ssh-connection"s,
-      .request = wire::PubKeyUserAuthRequestMsg{
-        .has_signature = false,
-        .public_key_alg = "ssh-ed25519"s,
-        .public_key = (*key)->toPublicKeyBlob(),
-      },
-    };
-    with_signature_ = wire::UserAuthRequestMsg{
-      .username = "foo@bar"s,
-      .service_name = "ssh-connection"s,
-      .request = wire::PubKeyUserAuthRequestMsg{
-        .has_signature = true,
-        .public_key_alg = "ssh-ed25519"s,
-        .public_key = (*key)->toPublicKeyBlob(),
-        .signature = to_bytes(absl::HexStringToBytes("0000000b7373682d6564323535313900000040bf1e4e617a3a1b72dd2d5c066d349e95df08b8d1b0f1f338349fc0db45e89fd0050c42f763dab4512d4b1e5cb109eff77a3cb094a3b7c3aa9a8b2f43c1d9f207")),
-      },
-    };
-  }
-
-  wire::UserAuthRequestMsg without_signature_{};
-  wire::UserAuthRequestMsg with_signature_{};
-};
-
-TEST_F(DuplicatePublicKeyAttemptsTest, HandleMessageSshPubKey_SameKeyWithoutSignatureAttemptedTwice) {
-  wire::Message resp;
-  EXPECT_CALL(*transport_, sendMessageToConnection(_))
-    .WillOnce(DoAll(SaveArg<0>(&resp),
-                    Return(0)));
-  ASSERT_OK(service_->handleMessage(wire::Message{without_signature_}));
-
-  ASSERT_EQ(absl::InvalidArgumentError("key already used"),
-            service_->handleMessage(wire::Message{without_signature_}));
-}
-
-TEST_F(DuplicatePublicKeyAttemptsTest, HandleMessageSshPubKey_AllowSecondAttemptWithSignature) {
-  wire::Message resp;
-  EXPECT_CALL(*transport_, sendMessageToConnection(_))
-    .WillOnce(DoAll(SaveArg<0>(&resp),
-                    Return(0)));
-  ASSERT_OK(service_->handleMessage(wire::Message{without_signature_}));
-
-  resp.visit(
-    [&](opt_ref<wire::UserAuthPubKeyOkMsg>) {},
-    [](auto&) {
-      FAIL() << "expected UserAuthPubKeyOkMsg";
-    });
-
-  // not concerned with the contents for this test; that is validated separately
-  EXPECT_CALL(*transport_, sendMgmtClientMessage(_));
-  ASSERT_OK(service_->handleMessage(wire::Message{with_signature_}));
-
-  {
-
-    ASSERT_EQ(absl::InvalidArgumentError("key already used"),
-              service_->handleMessage(wire::Message{with_signature_}));
-
-    ASSERT_EQ(absl::InvalidArgumentError("key already used"),
-              service_->handleMessage(wire::Message{without_signature_}));
+TEST_F(DownstreamUserAuthServiceTest, HandleMessageSshPubKey_TooManyAttempts_InvalidRequests) {
+  for (int i = 0; i <= 40; i++) {
+    wire::UserAuthRequestMsg req{.request = wire::PubKeyUserAuthRequestMsg{}};
+    if (i == 40) {
+      ASSERT_EQ(absl::InvalidArgumentError("too many auth attempts"),
+                service_->handleMessage(wire::Message{req}));
+      break;
+    }
+    auto r = service_->handleMessage(wire::Message{req});
+    ASSERT_FALSE(r.ok());
   }
 }
 
-TEST_F(DuplicatePublicKeyAttemptsTest, HandleMessageSshPubKey_SameKeyWithSignatureAttemptedTwice) {
-  EXPECT_CALL(*transport_, sendMgmtClientMessage(_));
-  ASSERT_OK(service_->handleMessage(wire::Message{with_signature_}));
+TEST_F(DownstreamUserAuthServiceTest, HandleMessageSshPubKey_TooManyAttempts_ValidRequests) {
+  for (int i = 0; i < 40; i++) {
+    SendValidPubKeyRequest();
+  }
 
-  ASSERT_EQ(absl::InvalidArgumentError("key already used"),
-            service_->handleMessage(wire::Message{with_signature_}));
-}
-
-TEST_F(DuplicatePublicKeyAttemptsTest, HandleMessageSshPubKey_KeyWithSignatureAttemptedAgainWithout) {
-  EXPECT_CALL(*transport_, sendMgmtClientMessage(_));
-  ASSERT_OK(service_->handleMessage(wire::Message{with_signature_}));
-
-  ASSERT_EQ(absl::InvalidArgumentError("key already used"),
-            service_->handleMessage(wire::Message{without_signature_}));
+  ASSERT_EQ(absl::InvalidArgumentError("too many auth attempts"),
+            service_->handleMessage(wire::Message{BuildValidPubKeyRequest()}));
+  ASSERT_EQ(absl::InvalidArgumentError("too many auth attempts"),
+            service_->handleMessage(wire::Message{BuildValidPubKeyRequest()}));
 }
 
 TEST_F(DownstreamUserAuthServiceTest, HandleMessageSshPubKeyUnexpectedSignature) {


### PR DESCRIPTION
The duplicate key check is complicated and has many edge cases. It ostensibly doesn't matter much for our auth flow anyway, so replacing with a fixed maximum attempt limit of 40.