### PR TITLE
remove @clang_platform; fix target labels that resolve incorrectly outside of the workspace

### DIFF
--- a/bazel/foreign_cc/openssh.BUILD
+++ b/bazel/foreign_cc/openssh.BUILD
@@ -35,8 +35,8 @@ config_setting(
 copy_file(
     name = "config_h",
     src = select({
-        ":darwin": "@//bazel/foreign_cc/openssh/include/config_darwin:config.h",
-        "//conditions:default": "@//bazel/foreign_cc/openssh/include/config_linux:config.h",
+        ":darwin": "@pomerium_envoy//bazel/foreign_cc/openssh/include/config_darwin:config.h",
+        "//conditions:default": "@pomerium_envoy//bazel/foreign_cc/openssh/include/config_linux:config.h",
     }),
     out = "config.h",
 )

--- a/bazel/toolchains.bzl
+++ b/bazel/toolchains.bzl
@@ -30,13 +30,6 @@ TOOLCHAIN_INTEGRITY = struct(
 )
 
 def pomerium_envoy_toolchains():
-    arch_alias(
-        name = "clang_platform",
-        aliases = {
-            "amd64": "@//bazel/platforms/rbe:linux_x64",
-            "aarch64": "@//bazel/platforms/rbe:linux_arm64",
-        },
-    )
     llvm_toolchain(
         name = "llvm_toolchain",
         llvm_version = LLVM_VERSION,

--- a/envoy.bazelrc
+++ b/envoy.bazelrc
@@ -114,7 +114,6 @@ common:clang-common --@toolchains_llvm//toolchain/config:libunwind=false
 # Clang with libc++ (default)
 common:clang --config=clang-common
 common:clang --config=libc++
-common:clang --host_platform=@clang_platform
 common:clang --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 
 # Clang installed to non-standard location (ie not /opt/llvm/)

--- a/patches/envoy.bazelrc.patch
+++ b/patches/envoy.bazelrc.patch
@@ -17,6 +17,14 @@ index c0bda60546..4465dc3c4b 100644
  
  # macOS
  build:macos --action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
+@@ -116,7 +114,6 @@ common:clang-common --@toolchains_llvm//toolchain/config:libunwind=false
+ # Clang with libc++ (default)
+ common:clang --config=clang-common
+ common:clang --config=libc++
+-common:clang --host_platform=@clang_platform
+ common:clang --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+ 
+ # Clang installed to non-standard location (ie not /opt/llvm/)
 @@ -249,13 +246,11 @@ test:sanitizer --build_tests_only
  # ASAN config with clang runtime
  build:asan --config=asan-common

--- a/patches/envoy/0003-protoc-gen-validate.patch
+++ b/patches/envoy/0003-protoc-gen-validate.patch
@@ -7,7 +7,7 @@ index c93daba62e..55f77d7b7d 100644
          name = "com_envoyproxy_protoc_gen_validate",
          patch_args = ["-p1"],
 -        patches = ["@envoy//bazel:pgv.patch"],
-+        patches = ["@envoy//bazel:pgv.patch", "//patches/protoc_gen_validate:fix-utf8-len.patch"],
++        patches = ["@envoy//bazel:pgv.patch", "@pomerium_envoy//patches/protoc_gen_validate:fix-utf8-len.patch"],
          repo_mapping = {"@com_google_absl": "@abseil-cpp"},
      )
      external_http_archive(


### PR DESCRIPTION
This fixes some labels that don't resolve correctly when this repo is imported as a dependency. This includes the `@clang_platform` alias, which was removed. `@clang_platform` has other issues related to cross-compiling anyway.