### PR TITLE
remove bazelrc ldflags workaround for external cmake dependencies

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,14 +16,6 @@ build:tsan --test_env=TSAN_SYMBOLIZER_PATH
 # the dependency on libgcc.
 common:clang-common --@toolchains_llvm//toolchain/config:compiler-rt=true
 common:clang-common --@toolchains_llvm//toolchain/config:libunwind=true
-# Same as above, but applies to foreign_cc targets using autotools/cmake, which may not inherit the
-# link flags applied by the toolchain.
-# FIXME: this should not be necessary, but not having it breaks c-only foreign_cc dependencies
-# that use cmake. The c-only targets DO inherit flags from the toolchain's conly_flags option, but
-# that also breaks other C targets when set due to unused compiler flag errors.
-common:libc++ --action_env=LDFLAGS="-stdlib=libc++ -fuse-ld=lld -rtlib=compiler-rt"
-common:sanitizer --action_env=LDFLAGS="-stdlib=libc++ -fuse-ld=lld -rtlib=compiler-rt -l:libunwind.a"
-common:coverage --action_env=LDFLAGS="-stdlib=libc++ -fuse-ld=lld -rtlib=compiler-rt -l:libunwind.a"
 
 # Disable cgo. If cgo is enabled, some of the cc toolchain flags will propagate to the go toolchain,
 # which causes fPIC mismatch errors.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,6 +54,8 @@ http_archive(
         "//patches/envoy:0007-coverage-format.patch",
         "//patches/envoy:0008-sanitizer-deps.patch",
         "//patches/envoy:0009-luajit.patch",
+        "//patches/envoy:0010-ensure-lld-is-used-for-external-cmake-44075.patch",
+        "//patches/envoy:0011-external-cmake-compiler-rt-support.patch",
         "//patches/envoy:fix-antlr4-cpp-runtime.patch",
         "//patches/envoy:fix-integration-test-server-exit.patch",
         "//patches/envoy:fix-missing-symbolizer-env.patch",

--- a/patches/envoy/0010-ensure-lld-is-used-for-external-cmake-44075.patch
+++ b/patches/envoy/0010-ensure-lld-is-used-for-external-cmake-44075.patch
@@ -1,0 +1,51 @@
+From d0703e0dc52bdd246a9dc7823b18742bcce83669 Mon Sep 17 00:00:00 2001
+From: Takeshi Yoneda <tyoneda@netflix.com>
+Date: Sun, 22 Mar 2026 16:42:04 +0000
+Subject: [PATCH] Ensure lld is used for external cmake with clang
+
+Signed-off-by: Takeshi Yoneda <tyoneda@netflix.com>
+---
+ bazel/envoy_build_system.bzl | 20 ++++++++++++++++++--
+ 1 file changed, 18 insertions(+), 2 deletions(-)
+
+diff --git a/bazel/envoy_build_system.bzl b/bazel/envoy_build_system.bzl
+index ecfee096b1c3f..c3d09953306c1 100644
+--- a/bazel/envoy_build_system.bzl
++++ b/bazel/envoy_build_system.bzl
+@@ -127,18 +127,34 @@ def envoy_cmake(
+         generate_args = ["-GNinja"],
+         targets = ["", "install"],
+         **kwargs):
++    # On clang builds, point cmake at the LLVM toolchain's lld instead of the
++    # system linker (/bin/ld).  rules_foreign_cc runs cmake with
++    # generate_crosstool_file=False by default, so it only exports CC/CXX and
++    # never passes -fuse-ld=lld to cmake's configure step.  Without this,
++    # cmake falls back to the host /bin/ld, which can be a wrong-glibc-version
++    # bfd linker or may not exist at all (e.g. Arch Linux).  The LLVM toolchain
++    # always ships ld.lld alongside clang, so -fuse-ld=lld is always safe here.
++    _lld_linker_entries = select({
++        "@envoy//bazel:clang_build": {
++            "CMAKE_EXE_LINKER_FLAGS": "-fuse-ld=lld",
++            "CMAKE_SHARED_LINKER_FLAGS": "-fuse-ld=lld",
++            "CMAKE_MODULE_LINKER_FLAGS": "-fuse-ld=lld",
++        },
++        "//conditions:default": {},
++    })
++
+     # If cache_entries is a dict, merge defaults and wrap for debug builds.
+     # If it's a select(), pass it through directly.
+     if hasattr(cache_entries, "update"):
+         cache_entries.update(default_cache_entries)
+         cache_entries_debug = dict(cache_entries)
+         cache_entries_debug.update(debug_cache_entries)
+-        final_cache_entries = select({
++        final_cache_entries = _lld_linker_entries | select({
+             "@envoy//bazel:dbg_build": cache_entries_debug,
+             "//conditions:default": cache_entries,
+         })
+     else:
+-        final_cache_entries = cache_entries
++        final_cache_entries = _lld_linker_entries | cache_entries
+
+     pf = ""
+     if copy_pdb:

--- a/patches/envoy/0011-external-cmake-compiler-rt-support.patch
+++ b/patches/envoy/0011-external-cmake-compiler-rt-support.patch
@@ -1,0 +1,32 @@
+diff --git a/bazel/envoy_build_system.bzl b/bazel/envoy_build_system.bzl
+index c3d0995330..81a4690bcb 100644
+--- a/bazel/envoy_build_system.bzl
++++ b/bazel/envoy_build_system.bzl
+@@ -143,18 +143,25 @@ def envoy_cmake(
+         "//conditions:default": {},
+     })
+
++    _compiler_rt_entries = select({
++        "@toolchains_llvm//toolchain/config:use_compiler_rt": {
++            "CMAKE_C_FLAGS": "-rtlib=compiler-rt -l:libunwind.a",
++        },
++        "//conditions:default": {},
++    })
++
+     # If cache_entries is a dict, merge defaults and wrap for debug builds.
+     # If it's a select(), pass it through directly.
+     if hasattr(cache_entries, "update"):
+         cache_entries.update(default_cache_entries)
+         cache_entries_debug = dict(cache_entries)
+         cache_entries_debug.update(debug_cache_entries)
+-        final_cache_entries = _lld_linker_entries | select({
++        final_cache_entries = _lld_linker_entries | _compiler_rt_entries | select({
+             "@envoy//bazel:dbg_build": cache_entries_debug,
+             "//conditions:default": cache_entries,
+         })
+     else:
+-        final_cache_entries = _lld_linker_entries | cache_entries
++        final_cache_entries = _lld_linker_entries | _compiler_rt_entries | cache_entries
+
+     pf = ""
+     if copy_pdb:


### PR DESCRIPTION
Add temporary patches until https://github.com/envoyproxy/envoy/pull/44075 is merged