### PR TITLE
experimental: add //:envoy_multiarch target 

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,6 +4,7 @@ load(
 )
 load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
+load("//bazel:multi_arch.bzl", "multiarch_envoy_cc_binary")
 load("//bazel/ci/images:oci.bzl", "image")
 
 package(default_visibility = ["//visibility:public"])
@@ -26,6 +27,13 @@ envoy_cc_binary(
         "//source/extensions/tracers/pomerium_otel",
         "@envoy//source/exe:envoy_main_entry_lib",
     ],
+)
+
+# Note: for this to work correctly, set --host_platform explicitly on the command line, and enable
+# --experimental_platform_in_output_dir
+multiarch_envoy_cc_binary(
+    name = "envoy_multiarch",
+    target = ":envoy",
 )
 
 image(

--- a/bazel/multi_arch.bzl
+++ b/bazel/multi_arch.bzl
@@ -1,0 +1,36 @@
+def _multi_arch_transition_impl(_, __):
+    return {
+        "linux-amd64": {"//command_line_option:platforms": "//bazel/platforms/rbe:linux_x64"},
+        "linux-arm64": {"//command_line_option:platforms": "//bazel/platforms/rbe:linux_arm64"},
+        "macos-arm64": {"//command_line_option:platforms": "//bazel/platforms/rbe:macos"},
+    }
+
+multiarch_transition = transition(
+    inputs = [],
+    outputs = ["//command_line_option:platforms"],
+    implementation = _multi_arch_transition_impl,
+)
+
+def _multiarch_envoy_cc_binary_impl(ctx):
+    targets = ctx.split_attr.target
+    return [DefaultInfo(
+        files = depset(
+            transitive = [
+                targets["linux-amd64"][DefaultInfo].files,
+                targets["linux-arm64"][DefaultInfo].files,
+                targets["macos-arm64"][DefaultInfo].files,
+            ],
+        ),
+    )]
+
+multiarch_envoy_cc_binary = rule(
+    attrs = {
+        "target": attr.label(
+            cfg = multiarch_transition,
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+    implementation = _multiarch_envoy_cc_binary_impl,
+)


### PR DESCRIPTION
add //:envoy_multiarch target which cross-compiles to all architectures at once