### PR TITLE
envoy: suppress duplicate wip validation warnings

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,6 +48,7 @@ http_archive(
         "//patches/envoy:0002-bump-dependencies.patch",
         "//patches/envoy:0003-envoy-copts.patch",
         "//patches/envoy:0004-pgv.patch",
+        "//patches/envoy:0005-suppress-duplicate-wip-warnings.patch",
         "//patches/envoy:tmp-fix-upstream-connection-callbacks.patch",
     ],
     sha256 = "2e2068a7f27d72edb82a27f0dc7f7502274d2dae11c4422bb1b5edecf7acde6a",

--- a/patches/envoy/0005-suppress-duplicate-wip-warnings.patch
+++ b/patches/envoy/0005-suppress-duplicate-wip-warnings.patch
@@ -1,0 +1,43 @@
+diff --git a/source/common/protobuf/message_validator_impl.cc b/source/common/protobuf/message_validator_impl.cc
+index 262b0350bb..a669160e18 100644
+--- a/source/common/protobuf/message_validator_impl.cc
++++ b/source/common/protobuf/message_validator_impl.cc
+@@ -36,6 +36,14 @@ void WipCounterBase::setWipCounter(Stats::Counter& wip_counter) {
+ }
+ 
+ void WipCounterBase::onWorkInProgressCommon(absl::string_view description) {
++  absl::MutexLock l(&descriptions_mu_);
++  const uint64_t hash = HashUtil::xxHash64(description);
++  auto it = descriptions_.insert(hash);
++  // If we've seen this before, skip.
++  if (!it.second) {
++    return;
++  }
++
+   ENVOY_LOG_MISC(warn, "{}", description);
+   if (wip_counter_ != nullptr) {
+     wip_counter_->inc();
+diff --git a/source/common/protobuf/message_validator_impl.h b/source/common/protobuf/message_validator_impl.h
+index 676c3f9056..2177f7dbc2 100644
+--- a/source/common/protobuf/message_validator_impl.h
++++ b/source/common/protobuf/message_validator_impl.h
+@@ -7,6 +7,7 @@
+ #include "source/common/common/logger.h"
+ 
+ #include "absl/container/flat_hash_set.h"
++#include "absl/synchronization/mutex.h"
+ 
+ namespace Envoy {
+ namespace ProtobufMessage {
+@@ -43,6 +44,11 @@ protected:
+   void onWorkInProgressCommon(absl::string_view description);
+ 
+ private:
++  // Track hashes of descriptions we've seen, to avoid log spam. A hash is used here to avoid
++  // wasting memory with unused strings.
++  static inline absl::flat_hash_set<uint64_t> descriptions_ ABSL_GUARDED_BY(descriptions_mu_);
++  static inline absl::Mutex descriptions_mu_;
++
+   Stats::Counter* wip_counter_{};
+   uint64_t prestats_wip_count_{};
+ };


### PR DESCRIPTION
This adds the same duplicate-suppression logic to wip warnings that exists for other validation warnings. These are especially noisy and only need to be logged once. Without the duplicate check, they are logged again on every config change.