### PR TITLE
add back --fission option to envoy bazelrc

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -86,6 +86,7 @@ configure_make(
 
 refresh_compile_commands(
     name = "refresh_compile_commands",
+    exclude_headers = "external",
     targets = {
         "//:envoy": "",
         "//test/...": "",

--- a/envoy.bazelrc
+++ b/envoy.bazelrc
@@ -91,6 +91,7 @@ build --@rules_rust//rust/settings:rustfmt.toml=@envoy//:rustfmt.toml
 build:linux --copt=-fPIC
 build:linux --cxxopt=-fsized-deallocation --host_cxxopt=-fsized-deallocation
 build:linux --conlyopt=-fexceptions
+build:linux --fission=dbg,opt
 
 # macOS
 build:macos --action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
@@ -99,6 +100,7 @@ build:macos --define tcmalloc=disabled
 build:macos --cxxopt=-Wno-nullability-completeness
 build:macos --@toolchains_llvm//toolchain/config:compiler-rt=false
 build:macos --@toolchains_llvm//toolchain/config:libunwind=false
+
 
 #############################################################################
 # compiler

--- a/patches/envoy.bazelrc.patch
+++ b/patches/envoy.bazelrc.patch
@@ -2,7 +2,7 @@ diff --git a/.bazelrc b/.bazelrc
 index c0bda60546..4465dc3c4b 100644
 --- a/.bazelrc
 +++ b/.bazelrc
-@@ -86,14 +86,11 @@ build --@rules_rust//rust/settings:rustfmt.toml=@envoy//:rustfmt.toml
+@@ -86,14 +86,12 @@ build --@rules_rust//rust/settings:rustfmt.toml=@envoy//:rustfmt.toml
  # os
  #############################################################################
  
@@ -12,7 +12,7 @@ index c0bda60546..4465dc3c4b 100644
  build:linux --copt=-fPIC
  build:linux --cxxopt=-fsized-deallocation --host_cxxopt=-fsized-deallocation
  build:linux --conlyopt=-fexceptions
--build:linux --fission=dbg,opt
+ build:linux --fission=dbg,opt
 -build:linux --features=per_object_debug_info
  
  # macOS


### PR DESCRIPTION
The options `--copt=-fdebug-types-section` and `--features=per_object_debug_info` break macos cross-compile builds when included in the bazelrc like this, but `--fission` is still necessary. Explicitly setting per_object_debug_info is no longer required anyway; bazel should automatically enable it based on platform and the value of --features. 