### PR TITLE
ssh: add ChannelOpen sub-messages for known channel types

### DIFF
--- a/source/extensions/filters/network/ssh/client_transport.cc
+++ b/source/extensions/filters/network/ssh/client_transport.cc
@@ -361,7 +361,7 @@ absl::StatusOr<MiddlewareResult> HandoffMiddleware::interceptMessage(wire::Messa
       }
       // Build and send the ChannelOpen message to the upstream
       wire::ChannelOpenMsg open;
-      open.channel_type = "session";
+      open.request = wire::SessionChannelOpenMsg{};
       open.sender_channel = *internalId;
       open.initial_window_size = info.channel_info->initial_window_size();
       open.max_packet_size = info.channel_info->max_packet_size();

--- a/source/extensions/filters/network/ssh/wire/messages.cc
+++ b/source/extensions/filters/network/ssh/wire/messages.cc
@@ -81,22 +81,66 @@ absl::StatusOr<size_t> ServiceAcceptMsg::encode(Envoy::Buffer::Instance& buffer)
                    service_name);
 }
 
+// X11ChannelOpenMsg
+absl::StatusOr<size_t> X11ChannelOpenMsg::decode(Envoy::Buffer::Instance& buffer, size_t payload_size) noexcept {
+  return decodeSequence(buffer, payload_size,
+                        originator_address,
+                        originator_port);
+}
+absl::StatusOr<size_t> X11ChannelOpenMsg::encode(Envoy::Buffer::Instance& buffer) const noexcept {
+  return encodeSequence(buffer,
+                        originator_address,
+                        originator_port);
+}
+
+// ForwardedTcpipChannelOpenMsg
+absl::StatusOr<size_t> ForwardedTcpipChannelOpenMsg::decode(Envoy::Buffer::Instance& buffer, size_t payload_size) noexcept {
+  return decodeSequence(buffer, payload_size,
+                        address_connected,
+                        port_connected,
+                        originator_address,
+                        originator_port);
+}
+absl::StatusOr<size_t> ForwardedTcpipChannelOpenMsg::encode(Envoy::Buffer::Instance& buffer) const noexcept {
+  return encodeSequence(buffer,
+                        address_connected,
+                        port_connected,
+                        originator_address,
+                        originator_port);
+}
+
+// DirectTcpipChannelOpenMsg
+absl::StatusOr<size_t> DirectTcpipChannelOpenMsg::decode(Envoy::Buffer::Instance& buffer, size_t payload_size) noexcept {
+  return decodeSequence(buffer, payload_size,
+                        host_to_connect,
+                        port_to_connect,
+                        originator_address,
+                        originator_port);
+}
+absl::StatusOr<size_t> DirectTcpipChannelOpenMsg::encode(Envoy::Buffer::Instance& buffer) const noexcept {
+  return encodeSequence(buffer,
+                        host_to_connect,
+                        port_to_connect,
+                        originator_address,
+                        originator_port);
+}
+
 // ChannelOpenMsg
 absl::StatusOr<size_t> ChannelOpenMsg::decode(Envoy::Buffer::Instance& buffer, size_t payload_size) noexcept {
   return decodeMsg(buffer, type, payload_size,
-                   channel_type,
+                   request.key_field(),
                    sender_channel,
                    initial_window_size,
                    max_packet_size,
-                   extra);
+                   request);
 }
 absl::StatusOr<size_t> ChannelOpenMsg::encode(Envoy::Buffer::Instance& buffer) const noexcept {
   return encodeMsg(buffer, type,
-                   channel_type,
+                   request.key_field(),
                    sender_channel,
                    initial_window_size,
                    max_packet_size,
-                   extra);
+                   request);
 }
 
 // PtyReqChannelRequestMsg

--- a/test/extensions/filters/network/ssh/client_transport_test.cc
+++ b/test/extensions/filters/network/ssh/client_transport_test.cc
@@ -548,7 +548,7 @@ TEST_F(ClientTransportTest, OpenChannelFromDownstream) {
                                                                 .local_peer = Peer::Downstream,
                                                               }));
     wire::ChannelOpenMsg from_downstream;
-    from_downstream.channel_type = "session"s;
+    from_downstream.request = wire::SessionChannelOpenMsg{};
     from_downstream.sender_channel = internal_id;
     from_downstream.initial_window_size = wire::ChannelWindowSize;
     from_downstream.max_packet_size = wire::ChannelMaxPacketSize;
@@ -708,7 +708,7 @@ TEST_F(ClientTransportTest, Handoff) {
   {
     wire::ChannelOpenMsg req;
     ASSERT_OK(ReadMsg(req));
-    ASSERT_EQ("session", *req.channel_type);
+    ASSERT_EQ("session", req.channel_type());
     ASSERT_EQ(*internalId, *req.sender_channel);
     ASSERT_EQ(wire::ChannelWindowSize, *req.initial_window_size);
     ASSERT_EQ(wire::ChannelMaxPacketSize, *req.max_packet_size);

--- a/test/extensions/filters/network/ssh/server_transport_test.cc
+++ b/test/extensions/filters/network/ssh/server_transport_test.cc
@@ -615,7 +615,7 @@ public:
 
     // when the downstream sends messages, they should be written to the hijacked stream
     wire::ChannelOpenMsg open;
-    open.channel_type = "session"s;
+    open.request = wire::SessionChannelOpenMsg{};
     open.sender_channel = ++last_downstream_id_;
     open.initial_window_size = wire::ChannelWindowSize;
     open.max_packet_size = wire::ChannelMaxPacketSize;
@@ -723,7 +723,7 @@ TEST_F(HijackedModeTest, HijackedMode_AddWellKnownMetadata) {
   (*metadataReq.mutable_metadata()->mutable_typed_filter_metadata())["com.pomerium.ssh"].PackFrom(sshMetadata);
 
   wire::ChannelOpenMsg open;
-  open.channel_type = "session"s;
+  open.request = wire::SessionChannelOpenMsg{};
   open.sender_channel = 1;
   open.initial_window_size = wire::ChannelWindowSize;
   open.max_packet_size = wire::ChannelMaxPacketSize;
@@ -792,7 +792,7 @@ TEST_F(HijackedModeTest, HijackedMode_OpenChannelFromUpstreamUnimplemented) {
   EXPECT_CALL(server_codec_callbacks_, onDecodingFailure("cannot open channels from a hijacked stream"));
   wire::ChannelOpenMsg msg;
   msg.sender_channel = 12345;
-  msg.channel_type = "foo"s;
+  msg.channel_type() = "foo"s;
   auto channelMsg = std::make_unique<ChannelMessage>();
   *channelMsg->mutable_raw_bytes()->mutable_value() = *wire::encodeTo<std::string>(msg);
   serve_channel_callbacks_[0]->onReceiveMessage(std::move(channelMsg));
@@ -959,7 +959,7 @@ public:
 
     // when the downstream opens a channel, it should start a new stream
     wire::ChannelOpenMsg open;
-    open.channel_type = "session"s;
+    open.request = wire::SessionChannelOpenMsg{};
     open.sender_channel = 1;
     open.initial_window_size = wire::ChannelWindowSize;
     open.max_packet_size = wire::ChannelMaxPacketSize;
@@ -1112,7 +1112,7 @@ TEST_F(ServerTransportTest, HijackedMode_StreamClosed) {
 
   // open a new channel to start the hijacked connection
   wire::ChannelOpenMsg open;
-  open.channel_type = "session"s;
+  open.request = wire::SessionChannelOpenMsg{};
   open.sender_channel = 1;
   open.initial_window_size = wire::ChannelWindowSize;
   open.max_packet_size = wire::ChannelMaxPacketSize;
@@ -1337,7 +1337,7 @@ TEST_F(ServerTransportTest, EncodeEffectiveHeaderHandoffComplete) {
   (*metadataReq.mutable_metadata()->mutable_typed_filter_metadata())["com.pomerium.ssh"].PackFrom(sshMetadata);
 
   wire::ChannelOpenMsg open;
-  open.channel_type = "session"s;
+  open.request = wire::SessionChannelOpenMsg{};
   open.sender_channel = 1;
   open.initial_window_size = wire::ChannelWindowSize;
   open.max_packet_size = wire::ChannelMaxPacketSize;

--- a/test/extensions/filters/network/ssh/test_mocks.h
+++ b/test/extensions/filters/network/ssh/test_mocks.h
@@ -187,4 +187,21 @@ constexpr decltype(auto) get(Message&& msg) {
   return std::move(msg).message.template get<T>();
 }
 
+template <typename T, typename... Opts>
+constexpr bool holds_alternative(const sub_message<Opts...>& msg) {
+  return msg.template holds_alternative<T>();
+}
+template <typename T, typename... Opts>
+constexpr bool holds_alternative(sub_message<Opts...>&& msg) {
+  return std::move(msg).template holds_alternative<T>();
+}
+template <typename T, typename... Opts>
+constexpr decltype(auto) get(const sub_message<Opts...>& msg) {
+  return msg.template get<T>();
+}
+template <typename T, typename... Opts>
+constexpr decltype(auto) get(sub_message<Opts...>&& msg) {
+  return std::move(msg).template get<T>();
+}
+
 } // namespace wire

--- a/test/extensions/filters/network/ssh/wire/test_field_reflect.h
+++ b/test/extensions/filters/network/ssh/wire/test_field_reflect.h
@@ -240,12 +240,25 @@ TEST_FIELDS(GlobalRequestMsg,
 TEST_FIELDS(GlobalRequestSuccessMsg,
             response);
 TEST_FIELDS(GlobalRequestFailureMsg);
+TEST_FIELDS(SessionChannelOpenMsg);
+TEST_FIELDS(X11ChannelOpenMsg,
+            originator_address,
+            originator_port);
+TEST_FIELDS(ForwardedTcpipChannelOpenMsg,
+            address_connected,
+            port_connected,
+            originator_address,
+            originator_port);
+TEST_FIELDS(DirectTcpipChannelOpenMsg,
+            host_to_connect,
+            port_to_connect,
+            originator_address,
+            originator_port);
 TEST_FIELDS(ChannelOpenMsg,
-            channel_type,
             sender_channel,
             initial_window_size,
             max_packet_size,
-            extra);
+            request);
 TEST_FIELDS(ChannelOpenConfirmationMsg,
             recipient_channel,
             sender_channel,

--- a/test/test_common/test_common.h
+++ b/test/test_common/test_common.h
@@ -97,12 +97,19 @@ WhenResolvedAs(const testing::Matcher<T>& inner_matcher) {
       return VariantWith<MsgType_>(AllOf(__VA_ARGS__));                                                                                  \
     }                                                                                                                                    \
   }()
+
+#define SUB_MSG(submsg_type, ...) \
+  VariantWith<submsg_type>(AllOf(__VA_ARGS__))
+
 // NOLINTEND(readability-identifier-naming)
 
 #define FIELD_EQ(name, ...) FIELD_EQ_IMPL_(name, (__VA_ARGS__))
 
 #define FIELD_EQ_IMPL_(name, ...) \
   Field(#name, &MsgType_::name, Eq(__VA_ARGS__))
+
+#define FIELD(name, ...) \
+  Field(#name, &MsgType_::name, (__VA_ARGS__))
 
 #define CONCATENATE_IMPL_(a, b) a##b
 #define CONCATENATE(a, b) CONCATENATE_IMPL_(a, b)


### PR DESCRIPTION
Adds new sub-message types for ChannelOpenMsg: 
- `SessionChannelOpenMsg` 
- `X11ChannelOpenMsg` 
- `ForwardedTcpipChannelOpenMsg` 
- `DirectTcpipChannelOpenMsg`

Instead of hard-coding channel type strings, these request types can be used instead. For channel types that have extra data attached to them, the strongly-typed messages are less error-prone.