### PR TITLE
tag oci images with the git tag(s) pointing to HEAD, if any

### DIFF
--- a/bazel/ci/images/BUILD
+++ b/bazel/ci/images/BUILD
@@ -7,6 +7,7 @@ tag_exprs = [
     ".STABLE_BUILD_SCM_REVISION",
     # go module pseudo version format
     "((.STABLE_BUILD_SCM_REVISION_TIMESTAMP | tostring) + \"-\" + (.STABLE_BUILD_SCM_REVISION | tostring | .[0:12]))",
+    "(.STABLE_BUILD_SCM_TAG // \"\" | split(\" \"))",
 ]
 
 jq(
@@ -19,7 +20,7 @@ jq(
         "repo",
         REPO_NAME,
     ],
-    filter = "[%s]" % ",".join(tag_exprs) + r'| map("\($repo):\(.)") | .[]',
+    filter = "[%s]" % ",".join(tag_exprs) + r' | flatten | map(select(.)) | map("\($repo):\(.)") | .[]',
     visibility = ["//visibility:public"],
 )
 

--- a/bazel/get_workspace_status
+++ b/bazel/get_workspace_status
@@ -9,3 +9,8 @@
 # this is derived from the command go uses to obtain rev info, see go/internal/modfetch/codehost/git.go
 commit_timestamp="$(TZ=UTC0 git log --no-decorate -n1 --date="format-local:%Y%m%d%H%M%S" --format="format:%cd" HEAD)"
 echo "STABLE_BUILD_SCM_REVISION_TIMESTAMP ${commit_timestamp}"
+
+current_tag="$(git tag --points-at HEAD | xargs)"
+if [[ -n "$current_tag" ]]; then
+  echo "STABLE_BUILD_SCM_TAG ${current_tag}"
+fi


### PR DESCRIPTION
This will add extra image tags for each git tag pointing to HEAD. This may be necessary to be able to find image tags when the envoy-custom dependency in go.mod is a tagged revision without a pseudo-version attached.