### PR TITLE
ssh: increase default thread timeout in transport_base_test

### DIFF
--- a/test/extensions/filters/network/ssh/transport_base_test.cc
+++ b/test/extensions/filters/network/ssh/transport_base_test.cc
@@ -205,7 +205,7 @@ inline absl::Duration defaultTimeout() {
   if (isDebuggerAttached()) {
     return absl::Hours(1);
   }
-  return absl::Seconds(10);
+  return absl::Minutes(1);
 }
 
 template <typename TestOptions>


### PR DESCRIPTION
https://github.com/pomerium/envoy-custom/actions/runs/17748373944/job/50438371900

Doesn't look like there is a bug here, this test sometimes just takes more than 10 seconds to run.