### PR TITLE
ssh: improve handling of key loading errors

### DIFF
--- a/source/extensions/filters/network/ssh/client_transport.cc
+++ b/source/extensions/filters/network/ssh/client_transport.cc
@@ -32,8 +32,9 @@ private:
 
 SshClientTransport::SshClientTransport(
   Envoy::Server::Configuration::ServerFactoryContext& context,
-  std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config)
-    : TransportBase(context.api(), std::move(config)) {
+  std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config,
+  const SecretsProvider& secrets_provider)
+    : TransportBase(context.api(), std::move(config), secrets_provider) {
   wire::ExtInfoMsg extInfo;
   extInfo.extensions->emplace_back(wire::PingExtension{.version = "0"s});
   outgoing_ext_info_ = std::move(extInfo);
@@ -41,11 +42,6 @@ SshClientTransport::SshClientTransport(
 
 void SshClientTransport::setCodecCallbacks(GenericProxy::ClientCodecCallbacks& callbacks) {
   TransportBase::setCodecCallbacks(callbacks);
-  if (auto keys = openssh::loadHostKeys(codecConfig().host_keys()); !keys.ok()) {
-    throw Envoy::EnvoyException(statusToString(keys.status()));
-  } else {
-    kex_->setHostKeys(std::move(*keys));
-  }
   initServices();
 }
 

--- a/source/extensions/filters/network/ssh/client_transport.h
+++ b/source/extensions/filters/network/ssh/client_transport.h
@@ -29,7 +29,8 @@ class SshClientTransport final : public TransportBase<ClientCodec>,
 
 public:
   SshClientTransport(Envoy::Server::Configuration::ServerFactoryContext& context,
-                     std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config);
+                     std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config,
+                     const SecretsProvider& secrets_provider);
   void setCodecCallbacks(GenericProxy::ClientCodecCallbacks& callbacks) override;
 
   void decode(Envoy::Buffer::Instance& buffer, bool end_stream) final;

--- a/source/extensions/filters/network/ssh/kex.cc
+++ b/source/extensions/filters/network/ssh/kex.cc
@@ -37,7 +37,7 @@ void Kex::onVersionExchangeCompleted(const bytes& server_version,
   kex_callbacks_.onVersionExchangeCompleted(server_version, client_version, banner);
 }
 
-void Kex::setHostKeys(std::vector<openssh::SSHKeyPtr> host_keys) {
+void Kex::setHostKeys(std::vector<openssh::SSHKeySharedPtr> host_keys) {
   host_keys_ = std::move(host_keys);
 }
 

--- a/source/extensions/filters/network/ssh/kex.h
+++ b/source/extensions/filters/network/ssh/kex.h
@@ -112,7 +112,7 @@ public:
                                   const bytes& client_version,
                                   const bytes& banner) override;
 
-  void setHostKeys(std::vector<openssh::SSHKeyPtr> host_keys);
+  void setHostKeys(std::vector<openssh::SSHKeySharedPtr> host_keys);
 
   KexState& getPendingStateForTest() const { return *pending_state_; }
 
@@ -170,7 +170,7 @@ private:
   std::unique_ptr<KexState> pending_state_;
   std::unique_ptr<KexState> active_state_;
   bool is_server_;
-  std::vector<openssh::SSHKeyPtr> host_keys_;
+  std::vector<openssh::SSHKeySharedPtr> host_keys_;
   Envoy::OptRef<MessageDispatcher<wire::Message>> msg_dispatcher_;
 };
 

--- a/source/extensions/filters/network/ssh/server_transport.h
+++ b/source/extensions/filters/network/ssh/server_transport.h
@@ -6,6 +6,7 @@
 #pragma clang unsafe_buffer_usage end
 #include "source/extensions/filters/network/generic_proxy/interface/codec.h"
 
+#include "source/extensions/filters/network/ssh/transport.h"
 #include "source/extensions/filters/network/ssh/service.h"
 #include "source/extensions/filters/network/ssh/stream_tracker.h"
 #include "source/extensions/filters/network/ssh/extension_ping.h"
@@ -29,9 +30,9 @@ public:
   SshServerTransport(Server::Configuration::ServerFactoryContext& context,
                      std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config,
                      CreateGrpcClientFunc create_grpc_client,
-                     StreamTrackerSharedPtr active_stream_tracker);
+                     StreamTrackerSharedPtr active_stream_tracker,
+                     const SecretsProvider& secrets_provider);
 
-  void setCodecCallbacks(GenericProxy::ServerCodecCallbacks& callbacks) override;
   void onConnected() override;
 
   GenericProxy::EncodingResult encode(const GenericProxy::StreamFrame& frame,

--- a/source/extensions/filters/network/ssh/service_userauth.h
+++ b/source/extensions/filters/network/ssh/service_userauth.h
@@ -63,7 +63,7 @@ public:
 private:
   key_params_t getUpstreamKeyParams();
 
-  openssh::SSHKeyPtr ca_user_key_;
+  openssh::SSHKeySharedPtr user_ca_key_;
   std::unique_ptr<wire::UserAuthRequestMsg> pending_req_;
   bool ext_info_received_{};
 };

--- a/test/extensions/filters/network/ssh/kex_test.cc
+++ b/test/extensions/filters/network/ssh/kex_test.cc
@@ -279,7 +279,7 @@ public:
   }
 
   auto newServerHostKeys() {
-    std::vector<openssh::SSHKeyPtr> hostKeys;
+    std::vector<openssh::SSHKeySharedPtr> hostKeys;
     hostKeys.push_back(*openssh::SSHKey::generate(KEY_ED25519, 256));
     hostKeys.push_back(*openssh::SSHKey::generate(KEY_ECDSA, 256));
     hostKeys.push_back(*openssh::SSHKey::generate(KEY_ECDSA, 384));

--- a/test/extensions/filters/network/ssh/openssh_test.cc
+++ b/test/extensions/filters/network/ssh/openssh_test.cc
@@ -777,18 +777,80 @@ TEST(OpensshTest, LoadHostKeysFromBytes_DuplicateAlgorithm) {
   });
 }
 
-TEST(OpensshTest, LoadHostKeys_InvalidMode) {
+TEST(OpensshTest, LoadHostKeysFromBytes_InvalidInlineData) {
+  for (bool use_bytes : {false, true}) {
+    {
+      std::vector<corev3::DataSource> keys;
+      corev3::DataSource ds1;
+      if (use_bytes) {
+        *ds1.mutable_inline_bytes() = "not an ssh key";
+      } else {
+        *ds1.mutable_inline_string() = "not an ssh key";
+      }
+      keys.push_back(std::move(ds1));
+      corev3::DataSource ds2;
+      if (use_bytes) {
+        *ds2.mutable_inline_bytes() = *(*openssh::SSHKey::generate(KEY_RSA, 2048))->formatPrivateKey();
+      } else {
+        *ds2.mutable_inline_string() = *(*openssh::SSHKey::generate(KEY_RSA, 2048))->formatPrivateKey();
+      }
+      keys.push_back(std::move(ds2));
+      auto stat = loadHostKeys(keys);
+      ASSERT_EQ(absl::InvalidArgumentError("error loading ssh host key [1/2] from inline data: invalid format"), stat.status());
+    }
+    {
+      std::vector<corev3::DataSource> keys;
+      corev3::DataSource ds1;
+      if (use_bytes) {
+        *ds1.mutable_inline_bytes() = *(*openssh::SSHKey::generate(KEY_RSA, 2048))->formatPrivateKey();
+      } else {
+        *ds1.mutable_inline_string() = *(*openssh::SSHKey::generate(KEY_RSA, 2048))->formatPrivateKey();
+      }
+      keys.push_back(std::move(ds1));
+      corev3::DataSource ds2;
+      if (use_bytes) {
+        *ds2.mutable_inline_bytes() = "not an ssh key";
+      } else {
+        *ds2.mutable_inline_string() = "not an ssh key";
+      }
+      keys.push_back(std::move(ds2));
+      auto stat = loadHostKeys(keys);
+      ASSERT_EQ(absl::InvalidArgumentError("error loading ssh host key [2/2] from inline data: invalid format"), stat.status());
+    }
+  }
+}
+
+TEST(OpensshTest, LoadHostKeys_InvalidMode_Unreadable) {
   std::vector<corev3::DataSource> sources;
   for (auto keyName : {"rsa_1", "ecdsa_1", "ed25519_1", "rsa_2"}) {
     // set invalid permissions on only one of the keys
     auto filename = copyTestdataToWritableTmp(absl::StrCat("regress/unittests/sshkey/testdata/", keyName),
-                                              std::string_view(keyName) == "ecdsa_1" ? 0644 : 0600);
+                                              std::string_view(keyName) == "ecdsa_1" ? 0200 : 0600);
     corev3::DataSource src;
     *src.mutable_filename() = filename;
     sources.push_back(std::move(src));
   }
   auto stat = loadHostKeys(sources);
-  ASSERT_EQ(absl::InvalidArgumentError("bad permissions"), stat.status());
+  ASSERT_EQ(absl::PermissionDeniedError(fmt::format("error loading ssh host key [2/4] from file {}: Permission denied",
+                                                    sources.at(1).filename())),
+            stat.status());
+}
+
+TEST(OpensshTest, LoadHostKeys_InvalidMode_TooOpen) {
+  std::vector<corev3::DataSource> sources;
+  for (auto keyName : {"rsa_1", "ecdsa_1", "ed25519_1", "rsa_2"}) {
+    // set invalid permissions on only one of the keys
+    auto filename = copyTestdataToWritableTmp(absl::StrCat("regress/unittests/sshkey/testdata/", keyName),
+                                              std::string_view(keyName) == "ecdsa_1" ? 0644 : 0600);
+
+    corev3::DataSource src;
+    *src.mutable_filename() = filename;
+    sources.push_back(std::move(src));
+  }
+  auto stat = loadHostKeys(sources);
+  ASSERT_EQ(absl::InvalidArgumentError(fmt::format("error loading ssh host key [2/4] from file {}: bad permissions",
+                                                   sources.at(1).filename())),
+            stat.status());
 }
 
 static const auto cipherInfo = std::unordered_map<std::string, std::tuple<uint32_t, uint32_t, uint32_t, uint32_t>>{

--- a/test/extensions/filters/network/ssh/service_connection_test.cc
+++ b/test/extensions/filters/network/ssh/service_connection_test.cc
@@ -29,6 +29,8 @@ public:
       : service_(transport_, GetParam()) {
     EXPECT_CALL(transport_, channelIdManager)
       .WillRepeatedly(ReturnRef(channel_id_manager_));
+    EXPECT_CALL(transport_, secretsProvider)
+      .WillRepeatedly(ReturnRef(secrets_provider_));
   }
 
   Peer LocalPeer() const {
@@ -39,6 +41,7 @@ public:
   }
 
   ChannelIDManager channel_id_manager_{100, 100};
+  TestSecretsProvider secrets_provider_;
   testing::StrictMock<MockTransportCallbacks> transport_;
   ConnectionService service_;
 };


### PR DESCRIPTION
This moves initialization of the ssh host keys and user ca key into `SshCodecFactoryConfig::createCodecFactory`. If an exception is thrown here, it will be caught by XDS which will reject the invalid listener config. The keys are now accessed using a `SecretsProvider` abstraction which is implemented by the `SshCodecFactory`, so that other components of the system do not need to load the keys themselves and handle errors.

Fixes https://github.com/pomerium/envoy-custom/issues/98