### PR TITLE
test timeout fixes

### DIFF
--- a/api/extensions/filters/network/ssh/ssh.proto
+++ b/api/extensions/filters/network/ssh/ssh.proto
@@ -8,6 +8,7 @@ import "envoy/config/core/v3/config_source.proto";
 import "envoy/config/core/v3/extension.proto";
 import "envoy/config/core/v3/grpc_service.proto";
 import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
@@ -51,6 +52,8 @@ message CodecConfig {
   uint32 internal_channel_id_start = 6;
 
   AlgorithmOptions algorithm_options = 7;
+
+  ConnectionServiceOptions connection_service_options = 8;
 }
 
 message AlgorithmOptions {
@@ -61,6 +64,14 @@ message AlgorithmOptions {
   // Optional list of packet cipher algorithms to explicitly disable. By default, all supported
   // algorithms are enabled.
   repeated string disable_packet_cipher_algorithms = 2;
+}
+
+message ConnectionServiceOptions {
+  // Maximum duration to wait for a response to a channel close message sent by Envoy to a server or
+  // client. If the grace period elapses before the channel close reply is received, the connection
+  // is terminated. Defaults to 5 seconds; minimum is 100ms.
+  // This may be useful to adjust for debugging/testing purposes.
+  google.protobuf.Duration channel_close_response_grace_period = 1;
 }
 
 message ReverseTunnelCluster {

--- a/source/extensions/filters/network/ssh/client_transport.cc
+++ b/source/extensions/filters/network/ssh/client_transport.cc
@@ -47,7 +47,7 @@ void SshClientTransport::setCodecCallbacks(GenericProxy::ClientCodecCallbacks& c
 
 void SshClientTransport::initServices() {
   user_auth_svc_ = std::make_unique<UpstreamUserAuthService>(*this, api_);
-  connection_svc_ = std::make_unique<UpstreamConnectionService>(*this);
+  connection_svc_ = std::make_unique<UpstreamConnectionService>(config_->connection_service_options(), *this);
   ping_handler_ = std::make_unique<PingExtensionHandler>(*this);
 
   services_[user_auth_svc_->name()] = user_auth_svc_.get();

--- a/source/extensions/filters/network/ssh/server_transport.cc
+++ b/source/extensions/filters/network/ssh/server_transport.cc
@@ -126,7 +126,7 @@ void SshServerTransport::onConnected() {
 
 void SshServerTransport::initServices() {
   user_auth_service_ = std::make_unique<DownstreamUserAuthService>(*this, api_);
-  connection_service_ = std::make_unique<DownstreamConnectionService>(*this, stream_tracker_);
+  connection_service_ = std::make_unique<DownstreamConnectionService>(config_->connection_service_options(), *this, stream_tracker_);
   ping_handler_ = std::make_unique<PingExtensionHandler>(*this);
 
   services_[user_auth_service_->name()] = user_auth_service_.get();

--- a/source/extensions/filters/network/ssh/service_connection.cc
+++ b/source/extensions/filters/network/ssh/service_connection.cc
@@ -12,9 +12,11 @@ namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 // ConnectionService
 
 ConnectionService::ConnectionService(
+  const ConnectionServiceOptions& options,
   TransportCallbacks& callbacks,
   Peer direction)
-    : transport_(callbacks),
+    : options_(options),
+      transport_(callbacks),
       local_peer_(direction) {}
 
 void ConnectionService::registerMessageHandlers(SshMessageDispatcher& dispatcher) {
@@ -268,7 +270,14 @@ void ConnectionService::ChannelCallbacksImpl::sendMessageLocal(wire::Message&& m
         // close as a way to gracefully signal that the host is being drained.
         parent_.transport_.terminate(absl::DeadlineExceededError(fmt::format("timed out waiting for channel close response from {}", local_peer_)));
       });
-      close_timer_->enableTimer(CloseResponseGracePeriod);
+      std::chrono::milliseconds timeout{5000};
+      if (parent_.options_.has_channel_close_response_grace_period()) {
+        timeout = std::max(std::chrono::milliseconds(100),
+                           std::chrono::milliseconds{
+                             google::protobuf::util::TimeUtil::DurationToMilliseconds(
+                               parent_.options_.channel_close_response_grace_period())});
+      }
+      close_timer_->enableTimer(timeout);
       return true;
     },
     [&](wire::ChannelOpenFailureMsg& msg) {
@@ -719,9 +728,10 @@ absl::StatusOr<MiddlewareResult> OpenHijackedChannelMiddleware::interceptMessage
 }
 
 DownstreamConnectionService::DownstreamConnectionService(
+  const ConnectionServiceOptions& options,
   TransportCallbacks& callbacks,
   std::shared_ptr<StreamTracker> stream_tracker)
-    : ConnectionService(callbacks, Peer::Downstream),
+    : ConnectionService(options, callbacks, Peer::Downstream),
       transport_(dynamic_cast<DownstreamTransportCallbacks&>(callbacks)),
       stream_tracker_(std::move(stream_tracker)) {}
 

--- a/source/extensions/filters/network/ssh/service_connection.h
+++ b/source/extensions/filters/network/ssh/service_connection.h
@@ -11,14 +11,14 @@
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 
 using Envoy::Event::Dispatcher;
-constexpr auto CloseResponseGracePeriod = std::chrono::seconds(5);
+using pomerium::extensions::ssh::ConnectionServiceOptions;
 
 class ConnectionService : public virtual Service,
                           public virtual StreamCallbacks,
                           public Logger::Loggable<Logger::Id::filter> {
 public:
   std::string name() override { return "ssh-connection"; };
-  ConnectionService(TransportCallbacks& callbacks, Peer direction);
+  ConnectionService(const ConnectionServiceOptions& options, TransportCallbacks& callbacks, Peer direction);
 
   // Channel Lifetime:
   // Creating channels and sending/receiving channel messages must only happen via ConnectionService
@@ -147,6 +147,7 @@ protected:
   // is being deleted.
   void preempt(ChannelCallbacks& ccb, absl::Status err);
 
+  ConnectionServiceOptions options_;
   TransportCallbacks& transport_;
   const Peer local_peer_;
   Envoy::OptRef<MessageDispatcher<wire::Message>> msg_dispatcher_;
@@ -170,7 +171,8 @@ class DownstreamConnectionService final : public ConnectionService,
   friend class OpenHijackedChannelMiddleware;
 
 public:
-  DownstreamConnectionService(TransportCallbacks& callbacks,
+  DownstreamConnectionService(const ConnectionServiceOptions& options,
+                              TransportCallbacks& callbacks,
                               std::shared_ptr<StreamTracker> stream_tracker);
 
   void onStreamBegin(Network::Connection& connection);
@@ -202,8 +204,8 @@ private:
 class UpstreamConnectionService final : public ConnectionService,
                                         public UpstreamService {
 public:
-  UpstreamConnectionService(UpstreamTransportCallbacks& callbacks)
-      : ConnectionService(callbacks, Peer::Upstream) {}
+  UpstreamConnectionService(const ConnectionServiceOptions& options, UpstreamTransportCallbacks& callbacks)
+      : ConnectionService(options, callbacks, Peer::Upstream) {}
   absl::Status requestService() override;
   absl::Status onServiceAccepted() override;
 };

--- a/test/extensions/filters/network/ssh/graceful_shutdown_test.cc
+++ b/test/extensions/filters/network/ssh/graceful_shutdown_test.cc
@@ -86,7 +86,7 @@ TEST_P(GracefulShutdownIntegrationTest, ServerDrain) {
     });
   });
   ASSERT_TRUE(driver_->wait(th));
-  ASSERT_TRUE(drainComplete.WaitForNotificationWithTimeout(absl::Seconds(1)));
+  ASSERT_TRUE(drainComplete.WaitForNotificationWithTimeout(absl::FromChrono(TestUtility::DefaultTimeout)));
 }
 
 TEST_P(GracefulShutdownIntegrationTest, ServerShutdown) {
@@ -113,7 +113,7 @@ TEST_P(GracefulShutdownIntegrationTest, ServerShutdownThenDrain) {
     });
   });
   ASSERT_TRUE(driver_->wait(th));
-  ASSERT_FALSE(drainComplete.WaitForNotificationWithTimeout(absl::Milliseconds(100)));
+  ASSERT_FALSE(drainComplete.WaitForNotificationWithTimeout(absl::FromChrono(TestUtility::DefaultTimeout)));
 }
 
 TEST_P(GracefulShutdownIntegrationTest, ServerShutdownTwice) {

--- a/test/extensions/filters/network/ssh/reverse_tunnel_test.cc
+++ b/test/extensions/filters/network/ssh/reverse_tunnel_test.cc
@@ -1162,8 +1162,7 @@ TEST_P(StaticPortForwardTest, InternalDownstreamChannelOpenFails) {
   }
 }
 
-class ChannelCloseTimeoutTest : public Envoy::Event::TestUsingSimulatedTime,
-                                public StaticPortForwardTest {
+class ChannelCloseTimeoutTest : public StaticPortForwardTest {
   using StaticPortForwardTest::StaticPortForwardTest;
 };
 
@@ -1185,7 +1184,8 @@ TEST_P(ChannelCloseTimeoutTest, UpstreamIgnoresChannelCloseDuringHostDrain) {
                .start(channel);
   setClusterLoad(cluster_name, {});
   ASSERT_TRUE(driver->wait(th2));
-  simTime().advanceTimeWait(CloseResponseGracePeriod + std::chrono::milliseconds(10));
+  // channel_close_response_grace_period is set to 1000ms for the integration tests
+  timeSystem().advanceTimeWait(std::chrono::milliseconds(1010));
   ASSERT_TRUE(driver->wait(driver->createTask<Tasks::WaitForDisconnectWithError>("timed out waiting for channel close").start()));
   downstream->waitForDisconnect();
 }

--- a/test/extensions/filters/network/ssh/reverse_tunnel_test.cc
+++ b/test/extensions/filters/network/ssh/reverse_tunnel_test.cc
@@ -1685,10 +1685,10 @@ TEST_P(EDSUpdatesIntegrationTest, TestClusterUpdates) {
   };
   setClusterLoad("tcp_cluster", {endpoint1});
 
-  test_server_->waitForCounterEq("cluster.tcp_cluster.update_no_rebuild", 0, std::chrono::seconds(1));
-  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_total", 1, std::chrono::seconds(1));
-  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_healthy", 1, std::chrono::seconds(1));
-  test_server_->waitForCounterEq("cluster.tcp_cluster.membership_change", 1, std::chrono::seconds(1));
+  test_server_->waitForCounterEq("cluster.tcp_cluster.update_no_rebuild", 0);
+  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_total", 1);
+  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_healthy", 1);
+  test_server_->waitForCounterEq("cluster.tcp_cluster.membership_change", 1);
 
   ClusterLoadOpts endpoint2{
     .stream_id = 2,
@@ -1699,10 +1699,10 @@ TEST_P(EDSUpdatesIntegrationTest, TestClusterUpdates) {
   };
   setClusterLoad("tcp_cluster", {endpoint1, endpoint2});
 
-  test_server_->waitForCounterEq("cluster.tcp_cluster.update_no_rebuild", 0, std::chrono::seconds(1));
-  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_total", 2, std::chrono::seconds(1));
-  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_healthy", 2, std::chrono::seconds(1));
-  test_server_->waitForCounterEq("cluster.tcp_cluster.membership_change", 2, std::chrono::seconds(1));
+  test_server_->waitForCounterEq("cluster.tcp_cluster.update_no_rebuild", 0);
+  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_total", 2);
+  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_healthy", 2);
+  test_server_->waitForCounterEq("cluster.tcp_cluster.membership_change", 2);
 
   ClusterLoadOpts endpoint3{
     .stream_id = 3,
@@ -1713,25 +1713,25 @@ TEST_P(EDSUpdatesIntegrationTest, TestClusterUpdates) {
   };
   setClusterLoad("tcp_cluster", {endpoint1, endpoint2, endpoint3});
 
-  test_server_->waitForCounterEq("cluster.tcp_cluster.update_no_rebuild", 0, std::chrono::seconds(1));
-  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_total", 3, std::chrono::seconds(1));
-  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_healthy", 3, std::chrono::seconds(1));
-  test_server_->waitForCounterEq("cluster.tcp_cluster.membership_change", 3, std::chrono::seconds(1));
+  test_server_->waitForCounterEq("cluster.tcp_cluster.update_no_rebuild", 0);
+  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_total", 3);
+  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_healthy", 3);
+  test_server_->waitForCounterEq("cluster.tcp_cluster.membership_change", 3);
 
   setClusterLoad("tcp_cluster", {endpoint2, endpoint3});
 
-  test_server_->waitForCounterEq("cluster.tcp_cluster.update_no_rebuild", 0, std::chrono::seconds(1));
-  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_total", 2, std::chrono::seconds(1));
-  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_healthy", 2, std::chrono::seconds(1));
-  test_server_->waitForCounterEq("cluster.tcp_cluster.membership_change", 4, std::chrono::seconds(1));
+  test_server_->waitForCounterEq("cluster.tcp_cluster.update_no_rebuild", 0);
+  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_total", 2);
+  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_healthy", 2);
+  test_server_->waitForCounterEq("cluster.tcp_cluster.membership_change", 4);
 
   endpoint3.is_dynamic = false; // trigger metadata update
   setClusterLoad("tcp_cluster", {endpoint2, endpoint3});
 
-  test_server_->waitForCounterEq("cluster.tcp_cluster.update_no_rebuild", 0, std::chrono::seconds(1)); // <-
-  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_total", 2, std::chrono::seconds(1));
-  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_healthy", 2, std::chrono::seconds(1));
-  test_server_->waitForCounterEq("cluster.tcp_cluster.membership_change", 4, std::chrono::seconds(1));
+  test_server_->waitForCounterEq("cluster.tcp_cluster.update_no_rebuild", 0);
+  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_total", 2);
+  test_server_->waitForGaugeEq("cluster.tcp_cluster.membership_healthy", 2);
+  test_server_->waitForCounterEq("cluster.tcp_cluster.membership_change", 4);
 }
 
 TEST_P(EDSUpdatesIntegrationTest, WrongClusterName) {
@@ -1740,7 +1740,7 @@ TEST_P(EDSUpdatesIntegrationTest, WrongClusterName) {
   envoy::config::endpoint::v3::ClusterLoadAssignment load;
   load.set_cluster_name("http_cluster");
   eds_helpers_["tcp_cluster"]->setEds(load);
-  test_server_->waitForCounterEq("cluster.tcp_cluster.update_rejected", 1, std::chrono::seconds(1));
+  test_server_->waitForCounterEq("cluster.tcp_cluster.update_rejected", 1);
 }
 
 TEST_P(EDSUpdatesIntegrationTest, InvalidResourceCount) {
@@ -1759,7 +1759,7 @@ TEST_P(EDSUpdatesIntegrationTest, InvalidResourceCount) {
     "tcp_cluster_eds.update.pb_text", MessageUtil::toTextProto(eds_response));
   TestEnvironment::renameFile(path, absl::StrReplaceAll(path, {{".update"s, ""s}}));
 
-  test_server_->waitForCounterEq("cluster.tcp_cluster.update_failure", 1, std::chrono::seconds(1));
+  test_server_->waitForCounterEq("cluster.tcp_cluster.update_failure", 1);
 }
 
 TEST_P(EDSUpdatesIntegrationTest, InvalidResourceData) {
@@ -1768,7 +1768,7 @@ TEST_P(EDSUpdatesIntegrationTest, InvalidResourceData) {
   std::string path = TestEnvironment::writeStringToFileForTest(
     "tcp_cluster_eds.update.pb_text", "bad data");
   TestEnvironment::renameFile(path, absl::StrReplaceAll(path, {{".update"s, ""s}}));
-  test_server_->waitForCounterGe("cluster.tcp_cluster.update_failure", 1, std::chrono::seconds(1));
+  test_server_->waitForCounterGe("cluster.tcp_cluster.update_failure", 1);
 }
 
 TEST_P(EDSUpdatesIntegrationTest, InvalidLbEndpointName) {
@@ -1792,7 +1792,7 @@ TEST_P(EDSUpdatesIntegrationTest, InvalidLbEndpointName) {
       "tcp_cluster_eds.update.pb_text", MessageUtil::toTextProto(eds_response));
     TestEnvironment::renameFile(path, absl::StrReplaceAll(path, {{".update"s, ""s}}));
 
-    test_server_->waitForCounterEq("cluster.tcp_cluster.update_failure", ++num_failures, std::chrono::seconds(1));
+    test_server_->waitForCounterEq("cluster.tcp_cluster.update_failure", ++num_failures);
   }
 }
 

--- a/test/extensions/filters/network/ssh/service_connection_impl_test.cc
+++ b/test/extensions/filters/network/ssh/service_connection_impl_test.cc
@@ -29,7 +29,7 @@ class UpstreamConnectionServiceTest : public testing::Test {
 public:
   UpstreamConnectionServiceTest() {
     transport_ = std::make_unique<testing::StrictMock<MockUpstreamTransportCallbacks>>();
-    service_ = std::make_unique<UpstreamConnectionService>(*transport_);
+    service_ = std::make_unique<UpstreamConnectionService>(ConnectionServiceOptions{}, *transport_);
     service_->registerMessageHandlers(msg_dispatcher_);
   }
 
@@ -63,7 +63,7 @@ class DownstreamConnectionServiceTest : public testing::Test {
 public:
   DownstreamConnectionServiceTest() {
     transport_ = std::make_unique<testing::StrictMock<MockDownstreamTransportCallbacks>>();
-    service_ = std::make_unique<DownstreamConnectionService>(*transport_, std::make_shared<StreamTracker>(context_));
+    service_ = std::make_unique<DownstreamConnectionService>(ConnectionServiceOptions{}, *transport_, std::make_shared<StreamTracker>(context_));
     service_->registerMessageHandlers(msg_dispatcher_);
 
     EXPECT_CALL(*transport_, streamId)

--- a/test/extensions/filters/network/ssh/service_connection_test.cc
+++ b/test/extensions/filters/network/ssh/service_connection_test.cc
@@ -44,7 +44,7 @@ public:
 class ConnectionServiceTest : public testing::TestWithParam<Peer> {
 public:
   ConnectionServiceTest()
-      : service_(transport_, GetParam()) {
+      : service_(ConnectionServiceOptions{}, transport_, GetParam()) {
     EXPECT_CALL(transport_, channelIdManager)
       .WillRepeatedly(ReturnRef(channel_id_manager_));
     EXPECT_CALL(transport_, secretsProvider)

--- a/test/extensions/filters/network/ssh/ssh_integration_test.cc
+++ b/test/extensions/filters/network/ssh/ssh_integration_test.cc
@@ -160,9 +160,13 @@ AssertionResult FakeUpstreamShimImpl::configureSshUpstream(std::shared_ptr<SshFa
     // XXX: this only handles one connection. If we need to support multiple upstream connections at
     // the same time, this will need to be adjusted.
     ASSERT(handler_ == nullptr);
+    auto config = std::make_shared<pomerium::extensions::ssh::CodecConfig>();
+    config->mutable_connection_service_options()
+      ->mutable_channel_close_response_grace_period()
+      ->set_seconds(1);
     handler_ = std::make_unique<SshFakeUpstreamHandler>(
       *ctx,
-      std::make_shared<pomerium::extensions::ssh::CodecConfig>(),
+      config,
       opts);
     timer_ = fake_upstream_->dispatcher()->createTimer([this] {
       absl::ReleasableMutexLock lock(fake_upstream_->lock());
@@ -301,6 +305,9 @@ static_resources:
                 timeout: 0s
               max_concurrent_channels: 100
               internal_channel_id_start: 100
+              connection_service_options:
+                channel_close_response_grace_period:
+                  seconds: 1
           filters:
             - name: envoy.filters.generic.router
               typed_config:

--- a/test/extensions/filters/network/ssh/ssh_upstream.cc
+++ b/test/extensions/filters/network/ssh/ssh_upstream.cc
@@ -6,6 +6,7 @@ SshFakeUpstreamHandler::SshFakeUpstreamHandler(Server::Configuration::ServerFact
                                                std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config,
                                                std::shared_ptr<SshFakeUpstreamHandlerOpts> opts)
     : TransportBase<SshFakeUpstreamHandlerCodec>(context, config, *this),
+      config_(config),
       opts_(opts) {}
 
 SshFakeUpstreamHandler::CodecCallbacks::CodecCallbacks(Network::Connection& connection)
@@ -33,7 +34,7 @@ void SshFakeUpstreamHandler::ReadFilter::initializeReadFilterCallbacks(Envoy::Ne
 }
 
 SshFakeUpstreamHandler::FakeUpstreamConnectionService::FakeUpstreamConnectionService(SshFakeUpstreamHandler& parent)
-    : ConnectionService(parent, Peer::Downstream),
+    : ConnectionService(parent.config_->connection_service_options(), parent, Peer::Downstream),
       parent_(parent) {
   (void)parent_;
 }

--- a/test/extensions/filters/network/ssh/ssh_upstream.h
+++ b/test/extensions/filters/network/ssh/ssh_upstream.h
@@ -148,7 +148,9 @@ protected:
   absl::Status handleMessage(wire::Message&& msg) override;
 
 private:
-  ChannelIDManager channel_id_manager_{100}; // order is important here
+  // order is important here
+  std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config_;
+  ChannelIDManager channel_id_manager_{100};
   MessageDispatcher<wire::Message>* msg_dispatcher_{};
   std::shared_ptr<SshFakeUpstreamHandlerOpts> opts_;
   std::unique_ptr<CodecCallbacks> codec_callbacks_;


### PR DESCRIPTION
This removes some hard coded timeouts when waiting for stat values. It also makes the previously hard-coded channel close response grace period configurable, so it can be lowered during integration tests. There was a channel close timeout test previously using the simulated time system, and this test was getting stuck advancing time when under heavy load. Switching it to use real time and setting the timeout lower solves the problem without making it take too much longer. The simulated time system is very complicated and this particular issue was not worth spending time debugging.