### PR TITLE
ssh: temp patch - implement filter state object sharing in generic_proxy

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -53,6 +53,7 @@ http_archive(
         "//patches/envoy:0007-userspace-socket-40748.patch",
         "//patches/envoy:0008-downstream-connected-40747.patch",
         "//patches/envoy:tmp-fix-upstream-connection-callbacks.patch",
+        "//patches/envoy:tmp-transport-socket-options.patch",
     ],
     sha256 = "332684aa4eb7a5613aa6e995231543e92d801128ae1f145cc58b24b24f25844c",
     strip_prefix = "envoy-" + envoy_version,

--- a/patches/envoy/tmp-transport-socket-options.patch
+++ b/patches/envoy/tmp-transport-socket-options.patch
@@ -1,0 +1,57 @@
+diff --git a/source/extensions/filters/network/generic_proxy/router/BUILD b/source/extensions/filters/network/generic_proxy/router/BUILD
+index d3e4d60b72..8d90a583f6 100644
+--- a/source/extensions/filters/network/generic_proxy/router/BUILD
++++ b/source/extensions/filters/network/generic_proxy/router/BUILD
+@@ -24,6 +24,7 @@ envoy_cc_library(
+         "//source/common/common:linked_object",
+         "//source/common/common:minimal_logger_lib",
+         "//source/common/config:well_known_names",
++        "//source/common/network:transport_socket_options_lib",
+         "//source/common/router:metadatamatchcriteria_lib",
+         "//source/common/stream_info:stream_info_lib",
+         "//source/common/tracing:tracer_lib",
+diff --git a/source/extensions/filters/network/generic_proxy/router/router.cc b/source/extensions/filters/network/generic_proxy/router/router.cc
+index 396def6c37..91ccb425fe 100644
+--- a/source/extensions/filters/network/generic_proxy/router/router.cc
++++ b/source/extensions/filters/network/generic_proxy/router/router.cc
+@@ -11,6 +11,7 @@
+ #include "source/common/tracing/tracer_impl.h"
+ #include "source/extensions/filters/network/generic_proxy/interface/filter.h"
+ #include "source/extensions/filters/network/generic_proxy/tracing.h"
++#include "source/common/network/transport_socket_options_impl.h"
+ 
+ namespace Envoy {
+ namespace Extensions {
+@@ -431,6 +432,9 @@ void RouterFilter::kickOffNewUpstreamRequest() {
+     return;
+   }
+ 
++  transport_socket_options_ = Network::TransportSocketOptionsUtility::fromFilterState(
++      downstreamConnection()->streamInfo().filterState());
++
+   GenericUpstreamSharedPtr generic_upstream = generic_upstream_factory_->createGenericUpstream(
+       *thread_local_cluster, this, const_cast<Network::Connection&>(*callbacks_->connection()),
+       callbacks_->codecFactory(), config_->bindUpstreamConnection());
+diff --git a/source/extensions/filters/network/generic_proxy/router/router.h b/source/extensions/filters/network/generic_proxy/router/router.h
+index 6907e1600a..21bc27d4e7 100644
+--- a/source/extensions/filters/network/generic_proxy/router/router.h
++++ b/source/extensions/filters/network/generic_proxy/router/router.h
+@@ -159,7 +159,9 @@ public:
+   // Upstream::LoadBalancerContextBase
+   const Envoy::Router::MetadataMatchCriteria* metadataMatchCriteria() override;
+   const Network::Connection* downstreamConnection() const override;
+-
++  Network::TransportSocketOptionsConstSharedPtr upstreamTransportSocketOptions() const override {
++    return transport_socket_options_;
++  }
+   // RequestFramesHandler
+   void onRequestCommonFrame(RequestCommonFramePtr frame) override;
+ 
+@@ -207,6 +209,7 @@ private:
+   // changed in the future.
+   UpstreamRequestPtr upstream_request_;
+   Envoy::Event::TimerPtr timeout_timer_;
++  Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
+ 
+   DecoderFilterCallback* callbacks_{};
+ 

--- a/source/extensions/filters/network/ssh/BUILD
+++ b/source/extensions/filters/network/ssh/BUILD
@@ -13,6 +13,7 @@ envoy_cc_library(
         "client_transport.cc",
         "config.cc",
         "extension_ping.cc",
+        "filter_state_objects.cc",
         "grpc_client_impl.cc",
         "id_manager.cc",
         "kex.cc",

--- a/source/extensions/filters/network/ssh/client_transport.cc
+++ b/source/extensions/filters/network/ssh/client_transport.cc
@@ -88,16 +88,11 @@ GenericProxy::EncodingResult SshClientTransport::encode(const GenericProxy::Stre
   switch (frame.frameFlags().frameTags() & FrameTags::FrameTypeMask) {
   case FrameTags::RequestHeader: {
     auto& filterState = callbacks_->connection()->streamInfo().filterState();
-    const auto& reqHeader = static_cast<const SSHRequestHeaderFrame&>(frame);
-    // copy filter state objects shared by the downstream
-    if (auto shared = reqHeader.downstreamSharedFilterStateObjects(); shared.has_value()) {
-      for (auto obj : *shared) {
-        filterState->setData(
-          obj.name_, obj.data_, obj.state_type_, StreamInfo::FilterState::LifeSpan::Request);
-      }
-    }
+
     ASSERT(filterState->hasDataWithName(ChannelIDManagerFilterStateKey));
     ASSERT(filterState->hasDataWithName(AuthInfoFilterStateKey));
+    ASSERT(filterState->hasDataWithName(RequestedServerName::key()));
+    ASSERT(filterState->hasDataWithName(DownstreamSourceAddressFilterStateFactory::key()));
 
     auth_info_ = std::dynamic_pointer_cast<AuthInfo>(
       filterState->getDataSharedMutableGeneric(AuthInfoFilterStateKey));

--- a/source/extensions/filters/network/ssh/filter_state_objects.cc
+++ b/source/extensions/filters/network/ssh/filter_state_objects.cc
@@ -1,0 +1,33 @@
+#include "source/extensions/filters/network/ssh/filter_state_objects.h"
+
+#pragma clang unsafe_buffer_usage begin
+#include "envoy/registry/registry.h"
+#pragma clang unsafe_buffer_usage end
+
+namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
+
+const std::string& DownstreamSourceAddressFilterStateFactory::key() {
+  CONSTRUCT_ON_FIRST_USE(std::string, "pomerium.extensions.ssh.downstream_source_address");
+}
+
+std::string DownstreamSourceAddressFilterStateFactory::name() const {
+  return key();
+}
+
+REGISTER_FACTORY(DownstreamSourceAddressFilterStateFactory, StreamInfo::FilterState::ObjectFactory);
+
+const std::string& RequestedServerName::key() {
+  CONSTRUCT_ON_FIRST_USE(std::string, "pomerium.extensions.ssh.requested_server_name");
+}
+
+const std::string& RequestedServerNameFilterStateFactory::key() {
+  return RequestedServerName::key();
+}
+
+std::string RequestedServerNameFilterStateFactory::name() const {
+  return key();
+}
+
+REGISTER_FACTORY(RequestedServerNameFilterStateFactory, StreamInfo::FilterState::ObjectFactory);
+
+} // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/source/extensions/filters/network/ssh/filter_state_objects.cc
+++ b/source/extensions/filters/network/ssh/filter_state_objects.cc
@@ -30,4 +30,18 @@ std::string RequestedServerNameFilterStateFactory::name() const {
 
 REGISTER_FACTORY(RequestedServerNameFilterStateFactory, StreamInfo::FilterState::ObjectFactory);
 
+const std::string& RequestedPath::key() {
+  CONSTRUCT_ON_FIRST_USE(std::string, "pomerium.extensions.ssh.requested_path");
+}
+
+const std::string& RequestedPathFilterStateFactory::key() {
+  return RequestedPath::key();
+}
+
+std::string RequestedPathFilterStateFactory::name() const {
+  return key();
+}
+
+REGISTER_FACTORY(RequestedPathFilterStateFactory, StreamInfo::FilterState::ObjectFactory);
+
 } // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/source/extensions/filters/network/ssh/filter_state_objects.h
+++ b/source/extensions/filters/network/ssh/filter_state_objects.h
@@ -32,6 +32,26 @@ public:
   }
 };
 
+class RequestedPath : public StreamInfo::FilterState::Object {
+public:
+  RequestedPath(absl::string_view server_name) : server_name_(server_name) {}
+  const std::string& value() const { return server_name_; }
+  absl::optional<std::string> serializeAsString() const override { return server_name_; }
+  static const std::string& key();
+
+private:
+  const std::string server_name_;
+};
+
+class RequestedPathFilterStateFactory : public StreamInfo::FilterState::ObjectFactory {
+public:
+  std::string name() const override;
+  static const std::string& key();
+  std::unique_ptr<StreamInfo::FilterState::Object> createFromBytes(absl::string_view data) const override {
+    return std::make_unique<RequestedPath>(data);
+  }
+};
+
 constexpr std::string_view ChannelIDManagerFilterStateKey = "pomerium.extensions.ssh.channel_id_manager";
 constexpr std::string_view AuthInfoFilterStateKey = "pomerium.extensions.ssh.auth_info";
 

--- a/source/extensions/filters/network/ssh/filter_state_objects.h
+++ b/source/extensions/filters/network/ssh/filter_state_objects.h
@@ -1,8 +1,36 @@
 #pragma once
 
-#include <string_view>
+#pragma clang unsafe_buffer_usage begin
+#include "source/common/network/filter_state_dst_address.h"
+#pragma clang unsafe_buffer_usage end
 
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
+
+class DownstreamSourceAddressFilterStateFactory : public Network::BaseAddressObjectFactory {
+public:
+  std::string name() const override;
+  static const std::string& key();
+};
+
+class RequestedServerName : public StreamInfo::FilterState::Object {
+public:
+  RequestedServerName(absl::string_view server_name) : server_name_(server_name) {}
+  const std::string& value() const { return server_name_; }
+  absl::optional<std::string> serializeAsString() const override { return server_name_; }
+  static const std::string& key();
+
+private:
+  const std::string server_name_;
+};
+
+class RequestedServerNameFilterStateFactory : public StreamInfo::FilterState::ObjectFactory {
+public:
+  std::string name() const override;
+  static const std::string& key();
+  std::unique_ptr<StreamInfo::FilterState::Object> createFromBytes(absl::string_view data) const override {
+    return std::make_unique<RequestedServerName>(data);
+  }
+};
 
 constexpr std::string_view ChannelIDManagerFilterStateKey = "pomerium.extensions.ssh.channel_id_manager";
 constexpr std::string_view AuthInfoFilterStateKey = "pomerium.extensions.ssh.auth_info";

--- a/source/extensions/filters/network/ssh/frame.h
+++ b/source/extensions/filters/network/ssh/frame.h
@@ -66,25 +66,18 @@ enum FrameTags : frame_tags_type {
 class SSHRequestHeaderFrame final : public GenericProxy::RequestHeaderFrame {
 public:
   SSHRequestHeaderFrame(const std::string& host,
-                        stream_id_t stream_id,
-                        const StreamInfo::FilterState& filter_state)
+                        stream_id_t stream_id)
       : host_(host),
-        stream_id_(stream_id),
-        filter_state_objects_(filter_state.objectsSharedWithUpstreamConnection()) {}
+        stream_id_(stream_id) {}
   std::string_view host() const override { return host_; }
   std::string_view protocol() const override { return "ssh"; }
   FrameFlags frameFlags() const override {
     return {stream_id_, 0, FrameTags::RequestHeader | FrameTags::EffectiveHeader};
   }
 
-  Envoy::OptRef<StreamInfo::FilterState::Objects> downstreamSharedFilterStateObjects() const {
-    return makeOptRefFromPtr(filter_state_objects_.get());
-  }
-
 private:
   std::string host_;
   stream_id_t stream_id_;
-  StreamInfo::FilterState::ObjectsPtr filter_state_objects_;
 };
 
 // Branchless conversion from FrameTags to matching FrameFlags. The expected FrameFlags value is

--- a/test/extensions/filters/network/ssh/BUILD
+++ b/test/extensions/filters/network/ssh/BUILD
@@ -357,6 +357,18 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "filter_state_objects_test",
+    srcs = [
+        "filter_state_objects_test.cc",
+    ],
+    repository = "@envoy",
+    deps = [
+        "//source/extensions/filters/network/ssh:pomerium_ssh",
+        "//test/test_common:test_common_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "socks5_test",
     srcs = [
         "socks5_test.cc",

--- a/test/extensions/filters/network/ssh/filter_state_objects_test.cc
+++ b/test/extensions/filters/network/ssh/filter_state_objects_test.cc
@@ -18,5 +18,19 @@ TEST(FilterStateObjectsTest, RequestedServerNameFilterStateFactory) {
   EXPECT_EQ("test name", obj->serializeAsString());
 }
 
+TEST(FilterStateObjectsTest, RequestedPath) {
+  RequestedPath obj("/foo");
+  EXPECT_EQ("/foo", obj.value());
+  EXPECT_EQ("/foo", obj.serializeAsString());
+  EXPECT_EQ("pomerium.extensions.ssh.requested_path", RequestedPath::key());
+}
+
+TEST(FilterStateObjectsTest, RequestedPathFilterStateFactory) {
+  RequestedPathFilterStateFactory factory;
+  EXPECT_EQ("pomerium.extensions.ssh.requested_path", RequestedPathFilterStateFactory::key());
+  auto obj = factory.createFromBytes("/foo");
+  EXPECT_EQ("/foo", obj->serializeAsString());
+}
+
 } // namespace test
 } // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/test/extensions/filters/network/ssh/filter_state_objects_test.cc
+++ b/test/extensions/filters/network/ssh/filter_state_objects_test.cc
@@ -1,0 +1,22 @@
+#include "source/extensions/filters/network/ssh/filter_state_objects.h"
+#include "gtest/gtest.h"
+
+namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
+namespace test {
+
+TEST(FilterStateObjectsTest, RequestedServerName) {
+  RequestedServerName obj("test name");
+  EXPECT_EQ("test name", obj.value());
+  EXPECT_EQ("test name", obj.serializeAsString());
+  EXPECT_EQ("pomerium.extensions.ssh.requested_server_name", RequestedServerName::key());
+}
+
+TEST(FilterStateObjectsTest, RequestedServerNameFilterStateFactory) {
+  RequestedServerNameFilterStateFactory factory;
+  EXPECT_EQ("pomerium.extensions.ssh.requested_server_name", RequestedServerNameFilterStateFactory::key());
+  auto obj = factory.createFromBytes("test name");
+  EXPECT_EQ("test name", obj->serializeAsString());
+}
+
+} // namespace test
+} // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/test/extensions/filters/network/ssh/server_transport_test.cc
+++ b/test/extensions/filters/network/ssh/server_transport_test.cc
@@ -1424,7 +1424,7 @@ TEST_P(ServerTransportResponseCodeTest, ErrorFlagInHeaderFrame) {
   auto authInfo = std::make_shared<AuthInfo>();
   authInfo->stream_id = 1234;
   SetAuthInfo(authInfo);
-  SSHRequestHeaderFrame mockHeaderFrame("example", 1234, *mock_connection_.streamInfo().filterState());
+  SSHRequestHeaderFrame mockHeaderFrame("example", 1234);
   auto status = absl::Status(absl::StatusCode::kInternal, msg);
   auto responseFrame = transport_.respond(status, "", mockHeaderFrame);
   ASSERT_EQ(ResponseHeader | EffectiveCommon | Error,
@@ -1451,7 +1451,7 @@ TEST_P(ServerTransportResponseCodeTest, RespondAdditionalMessage) {
   auto authInfo = std::make_shared<AuthInfo>();
   authInfo->stream_id = 1234;
   SetAuthInfo(authInfo);
-  SSHRequestHeaderFrame mockHeaderFrame("example", 1234, *mock_connection_.streamInfo().filterState());
+  SSHRequestHeaderFrame mockHeaderFrame("example", 1234);
   auto status = absl::Status(absl::StatusCode::kInternal, msg);
   auto responseFrame = transport_.respond(status, "additional message", mockHeaderFrame);
   auto dc = extractFrameMessage(*responseFrame);


### PR DESCRIPTION
Working on implementing filter state object sharing in upstream generic_proxy, which is currently missing. This removes the need for us to manually pass the objects through the request header message and extract them in the client codec.

This is needed because we have to propagate the `downstream_source_address` and `requested_server_name` filter state objects through to the upstream transport socket to enable reverse tunneling ssh routes.