### PR TITLE
ssh: fix handoff middleware binding downstream ID twice

### DIFF
--- a/source/extensions/filters/network/ssh/client_transport.cc
+++ b/source/extensions/filters/network/ssh/client_transport.cc
@@ -347,14 +347,6 @@ absl::StatusOr<MiddlewareResult> HandoffMiddleware::interceptMessage(wire::Messa
         std::move(channel), info.channel_info->internal_upstream_channel_id());
       ASSERT(internalId.ok()); // should not be able to fail
 
-      if (auto stat = parent_.channel_id_manager_->bindChannelID(
-            *internalId, PeerLocalID{
-                           .channel_id = info.channel_info->downstream_channel_id(),
-                           .local_peer = Peer::Downstream,
-                         });
-          !stat.ok()) {
-        return statusf("error during handoff: {}", stat);
-      }
       // Build and send the ChannelOpen message to the upstream
       wire::ChannelOpenMsg open;
       open.request = wire::SessionChannelOpenMsg{};


### PR DESCRIPTION
This would have been caught by integration tests, which are only in the pomerium repo (maybe we should have some here as well?)