### PR TITLE
update Envoy to v1.34.5

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,7 +26,7 @@ load("@hedron_compile_commands//:workspace_setup_transitive_transitive_transitiv
 
 hedron_compile_commands_setup_transitive_transitive_transitive()
 
-envoy_version = "6fe1905459ff267a43a8a26d042ae03a8aa7bc98"
+envoy_version = "7e251c0145bb32a1ca7d7199ac0727765538d942"
 
 openssh_version = "V_10_0_P2"
 
@@ -51,7 +51,7 @@ http_archive(
         "//patches/envoy:0005-suppress-duplicate-wip-warnings.patch",
         "//patches/envoy:tmp-fix-upstream-connection-callbacks.patch",
     ],
-    sha256 = "ff6503d08da9626dce0a58dac9fd2e560e1582d4b05a3f293efdbe64467844c9",
+    sha256 = "8761f6508c808725e5879b05dc9a6b2b528ef34957ba606d950b8c9ad6441a48",
     strip_prefix = "envoy-" + envoy_version,
     url = "https://github.com/envoyproxy/envoy/archive/" + envoy_version + ".zip",
 )


### PR DESCRIPTION
Update Envoy from v1.34.4 to v1.34.5.

Related issue: https://linear.app/pomerium/issue/ENG-2751/update-to-envoy-1345