### PR TITLE
Revert "ssh: populate source_address in DownstreamConnectEvent"

### DIFF
--- a/source/extensions/filters/network/ssh/grpc_client_impl.cc
+++ b/source/extensions/filters/network/ssh/grpc_client_impl.cc
@@ -16,10 +16,9 @@ void StreamManagementServiceClient::setOnRemoteCloseCallback(std::function<void(
   on_remote_close_ = cb;
 }
 
-void StreamManagementServiceClient::connect(stream_id_t stream_id, const std::string& remote_address) {
+void StreamManagementServiceClient::connect(stream_id_t stream_id) {
   ClientMessage msg;
   msg.mutable_event()->mutable_downstream_connected()->set_stream_id(stream_id);
-  msg.mutable_event()->mutable_downstream_connected()->set_source_address(remote_address);
   stream_ = client_.start(method_manage_stream_, *this, Http::AsyncClient::StreamOptions{});
   ASSERT(stream_ != nullptr);
   stream_.sendMessage(msg, false);

--- a/source/extensions/filters/network/ssh/grpc_client_impl.h
+++ b/source/extensions/filters/network/ssh/grpc_client_impl.h
@@ -42,7 +42,7 @@ class StreamManagementServiceClient : public Grpc::AsyncStreamCallbacks<ServerMe
 public:
   StreamManagementServiceClient(Grpc::RawAsyncClientSharedPtr client);
 
-  void connect(stream_id_t stream_id, const std::string& remote_address);
+  void connect(stream_id_t stream_id);
 
   Grpc::AsyncStream<ClientMessage>& stream();
   void setOnRemoteCloseCallback(std::function<void(Grpc::Status::GrpcStatus, std::string)> cb);

--- a/source/extensions/filters/network/ssh/server_transport.cc
+++ b/source/extensions/filters/network/ssh/server_transport.cc
@@ -74,8 +74,7 @@ void SshServerTransport::setCodecCallbacks(Callbacks& callbacks) {
     onDecodingFailure(absl::CancelledError(err));
   });
   stream_id_ = api_.randomGenerator().random();
-  mgmt_client_->connect(streamId(),
-                        callbacks_->connection()->streamInfo().downstreamAddressProvider().remoteAddress()->asString());
+  mgmt_client_->connect(streamId());
 }
 
 void SshServerTransport::initServices() {

--- a/test/extensions/filters/network/ssh/grpc_client_impl_test.cc
+++ b/test/extensions/filters/network/ssh/grpc_client_impl_test.cc
@@ -26,10 +26,9 @@ TEST_F(StreamManagementServiceClientTest, Connect) {
     .WillOnce(Return(&stream_));
   ClientMessage expectedInitMsg;
   expectedInitMsg.mutable_event()->mutable_downstream_connected()->set_stream_id(1);
-  expectedInitMsg.mutable_event()->mutable_downstream_connected()->set_source_address("127.0.0.1"s);
   EXPECT_CALL(stream_, sendMessageRaw_(Grpc::ProtoBufferEq(expectedInitMsg), false));
   StreamManagementServiceClient client(client_);
-  client.connect(1, "127.0.0.1"s);
+  client.connect(1);
 }
 
 TEST_F(StreamManagementServiceClientTest, OnReceiveMessage) {
@@ -48,7 +47,7 @@ TEST_F(StreamManagementServiceClientTest, OnReceiveMessage) {
   EXPECT_CALL(handler, handleMessage(testing::Pointee(Envoy::ProtoEq(msg))))
     .WillOnce(Return(absl::OkStatus()));
 
-  client.connect(1, "127.0.0.1"s); // only to ensure client.stream_ is set
+  client.connect(1); // only to ensure client.stream_ is set
   EXPECT_NE(nullptr, &client.stream());
   client.onReceiveMessage(std::make_unique<ServerMessage>(msg));
 }
@@ -68,7 +67,7 @@ TEST_F(StreamManagementServiceClientTest, OnReceiveMessage_HandlerReturnsError) 
   EXPECT_CALL(stream_, sendMessageRaw_);
   EXPECT_CALL(handler, handleMessage(_))
     .WillOnce(Return(absl::InvalidArgumentError("test error")));
-  client.connect(1, "127.0.0.1"s);
+  client.connect(1);
 
   client.onReceiveMessage(std::make_unique<ServerMessage>(msg1));
 }
@@ -88,7 +87,7 @@ TEST_F(StreamManagementServiceClientTest, OnReceiveMessage_HandlerReturnsError_O
   EXPECT_CALL(stream_, sendMessageRaw_);
   EXPECT_CALL(handler, handleMessage(_))
     .WillOnce(Return(absl::InvalidArgumentError("test error")));
-  client.connect(1, "127.0.0.1"s);
+  client.connect(1);
 
   bool called = false;
   client.setOnRemoteCloseCallback([&](Grpc::Status::GrpcStatus status, std::string err) {
@@ -113,7 +112,7 @@ TEST_F(StreamManagementServiceClientTest, OnReceiveMessage_NoRegisteredHandler) 
   ServerMessage msg1;
   msg1.mutable_auth_response();
 
-  client.connect(1, "127.0.0.1"s);
+  client.connect(1);
 
   client.onReceiveMessage(std::make_unique<ServerMessage>(msg1));
 }
@@ -138,7 +137,7 @@ TEST_F(StreamManagementServiceClientTest, OnRemoteClose) {
     EXPECT_EQ("test error", err);
     called = true;
   });
-  client.connect(1, "127.0.0.1"s);
+  client.connect(1);
   callbacks_ref->onRemoteClose(Grpc::Status::InvalidArgument, "test error");
   EXPECT_TRUE(called);
 }
@@ -156,7 +155,7 @@ TEST_F(StreamManagementServiceClientTest, OnRemoteClose_NoCallback) {
         return &stream_;
       }));
   EXPECT_CALL(stream_, sendMessageRaw_);
-  client.connect(1, "127.0.0.1"s);
+  client.connect(1);
   callbacks_ref->onRemoteClose(Grpc::Status::InvalidArgument, "test error");
 }
 
@@ -173,7 +172,7 @@ TEST_F(StreamManagementServiceClientTest, NoopMetadataCallbacks) {
       }));
 
   EXPECT_CALL(stream_, sendMessageRaw_);
-  client.connect(1, "127.0.0.1"s);
+  client.connect(1);
   auto headers = Http::RequestHeaderMapImpl::create();
   callbacks_ref->onCreateInitialMetadata(*headers);
   EXPECT_TRUE(headers->empty());

--- a/test/extensions/filters/network/ssh/server_transport_test.cc
+++ b/test/extensions/filters/network/ssh/server_transport_test.cc
@@ -67,19 +67,17 @@ public:
         return &serve_channel_stream_;
       }));
     EXPECT_CALL(*client_, startRaw("pomerium.extensions.ssh.StreamManagement", "ManageStream", _, _));
-
-    ON_CALL(server_codec_callbacks_, connection())
-      .WillByDefault(Return(makeOptRef<Network::Connection>(mock_connection_)));
-    EXPECT_CALL(server_codec_callbacks_, connection())
-      .Times(AnyNumber());
+    transport_.setCodecCallbacks(server_codec_callbacks_);
     ON_CALL(server_codec_callbacks_, writeToConnection(_))
       .WillByDefault([this](Envoy::Buffer::Instance& buffer) {
         output_buffer_.move(buffer);
       });
     EXPECT_CALL(server_codec_callbacks_, writeToConnection(_))
       .Times(AnyNumber());
-
-    transport_.setCodecCallbacks(server_codec_callbacks_);
+    ON_CALL(server_codec_callbacks_, connection())
+      .WillByDefault(Return(makeOptRef<Network::Connection>(mock_connection_)));
+    EXPECT_CALL(server_codec_callbacks_, connection())
+      .Times(AnyNumber());
 
     // Perform a manual key exchange as the client and set up a packet cipher
     input_buffer_.add("SSH-2.0-TestClient\r\n");


### PR DESCRIPTION
Reverts pomerium/envoy-custom#85

The downstream connection is not available in setCodecCallbacks as initially thought. This will take some more time to figure out.