### PR TITLE
misc. test fixes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,6 +54,7 @@ http_archive(
         "//patches/envoy:0007-coverage-format.patch",
         "//patches/envoy:0008-sanitizer-deps.patch",
         "//patches/envoy:0009-luajit.patch",
+        "//patches/envoy:0011-integration-tcp-client-write.patch",
         "//patches/envoy:fix-antlr4-cpp-runtime.patch",
         "//patches/envoy:fix-integration-test-server-exit.patch",
         "//patches/envoy:fix-missing-symbolizer-env.patch",

--- a/patches/envoy/0011-integration-tcp-client-write.patch
+++ b/patches/envoy/0011-integration-tcp-client-write.patch
@@ -1,0 +1,39 @@
+diff --git a/test/integration/integration_tcp_client.cc b/test/integration/integration_tcp_client.cc
+index e1655957dd..7ea2b8ad78 100644
+--- a/test/integration/integration_tcp_client.cc
++++ b/test/integration/integration_tcp_client.cc
+@@ -142,7 +142,8 @@ void IntegrationTcpClient::waitForHalfClose(std::chrono::milliseconds timeout,
+ void IntegrationTcpClient::readDisable(bool disabled) { connection_->readDisable(disabled); }
+ 
+ AssertionResult IntegrationTcpClient::write(const std::string& data, bool end_stream, bool verify,
+-                                            std::chrono::milliseconds timeout) {
++                                            std::chrono::milliseconds timeout,
++                                            bool ignore_disconnect_after_verified_write) {
+   Event::TestTimeSystem::RealTimeBound bound(timeout);
+   Buffer::OwnedImpl buffer(data);
+   if (verify) {
+@@ -165,6 +166,10 @@ AssertionResult IntegrationTcpClient::write(const std::string& data, bool end_st
+   if (!bound.withinBound()) {
+     return AssertionFailure() << "Timed out completing write";
+   } else if (verify && (disconnected_ || client_write_buffer_->bytesDrained() != bytes_expected)) {
++    if (disconnected_ && client_write_buffer_->bytesDrained() == bytes_expected &&
++        ignore_disconnect_after_verified_write) {
++      return AssertionSuccess();
++    }
+     return AssertionFailure()
+            << "Failed to complete write or unexpected disconnect. disconnected_: " << disconnected_
+            << " bytes_drained: " << client_write_buffer_->bytesDrained()
+diff --git a/test/integration/integration_tcp_client.h b/test/integration/integration_tcp_client.h
+index 7fb934401d..6f11120309 100644
+--- a/test/integration/integration_tcp_client.h
++++ b/test/integration/integration_tcp_client.h
+@@ -44,7 +44,8 @@ public:
+   void readDisable(bool disabled);
+   ABSL_MUST_USE_RESULT AssertionResult
+   write(const std::string& data, bool end_stream = false, bool verify = true,
+-        std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
++        std::chrono::milliseconds timeout = TestUtility::DefaultTimeout,
++        bool ignore_disconnect_after_verified_write = false);
+ 
+   const std::string& data() { return payload_reader_->data(); }
+   bool connected() const { return !disconnected_; }

--- a/source/extensions/filters/network/ssh/reverse_tunnel.cc
+++ b/source/extensions/filters/network/ssh/reverse_tunnel.cc
@@ -124,8 +124,6 @@ public:
     };
     *local_queue = &local_queue_;
 
-    remote_stream_handler_sync.syncPoint("initialize");
-
     // The remote dispatcher could be running concurrently, but it won't pick up this callback
     // until after the next time it acquires post_lock_ (see dispatcher_impl.cc). Because this call
     // to post() adds the callback to the queue while holding post_lock_, the write to peer_state_
@@ -138,10 +136,11 @@ public:
       // First check if the socket has been closed
       bool isDynamic = metadata_->server_port().is_dynamic();
       if (socket_closed_) {
-        ENVOY_LOG(debug, "channel {}: downstream closed before initialization", peer_state_.id);
+        ENVOY_LOG(debug, "channel {}: upstream init canceled: downstream is already disconnected", peer_state_.id);
         // If the downstream closes before sending any data, and the upstream is expecting a SOCKS
         // handshake, we have to send it an EOF before closing the channel because openssh client
         // can become stuck
+        reverse_tunnel_stats_.upstream_init_canceled_by_downstream_disconnect_total_.inc();
         onError(absl::CancelledError("downstream closed"), isDynamic);
         return;
       }
@@ -187,6 +186,7 @@ public:
 private:
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override {
+    ASSERT(remote_dispatcher_.isThreadSafe());
     ENVOY_LOG(debug, "downstream connection event: {}", std::to_underlying(event));
     // These events are from the perspective of the downstream client connection, so LocalClose
     // means the downstream closed the connection, and RemoteClose means the upstream (us) closed
@@ -195,11 +195,11 @@ private:
         event == Network::ConnectionEvent::RemoteClose) {
       // This is the last event received; the downstream connection will be destroyed and it is
       // safe to delete this object.
-      remote_stream_handler_sync.syncPoint("downstream_closed");
       socket_closed_ = true;
       if (!initialized_) {
         // Downstream closed before initialization
         ENVOY_LOG(debug, "downstream closed before initialization");
+        reverse_tunnel_stats_.downstream_disconnect_before_init_total_.inc();
         if (detached_) {
           remote_dispatcher_.deferredDelete(std::move(detached_self_));
         }

--- a/source/extensions/filters/network/ssh/reverse_tunnel.h
+++ b/source/extensions/filters/network/ssh/reverse_tunnel.h
@@ -26,6 +26,8 @@ namespace Envoy {
   COUNTER(downstream_flow_control_remote_window_restored_total)                     \
   COUNTER(downstream_flow_control_high_watermark_activated_total)                   \
   COUNTER(downstream_flow_control_low_watermark_activated_total)                    \
+  COUNTER(downstream_disconnect_before_init_total)                                  \
+  COUNTER(upstream_init_canceled_by_downstream_disconnect_total)                    \
   STATNAME(ssh_reverse_tunnel)
 
 MAKE_STAT_NAMES_STRUCT(ReverseTunnelStatNames, ALL_REVERSE_TUNNEL_STATS);
@@ -141,5 +143,3 @@ DECLARE_FACTORY(SshReverseTunnelClusterFactory);
 
 } // namespace Upstream
 } // namespace Envoy
-
-inline Envoy::Thread::ThreadSynchronizer remote_stream_handler_sync;

--- a/test/extensions/filters/network/ssh/BUILD
+++ b/test/extensions/filters/network/ssh/BUILD
@@ -278,7 +278,6 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "kex_test",
-    size = "large",
     srcs = [
         "kex_test.cc",
     ],
@@ -464,7 +463,6 @@ envoy_cc_test_library(
 
 envoy_cc_test(
     name = "reverse_tunnel_test",
-    size = "large",
     srcs = [
         "reverse_tunnel_test.cc",
     ],
@@ -477,7 +475,6 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "graceful_shutdown_test",
-    size = "large",
     srcs = [
         "graceful_shutdown_test.cc",
     ],

--- a/test/extensions/filters/network/ssh/reverse_tunnel_test.cc
+++ b/test/extensions/filters/network/ssh/reverse_tunnel_test.cc
@@ -386,6 +386,10 @@ static constexpr auto stat_downstream_high_watermark =
   "cluster.tcp_cluster.ssh_reverse_tunnel.downstream_flow_control_high_watermark_activated_total";
 static constexpr auto stat_downstream_low_watermark =
   "cluster.tcp_cluster.ssh_reverse_tunnel.downstream_flow_control_low_watermark_activated_total";
+static constexpr auto stat_downstream_disconnect_before_init =
+  "cluster.tcp_cluster.ssh_reverse_tunnel.downstream_disconnect_before_init_total";
+static constexpr auto stat_upstream_init_canceled_by_downstream_disconnect =
+  "cluster.tcp_cluster.ssh_reverse_tunnel.upstream_init_canceled_by_downstream_disconnect_total";
 
 class SendDataUntilRemoteWindowExhausted : public Task<Tasks::Channel, Tasks::Channel> {
 public:
@@ -1390,27 +1394,32 @@ TEST_P(DynamicPortForwardTest, DownstreamResetBeforeOpen) {
   ASSERT_TRUE(driver->wait(th));
 }
 
-static std::once_flag enable_once;
-
 TEST_P(DynamicPortForwardTest, DownstreamResetBeforeInitialize) {
-  std::call_once(enable_once, [] {
-    remote_stream_handler_sync.enable();
-  });
-  remote_stream_handler_sync.waitOn("initialize");
-  remote_stream_handler_sync.waitOn("downstream_closed");
-
-  auto th = driver->createTask<Tasks::AcceptReversePortForward>("", virtual_port, 1)
-              .then(driver->createTask<Tasks::WaitForChannelCloseByPeer>(Tasks::ExpectEOF::Yes))
+  auto th = driver->createTask<ReceiveReversePortForwardButDoNotConfirm>()
               .start();
-
   auto downstream = makeTcpConnectionWithServerName(lookupPort("tcp"), "tcp-cluster");
-  downstream->close(Network::ConnectionCloseType::AbortReset);
-
-  remote_stream_handler_sync.barrierOn("downstream_closed");
-  remote_stream_handler_sync.signal("downstream_closed");
-  remote_stream_handler_sync.signal("initialize");
-
   ASSERT_TRUE(driver->wait(th));
+  downstream->close(Network::ConnectionCloseType::AbortReset);
+  test_server_->waitForCounterEq(stat_downstream_disconnect_before_init, 1);
+}
+
+TEST_P(DynamicPortForwardTest, AcceptAfterDownstreamDisconnected) {
+  Tasks::Channel channel;
+  auto th = driver->createTask<ReceiveReversePortForwardButDoNotConfirm>()
+              .saveOutput(&channel)
+              .start();
+  auto downstream = makeTcpConnectionWithServerName(lookupPort("tcp"), "tcp-cluster");
+  ASSERT_TRUE(driver->wait(th));
+  downstream->close(Network::ConnectionCloseType::AbortReset);
+  test_server_->waitForCounterEq(stat_downstream_disconnect_before_init, 1);
+  driver->sendMessage(wire::ChannelOpenConfirmationMsg{
+    .recipient_channel = channel.remote_id,
+    .sender_channel = channel.local_id,
+    .initial_window_size = wire::ChannelWindowSize,
+    .max_packet_size = wire::ChannelMaxPacketSize,
+  });
+  test_server_->waitForCounterEq(stat_upstream_init_canceled_by_downstream_disconnect, 1,
+                                 TestUtility::DefaultTimeout, driver->connectionDispatcher().ptr());
 }
 
 TEST_P(DynamicPortForwardTest, DownstreamClosesDuringUpstreamSocks5Handshake) {

--- a/test/extensions/filters/network/ssh/reverse_tunnel_test.cc
+++ b/test/extensions/filters/network/ssh/reverse_tunnel_test.cc
@@ -822,12 +822,18 @@ public:
 };
 
 TEST_P(StaticPortForwardTest, UpstreamPacketTooLarge) {
+  Tasks::Channel channel;
   auto th = driver->createTask<Tasks::AcceptReversePortForward>(route_name, route_port, 1)
-              .then(driver->createTask<SendTooLargePacket>()
-                      .then(driver->createTask<Tasks::WaitForChannelCloseByPeer>()))
+              .saveOutput(&channel)
               .start();
+
   auto downstream = makeTcpConnectionWithServerName(route_port, route_name);
   ASSERT_TRUE(driver->wait(th));
+
+  ASSERT_TRUE(driver->wait(
+    driver->createTask<SendTooLargePacket>()
+      .then(driver->createTask<Tasks::WaitForChannelCloseByPeer>())
+      .start(channel)));
 
   downstream->close();
 }
@@ -1487,7 +1493,7 @@ TEST_P(ProtocolMismatchUpstreamExpectingDynamicModeTest, UpstreamExpectingDynami
                .then(driver->createTask<Tasks::SendChannelCloseAndWait>(Tasks::SendEOF(true)))
                .start(channel);
 
-  EXPECT_TRUE(downstream->write("not a socks5 handshake"));
+  EXPECT_TRUE(downstream->write("not a socks5 handshake", false, true, TestUtility::DefaultTimeout, true));
   ASSERT_TRUE(driver->wait(th2));
   EXPECT_TRUE(driver->waitForDiagnostic("ssh client may be expecting dynamic port-forwarding"));
 


### PR DESCRIPTION
* Fixed a test that was using ThreadSynchronizer to force specific threading behavior, but it wasn't working correctly (the test did exercise the correct code paths most of the time, but would occasionally get stuck). It turns out we don't actually need to use the ThreadSynchronizer anyway.
* Fixed a test that was flaky due to IntegrationTcpClient::write() failing if the server disconnected shortly after the write. That was expected behavior for the test however.
* Remove the size tags from ssh tests, they aren't needed since we enabled test sharding and produce a bunch of warnings.