### PR TITLE
ssh: fix async stream cleanup in StreamManagementServiceClient

### DIFF
--- a/source/extensions/filters/network/ssh/grpc_client_impl.cc
+++ b/source/extensions/filters/network/ssh/grpc_client_impl.cc
@@ -49,6 +49,12 @@ ChannelStreamServiceClient::ChannelStreamServiceClient(Grpc::RawAsyncClientShare
         "pomerium.extensions.ssh.StreamManagement.ServeChannel")),
       client_(client) {}
 
+ChannelStreamServiceClient::~ChannelStreamServiceClient() {
+  if (stream_ != nullptr) {
+    stream_.resetStream();
+  }
+}
+
 void ChannelStreamServiceClient::start(ChannelStreamCallbacks* callbacks, envoy::config::core::v3::Metadata metadata) {
   callbacks_ = callbacks;
   Http::AsyncClient::StreamOptions opts;

--- a/source/extensions/filters/network/ssh/grpc_client_impl.h
+++ b/source/extensions/filters/network/ssh/grpc_client_impl.h
@@ -71,6 +71,7 @@ class ChannelStreamServiceClient : public Grpc::AsyncStreamCallbacks<ChannelMess
                                    public Logger::Loggable<Logger::Id::filter> {
 public:
   ChannelStreamServiceClient(Grpc::RawAsyncClientSharedPtr client);
+  ~ChannelStreamServiceClient();
   void start(ChannelStreamCallbacks* callbacks, envoy::config::core::v3::Metadata metadata);
   void onReceiveMessage(Grpc::ResponsePtr<ChannelMessage>&& message) override;
   void sendMessage(const ChannelMessage& message);

--- a/test/extensions/filters/network/ssh/grpc_client_impl_test.cc
+++ b/test/extensions/filters/network/ssh/grpc_client_impl_test.cc
@@ -207,6 +207,8 @@ TEST_F(ChannelStreamServiceClientTest, Start_Metadata) {
   EXPECT_CALL(stream_, sendMessageRaw_(Grpc::ProtoBufferEq(expectedMetadataMsg), false));
 
   client.start(&callbacks_, md);
+
+  EXPECT_CALL(stream_, resetStream);
 }
 
 TEST_F(ChannelStreamServiceClientTest, SendMessages) {
@@ -230,6 +232,8 @@ TEST_F(ChannelStreamServiceClientTest, SendMessages) {
   *msg2.mutable_raw_bytes()->mutable_value() = "test2";
   EXPECT_CALL(stream_, sendMessageRaw_(Grpc::ProtoBufferEq(msg2), false));
   client.sendMessage(msg2);
+
+  EXPECT_CALL(stream_, resetStream);
 }
 
 TEST_F(ChannelStreamServiceClientTest, OnReceiveMessage) {
@@ -250,6 +254,8 @@ TEST_F(ChannelStreamServiceClientTest, OnReceiveMessage) {
 
   client.start(&callbacks_, {});
   client.onReceiveMessage(std::make_unique<ChannelMessage>(msg1));
+
+  EXPECT_CALL(stream_, resetStream);
 }
 
 TEST_F(ChannelStreamServiceClientTest, OnReceiveMessage_HandlerReturnsError) {
@@ -360,6 +366,8 @@ TEST_F(ChannelStreamServiceClientTest, NoopMetadataCallbacks) {
   EXPECT_TRUE(headers->empty());
   callbacks_ref->onReceiveInitialMetadata(Http::ResponseHeaderMapImpl::create());
   callbacks_ref->onReceiveTrailingMetadata(Http::ResponseTrailerMapImpl::create());
+
+  EXPECT_CALL(stream_, resetStream);
 }
 
 } // namespace test


### PR DESCRIPTION
If the ChannelStreamServiceClient is destroyed and there is still a valid stream, it needs to be reset, without invoking callbacks.