### PR TITLE
fix thread shutdown in stream tracker test

### DIFF
--- a/test/extensions/filters/network/ssh/stream_tracker_test.cc
+++ b/test/extensions/filters/network/ssh/stream_tracker_test.cc
@@ -224,12 +224,10 @@ public:
   }
 
   ~StreamTrackerThreadingTest() {
-    std::weak_ptr<StreamTracker> wp = stream_tracker_;
-    ASSERT(!wp.expired());
-    runOnMainBlocking([&] { stream_tracker_.reset(); });
     shutdownThreading();
-    exitThreads();
-    ASSERT(wp.expired());
+    exitThreads([this] {
+      stream_tracker_.reset();
+    });
   }
 
   std::shared_ptr<StreamTracker> stream_tracker_;


### PR DESCRIPTION
In these tests the stream tracker should stay alive until TLS is fully shut down. Deleting it too early was causing a race in internal thread local slot callbacks.