### PR TITLE
buildbarn toolchain config fixes

### DIFF
--- a/bazel/foreign_cc/luajit.bzl
+++ b/bazel/foreign_cc/luajit.bzl
@@ -53,7 +53,13 @@ _platform_mappings = {
     "linux_aarch64": "linux_arm64",
     "macos_arm64": "macos_arm64",
     "macos_aarch64": "macos_arm64",
+    "darwin_arm64": "macos_arm64",
+    "darwin_aarch64": "macos_arm64",
+    "osx_arm64": "macos_arm64",
+    "osx_aarch64": "macos_arm64",
     "macos": "macos_arm64",
+    "darwin": "macos_arm64",
+    "osx": "macos_arm64",
 }
 
 def _use_host_platform_impl(settings, _):

--- a/bazel/platforms/rbe/BUILD
+++ b/bazel/platforms/rbe/BUILD
@@ -3,13 +3,12 @@ package(default_visibility = ["//visibility:public"])
 # Note: these platforms are for cross-compiling only. The envoy-build container image is only
 # available for linux/amd64.
 
-container_image = "ghcr.io/pomerium/envoy-build:22.1.1-1@sha256:67051c647045567b0c7069227b13e00490dd01bccf8d66288e7daa90cf8c0337"
+container_image = "ghcr.io/pomerium/envoy-build:22.1.1-1@sha256:e58ed6feffccad36bd064efdb845eee9d7c7c73bf7b413a4089a9273d9db6b03"
 
 platform(
     name = "linux_x64",
     exec_properties = {
-        "container-image": "docker://" + container_image,
-        "OSFamily": "linux",
+        "container-image": container_image,
     },
     parents = ["@envoy//bazel/platforms:linux_x64"],
 )
@@ -17,8 +16,7 @@ platform(
 platform(
     name = "linux_arm64",
     exec_properties = {
-        "container-image": "docker://" + container_image,
-        "OSFamily": "linux",
+        "container-image": container_image,
     },
     parents = ["@envoy//bazel/platforms:linux_arm64"],
 )
@@ -26,8 +24,7 @@ platform(
 platform(
     name = "macos",
     exec_properties = {
-        "container-image": "docker://" + container_image,
-        "OSFamily": "linux",
+        "container-image": container_image,
     },
     parents = ["@envoy//bazel/platforms:macos_arm64"],
 )

--- a/bazel/toolchains.bzl
+++ b/bazel/toolchains.bzl
@@ -32,8 +32,8 @@ def pomerium_envoy_toolchains():
     arch_alias(
         name = "clang_platform",
         aliases = {
-            "amd64": "@envoy//bazel/platforms/rbe:linux_x64",
-            "aarch64": "@envoy//bazel/platforms/rbe:linux_arm64",
+            "amd64": "@//bazel/platforms/rbe:linux_x64",
+            "aarch64": "@//bazel/platforms/rbe:linux_arm64",
         },
     )
     llvm_toolchain(


### PR DESCRIPTION
Updates rbe exec properties, build image, arch_alias (which we might want to remove I think, but not right now), and luajit platform mappings (also kind of hacky, but fine for now).