### PR TITLE
mark envoy/, absl/, and api/ as system include prefixes

### DIFF
--- a/source/common/factory.h
+++ b/source/common/factory.h
@@ -7,9 +7,7 @@
 #include <ranges>
 #include "fmt/format.h"
 
-#pragma clang unsafe_buffer_usage begin
 #include "envoy/common/exception.h"
-#pragma clang unsafe_buffer_usage end
 
 // algorithm priority index (0 is highest priority)
 using priority_t = uint32_t;

--- a/source/common/id_alloc.h
+++ b/source/common/id_alloc.h
@@ -3,10 +3,8 @@
 #include <concepts>
 #include <set>
 
-#pragma clang unsafe_buffer_usage begin
 #include "absl/status/statusor.h"
 #include "source/common/common/assert.h"
-#pragma clang unsafe_buffer_usage end
 
 // A basic numeric ID allocator for unsigned integer types.
 // To allocate a new identifier, call alloc(). When an identifier is no longer needed and should

--- a/source/common/status.h
+++ b/source/common/status.h
@@ -2,9 +2,7 @@
 
 #include "source/common/common/fmt.h" // IWYU pragma: keep
 #include "fmt/format.h"
-#pragma clang unsafe_buffer_usage begin
 #include "absl/status/statusor.h" // IWYU pragma: keep
-#pragma clang unsafe_buffer_usage end
 
 // Wraps an absl::Status with additional message context, but keeps the status code. Similar to
 // fmt.Errorf.

--- a/source/extensions/filters/network/ssh/BUILD
+++ b/source/extensions/filters/network/ssh/BUILD
@@ -58,6 +58,11 @@ envoy_cc_library(
         "-Wimplicit-fallthrough",
         "-Wimplicit-int-conversion",
         "-Wunsafe-buffer-usage",
+        "--system-header-prefix=envoy/",
+        "--system-header-prefix=absl/",
+        "--system-header-prefix=api/",
+        "--system-header-prefix=source/common/common/",
+        "--system-header-prefix=source/common/buffer/",
     ],
     repository = "@envoy",
     deps = [

--- a/source/extensions/filters/network/ssh/channel.h
+++ b/source/extensions/filters/network/ssh/channel.h
@@ -2,9 +2,7 @@
 
 #include "source/extensions/filters/network/ssh/wire/messages.h"
 
-#pragma clang unsafe_buffer_usage begin
 #include "api/extensions/filters/network/ssh/ssh.pb.h"
-#pragma clang unsafe_buffer_usage end
 
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 

--- a/source/extensions/filters/network/ssh/client_transport.h
+++ b/source/extensions/filters/network/ssh/client_transport.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#pragma clang unsafe_buffer_usage begin
 #include "source/extensions/filters/network/generic_proxy/codec_callbacks.h"
-#pragma clang unsafe_buffer_usage end
 #include "source/extensions/filters/network/generic_proxy/interface/codec.h"
 
 #include "source/extensions/filters/network/ssh/extension_ping.h"

--- a/source/extensions/filters/network/ssh/common.h
+++ b/source/extensions/filters/network/ssh/common.h
@@ -4,10 +4,8 @@
 #include <unordered_set>
 #include <unordered_map>
 
-#include "fmt/std.h" // IWYU pragma: keep
-#pragma clang unsafe_buffer_usage begin
+#include "fmt/std.h"              // IWYU pragma: keep
 #include "absl/status/statusor.h" // IWYU pragma: keep
-#pragma clang unsafe_buffer_usage end
 
 #include "source/common/types.h" // IWYU pragma: keep
 

--- a/source/extensions/filters/network/ssh/config.h
+++ b/source/extensions/filters/network/ssh/config.h
@@ -3,11 +3,9 @@
 #include <cerrno>
 #include <unistd.h>
 
-#pragma clang unsafe_buffer_usage begin
 #include "api/extensions/filters/network/ssh/ssh.pb.h"
 #include "api/extensions/filters/network/ssh/ssh.pb.validate.h"
 #include "source/extensions/filters/network/generic_proxy/interface/codec.h"
-#pragma clang unsafe_buffer_usage end
 
 #include "source/extensions/filters/network/ssh/openssh.h"
 #include "source/extensions/filters/network/ssh/transport.h"

--- a/source/extensions/filters/network/ssh/frame.h
+++ b/source/extensions/filters/network/ssh/frame.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#pragma clang unsafe_buffer_usage begin
 #include "source/extensions/filters/network/generic_proxy/interface/stream.h"
-#pragma clang unsafe_buffer_usage end
 
 #include "source/extensions/filters/network/ssh/wire/messages.h"
 #include "source/extensions/filters/network/ssh/common.h"

--- a/source/extensions/filters/network/ssh/grpc_client_impl.h
+++ b/source/extensions/filters/network/ssh/grpc_client_impl.h
@@ -2,10 +2,9 @@
 
 #include <type_traits>
 
-#pragma clang unsafe_buffer_usage begin
 #include "source/common/grpc/typed_async_client.h"
+
 #include "api/extensions/filters/network/ssh/ssh.pb.h"
-#pragma clang unsafe_buffer_usage end
 
 #include "source/extensions/filters/network/ssh/message_handler.h"
 #include "source/extensions/filters/network/ssh/common.h"

--- a/source/extensions/filters/network/ssh/message_handler.h
+++ b/source/extensions/filters/network/ssh/message_handler.h
@@ -3,10 +3,8 @@
 #include <unordered_map>
 #include <utility>
 
-#pragma clang unsafe_buffer_usage begin
 #include "absl/status/status.h"
 #include "source/common/common/assert.h"
-#pragma clang unsafe_buffer_usage end
 #include "fmt/format.h"
 
 #include "envoy/common/pure.h"

--- a/source/extensions/filters/network/ssh/openssh.cc
+++ b/source/extensions/filters/network/ssh/openssh.cc
@@ -6,9 +6,7 @@
 #include "source/common/common/assert.h"
 #include "source/extensions/filters/network/ssh/wire/common.h"
 
-#pragma clang unsafe_buffer_usage begin
 #include "envoy/config/core/v3/base.pb.h"
-#pragma clang unsafe_buffer_usage end
 
 extern "C" {
 #include "openssh/ssh2.h"

--- a/source/extensions/filters/network/ssh/openssh.h
+++ b/source/extensions/filters/network/ssh/openssh.h
@@ -6,9 +6,7 @@
 
 #include "source/extensions/filters/network/ssh/common.h"
 
-#pragma clang unsafe_buffer_usage begin
 #include "envoy/buffer/buffer.h"
-#pragma clang unsafe_buffer_usage end
 
 extern "C" {
 #include "openssh/sshkey.h"

--- a/source/extensions/filters/network/ssh/packet_cipher.h
+++ b/source/extensions/filters/network/ssh/packet_cipher.h
@@ -2,9 +2,7 @@
 
 #include <cstdint>
 
-#pragma clang unsafe_buffer_usage begin
 #include "envoy/buffer/buffer.h"
-#pragma clang unsafe_buffer_usage end
 #include "source/common/factory.h"
 #include "source/extensions/filters/network/ssh/openssh.h"
 

--- a/source/extensions/filters/network/ssh/packet_cipher_aead.h
+++ b/source/extensions/filters/network/ssh/packet_cipher_aead.h
@@ -3,9 +3,7 @@
 #include <memory>
 #include <string>
 
-#pragma clang unsafe_buffer_usage begin
 #include "envoy/buffer/buffer.h"
-#pragma clang unsafe_buffer_usage end
 #include "source/common/common/logger.h"
 
 #include "source/extensions/filters/network/ssh/openssh.h"

--- a/source/extensions/filters/network/ssh/packet_cipher_etm.cc
+++ b/source/extensions/filters/network/ssh/packet_cipher_etm.cc
@@ -1,9 +1,7 @@
 #include "source/extensions/filters/network/ssh/packet_cipher_etm.h"
 #include "source/common/span.h"
 
-#pragma clang unsafe_buffer_usage begin
 #include "source/common/buffer/buffer_impl.h"
-#pragma clang unsafe_buffer_usage end
 
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 

--- a/source/extensions/filters/network/ssh/server_transport.h
+++ b/source/extensions/filters/network/ssh/server_transport.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#pragma clang unsafe_buffer_usage begin
 #include "source/extensions/filters/network/generic_proxy/codec_callbacks.h"
 #include "api/extensions/filters/network/ssh/ssh.pb.h"
-#pragma clang unsafe_buffer_usage end
 #include "source/extensions/filters/network/generic_proxy/interface/codec.h"
 
 #include "source/extensions/filters/network/ssh/transport.h"

--- a/source/extensions/filters/network/ssh/stream_tracker.h
+++ b/source/extensions/filters/network/ssh/stream_tracker.h
@@ -2,12 +2,10 @@
 
 #include "source/extensions/filters/network/ssh/channel.h"
 
-#pragma clang unsafe_buffer_usage begin
 #include "envoy/event/dispatcher.h"
 #include "envoy/server/factory_context.h"
 #include "api/extensions/filters/network/ssh/ssh.pb.h"
 #include "api/extensions/filters/network/ssh/ssh.pb.validate.h"
-#pragma clang unsafe_buffer_usage end
 
 #include "source/extensions/filters/network/ssh/common.h"
 

--- a/source/extensions/filters/network/ssh/transport.h
+++ b/source/extensions/filters/network/ssh/transport.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#pragma clang unsafe_buffer_usage begin
 #include "api/extensions/filters/network/ssh/ssh.pb.h"
-#pragma clang unsafe_buffer_usage end
 #include "source/common/id_alloc.h"
 #include "source/extensions/filters/network/ssh/id_manager.h"
 #include "source/extensions/filters/network/ssh/openssh.h"

--- a/source/extensions/filters/network/ssh/version_exchange.h
+++ b/source/extensions/filters/network/ssh/version_exchange.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#pragma clang unsafe_buffer_usage begin
 #include "absl/status/statusor.h"
 #include "envoy/buffer/buffer.h"
-#pragma clang unsafe_buffer_usage end
 
 #include "source/extensions/filters/network/ssh/transport.h"
 

--- a/source/extensions/filters/network/ssh/wire/BUILD
+++ b/source/extensions/filters/network/ssh/wire/BUILD
@@ -27,6 +27,11 @@ envoy_cc_library(
         "-Wimplicit-fallthrough",
         "-Wimplicit-int-conversion",
         "-Wunsafe-buffer-usage",
+        "--system-header-prefix=envoy/",
+        "--system-header-prefix=absl/",
+        "--system-header-prefix=api/",
+        "--system-header-prefix=source/common/common/",
+        "--system-header-prefix=source/common/buffer/",
     ],
     repository = "@envoy",
     deps = [

--- a/source/extensions/filters/network/ssh/wire/encoding.h
+++ b/source/extensions/filters/network/ssh/wire/encoding.h
@@ -13,10 +13,8 @@
 #include <string>
 #include <utility>
 
-#pragma clang unsafe_buffer_usage begin
 #include "absl/status/statusor.h"
 #include "source/common/buffer/buffer_impl.h"
-#pragma clang unsafe_buffer_usage end
 
 #include "source/extensions/filters/network/ssh/wire/common.h"
 #include "source/extensions/filters/network/ssh/wire/validation.h"

--- a/source/extensions/filters/network/ssh/wire/field.h
+++ b/source/extensions/filters/network/ssh/wire/field.h
@@ -7,10 +7,8 @@
 #include <utility>
 #include <variant>
 
-#pragma clang unsafe_buffer_usage begin
 #include "absl/strings/escaping.h"
 #include "fmt/ranges.h"
-#pragma clang unsafe_buffer_usage end
 
 #include "source/common/common/fmt.h" // IWYU pragma: keep
 #include "source/common/visit.h"

--- a/source/extensions/filters/network/ssh/wire/util.h
+++ b/source/extensions/filters/network/ssh/wire/util.h
@@ -2,9 +2,7 @@
 
 #include <concepts>
 
-#pragma clang unsafe_buffer_usage begin
 #include "source/common/buffer/buffer_impl.h"
-#pragma clang unsafe_buffer_usage end
 
 namespace {
 

--- a/source/extensions/filters/network/ssh/wire/validation.h
+++ b/source/extensions/filters/network/ssh/wire/validation.h
@@ -4,10 +4,8 @@
 #include <cstdio>
 #include <type_traits>
 
-#pragma clang unsafe_buffer_usage begin
 #include "envoy/buffer/buffer.h"
 #include "absl/status/statusor.h"
-#pragma clang unsafe_buffer_usage end
 
 namespace wire::tags {
 struct no_validation : ::tags::no_validation {

--- a/test/common/span_test.cc
+++ b/test/common/span_test.cc
@@ -1,9 +1,7 @@
 #include "source/common/span.h"
 #include "gtest/gtest.h"
 
-#pragma clang unsafe_buffer_usage begin
 #include "source/common/buffer/buffer_impl.h"
-#pragma clang unsafe_buffer_usage end
 
 TEST(SpanTest, UnsafeForgeSpan) {
   uint8_t* x = new uint8_t[10]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};

--- a/test/extensions/filters/network/ssh/config_test.cc
+++ b/test/extensions/filters/network/ssh/config_test.cc
@@ -2,10 +2,8 @@
 #include "test/mocks/server/server_factory_context.h"
 #include "test/extensions/filters/network/ssh/test_env_util.h"
 
-#pragma clang unsafe_buffer_usage begin
 #include "api/extensions/filters/network/ssh/ssh.pb.h"
 #include "source/extensions/filters/network/generic_proxy/interface/codec.h"
-#pragma clang unsafe_buffer_usage end
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"

--- a/test/extensions/filters/network/ssh/openssh_test.cc
+++ b/test/extensions/filters/network/ssh/openssh_test.cc
@@ -10,10 +10,8 @@
 #include "test/extensions/filters/network/ssh/wire/test_field_reflect.h"
 #include "test/test_common/logging.h"
 
-#pragma clang unsafe_buffer_usage begin
 #include "absl/strings/str_split.h"
 #include "absl/strings/str_replace.h"
-#pragma clang unsafe_buffer_usage end
 
 extern "C" {
 #include "openssh/ssh2.h"

--- a/test/extensions/filters/network/ssh/test_mocks.h
+++ b/test/extensions/filters/network/ssh/test_mocks.h
@@ -9,10 +9,8 @@
 #include "source/extensions/filters/network/ssh/kex.h"
 #include "api/extensions/filters/network/ssh/ssh.pb.h"
 
-#pragma clang unsafe_buffer_usage begin
 #include "envoy/buffer/buffer.h"
 #include "absl/status/statusor.h"
-#pragma clang unsafe_buffer_usage end
 
 #include "gmock/gmock.h" // IWYU pragma: keep
 

--- a/test/extensions/filters/network/ssh/wire/test_mocks.h
+++ b/test/extensions/filters/network/ssh/wire/test_mocks.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#pragma clang unsafe_buffer_usage begin
 #include "envoy/buffer/buffer.h"
 #include "absl/status/statusor.h"
-#pragma clang unsafe_buffer_usage end
 
 #include "gmock/gmock.h" // IWYU pragma: keep
 

--- a/test/extensions/filters/network/ssh/wire/test_util.h
+++ b/test/extensions/filters/network/ssh/wire/test_util.h
@@ -4,9 +4,7 @@
 #include "source/extensions/filters/network/ssh/wire/common.h"
 #include "gtest/gtest.h" // IWYU pragma: keep
 
-#pragma clang unsafe_buffer_usage begin
 #include "absl/random/random.h"
-#pragma clang unsafe_buffer_usage end
 
 namespace wire::test {
 

--- a/test/test_common/test_common.h
+++ b/test/test_common/test_common.h
@@ -3,7 +3,6 @@
 #include "source/common/optref.h"
 #include "source/common/types.h"
 #include "source/common/type_traits.h"
-#pragma clang unsafe_buffer_usage begin
 #include "source/common/buffer/buffer_impl.h" // IWYU pragma: keep
 #include "absl/random/random.h"
 #include "test/test_common/status_utility.h" // IWYU pragma: keep
@@ -11,7 +10,6 @@
 #if defined(NDEBUG) || defined(ENVOY_CONFIG_COVERAGE)
 #include "test/test_common/logging.h"
 #endif
-#pragma clang unsafe_buffer_usage end
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h" // IWYU pragma: keep


### PR DESCRIPTION
Because we use the clang safe buffers feature (https://clang.llvm.org/docs/SafeBuffers.html), some external dependency includes need to be wrapped with pragma statements that disable/enable these warnings. We can try using the --system-header-prefix flag (https://github.com/llvm/llvm-project/blob/main/clang/docs/UsersManual.rst#controlling-diagnostics-in-system-headers) to tell clang that certain header prefixes contain "system" headers, which suppresses warnings. The include paths for external envoy headers and our own headers share the same directory structure, and this flag only operates on the include paths as they appear in the source code (instead of the resolved "external/" headers), so by default none of the envoy headers are treated as system headers. 

We can add the `envoy/`, `absl/`, and `api/` prefixes to the system headers list, since these contain envoy public api definitions, abseil code, and generated api code respectively. We also add `source/common/common/` to suppress warnings in envoy common code, and `source/common/buffer/` (which most of the warnings originate from), which is fine as long as we don't use these paths in our own code in the future.