### PR TITLE
ssh: improve status handling in ChannelCallbacks api

### DIFF
--- a/source/extensions/filters/network/ssh/channel.h
+++ b/source/extensions/filters/network/ssh/channel.h
@@ -12,10 +12,14 @@ class ChannelCallbacks {
 public:
   virtual ~ChannelCallbacks() = default;
 
-  // Sends a message to the local peer.
-  virtual absl::Status sendMessageLocal(wire::Message&& msg) PURE;
+  // Sends a message to the local peer. For channel messages (see wire::ChannelMsg), the
+  // recipient_channel field does not need to be set. It will be set to the current internal
+  // channel ID automatically.
+  virtual void sendMessageLocal(wire::Message&& msg) PURE;
 
-  // Sends a message to the remote peer.
+  // Sends a message to the remote peer. For channel messages (see wire::ChannelMsg), the
+  // recipient_channel field does not need to be set. It will be set to the current internal
+  // channel ID automatically.
   virtual absl::Status sendMessageRemote(wire::Message&& msg) PURE;
 
   // Returns the channel's internal ID.

--- a/source/extensions/filters/network/ssh/client_transport.cc
+++ b/source/extensions/filters/network/ssh/client_transport.cc
@@ -297,10 +297,7 @@ public:
         .modes = info_.pty_info->modes(),
       },
     };
-    auto stat = callbacks_->sendMessageLocal(std::move(channelReq));
-    if (!stat.ok()) {
-      return statusf("error requesting pty: {}", stat);
-    }
+    callbacks_->sendMessageLocal(std::move(channelReq));
     return absl::OkStatus();
   }
   absl::Status onChannelOpenFailed(wire::ChannelOpenFailureMsg&& msg) override {
@@ -320,8 +317,7 @@ public:
         shellReq.recipient_channel = callbacks_->channelId();
         shellReq.request = wire::ShellChannelRequestMsg{};
         shellReq.want_reply = false;
-        auto r = callbacks_->sendMessageLocal(std::move(shellReq));
-        RELEASE_ASSERT(r.ok(), "failed to send ShellChannelRequestMsg");
+        callbacks_->sendMessageLocal(std::move(shellReq));
 
         ENVOY_LOG(debug, "handoff complete");
         handoff_complete_ = true;

--- a/source/extensions/filters/network/ssh/service_connection.h
+++ b/source/extensions/filters/network/ssh/service_connection.h
@@ -46,7 +46,7 @@ public:
                                      public LinkedObject<ChannelCallbacksImpl> {
   public:
     ChannelCallbacksImpl(ConnectionService& parent, uint32_t channel_id, Peer local_peer);
-    absl::Status sendMessageLocal(wire::Message&& msg) override;
+    void sendMessageLocal(wire::Message&& msg) override;
     absl::Status sendMessageRemote(wire::Message&& msg) override;
     uint32_t channelId() const override { return channel_id_; }
     void cleanup() override;

--- a/test/extensions/filters/network/ssh/client_transport_test.cc
+++ b/test/extensions/filters/network/ssh/client_transport_test.cc
@@ -881,7 +881,7 @@ TEST_F(ClientTransportTest, Handoff_SendPtyRequestFailure) {
   wire::ChannelOpenMsg req;
   ASSERT_OK(ReadMsg(req));
 
-  ExpectDisconnectAsHeader(absl::AbortedError("error opening channel: error requesting pty: error encoding packet: message size too large"));
+  ExpectDisconnectAsHeader(absl::AbortedError("error encoding packet: message size too large"));
   ASSERT_OK(WriteMsg(wire::ChannelOpenConfirmationMsg{
     .recipient_channel = authInfo->handoff_info.channel_info->internal_upstream_channel_id(),
     .sender_channel = 300,


### PR DESCRIPTION
- Removes the status return from sendMessageLocal
- Also set the recipient channel ID automatically for sendMessageRemote (we do this already for sendMessageLocal)