### PR TITLE
dynamic extensions: set RTLD_NODELETE; better support for factory registration

### DIFF
--- a/bazel/dynamic_extension.bzl
+++ b/bazel/dynamic_extension.bzl
@@ -12,6 +12,7 @@ def cc_dynamic_extension(
         hdrs = [],
         copts = [],
         host_deps = [],
+        testonly = 0,
         visibility = ["//visibility:public"]):
     _name = "_" + name
     cc_library(
@@ -23,6 +24,7 @@ def cc_dynamic_extension(
             "-fvisibility=hidden",
             "-fPIC",
         ],
+        testonly = testonly,
         features = ["prefer_pic_for_opt_binaries"],
         linkstatic = True,
         deps = host_deps + builtin_host_deps + [
@@ -37,6 +39,7 @@ def cc_dynamic_extension(
             "-fvisibility=hidden",
             "-fPIC",
         ],
+        testonly = testonly,
         deps = ["@pomerium_envoy//source/common/dynamic_extensions:version_ref_lib"],
         linkshared = True,
         linkstatic = False,

--- a/source/common/dynamic_extensions/BUILD
+++ b/source/common/dynamic_extensions/BUILD
@@ -31,8 +31,14 @@ cc_library(
 
 cc_library(
     name = "extension_common_lib",
-    srcs = ["extension.h"],
+    srcs = [
+        "extension.h",
+        "factory.h",
+    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//source/common:common_lib",
+    ],
 )
 
 cc_library(

--- a/source/common/dynamic_extensions/factory.h
+++ b/source/common/dynamic_extensions/factory.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "envoy/registry/registry.h"
+#include "source/common/fixed_string.h"
+#include "fmt/compile.h"
+
+namespace detail {
+template <fixed_string Name>
+struct use_factory_guard {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++26-extensions"
+  static_assert(false, fixed_fmt_string{FMT_STATIC_FORMAT(
+                         "missing required declaration: `DYNAMIC_EXTENSION_USE_FACTORY_BASE({});`",
+                         Name.to_string())});
+#pragma clang diagnostic pop
+};
+} // namespace detail
+
+// This must be declared in global scope before registering a factory with an existing base type
+// known to the host, so that the extension will use the same instance of the factory registry for
+// this type instead of instantiating its own.
+#define DYNAMIC_EXTENSION_USE_FACTORY_BASE(BASE)                \
+  namespace detail {                                            \
+  template <> struct use_factory_guard<#BASE> {};               \
+  }                                                             \
+  extern template class Envoy::Registry::FactoryRegistry<BASE>; \
+  extern template class Envoy::Registry::FactoryRegistryProxyImpl<BASE>;
+
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
+#define _DYNAMIC_EXTENSION_REGISTER_FACTORY_2(FACTORY, BASE, ID) \
+  static Envoy::Registry::RegisterFactory<FACTORY, BASE>         \
+    _factory_##ID
+
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
+#define _DYNAMIC_EXTENSION_REGISTER_FACTORY(FACTORY, BASE, ID) \
+  _DYNAMIC_EXTENSION_REGISTER_FACTORY_2(FACTORY, BASE, ID)
+
+// This should be called from within dynamicExtensionInit, in place of the usual REGISTER_FACTORY.
+#define DYNAMIC_EXTENSION_REGISTER_FACTORY(FACTORY, BASE) \
+  (void)detail::use_factory_guard<#BASE>{};               \
+  _DYNAMIC_EXTENSION_REGISTER_FACTORY(FACTORY, BASE, __COUNTER__)
+
+#undef DECLARE_FACTORY
+#define DECLARE_FACTORY(FACTORY) static_assert(false, "use DYNAMIC_EXTENSION_REGISTER_FACTORY instead");
+
+#undef REGISTER_FACTORY
+#define REGISTER_FACTORY(FACTORY, BASE) static_assert(false, "use DYNAMIC_EXTENSION_REGISTER_FACTORY instead")

--- a/source/common/fixed_string.h
+++ b/source/common/fixed_string.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <string_view>
+#include <fmt/compile.h>
 
 // A simple compile-time-only string.
 template <size_t N>
@@ -23,4 +24,25 @@ consteval auto operator<=>(const fixed_string<A>& lhs, const fixed_string<B>& rh
 template <size_t A, size_t B>
 consteval bool operator==(const fixed_string<A>& lhs, const fixed_string<B>& rhs) {
   return lhs.to_string() == rhs.to_string();
+};
+
+// Used with FMT_STATIC_FORMAT() to produce user-defined static_assert messages.
+// Example: `static_assert(false, fixed_fmt_string{FMT_STATIC_FORMAT("error: {}", ...)})`
+template <size_t N>
+struct fixed_fmt_string {
+  consteval fixed_fmt_string(fmt::static_format_result<N> fmt_result) {
+    // for some reason, static_format_result::str() is not constexpr, so we can't use it directly
+    std::copy_n(std::bit_cast<static_format_result_data>(fmt_result).data, N, static_cast<char*>(value));
+  }
+
+  // implements the static_assert constant expression requirements
+  consteval size_t size() { return N - 1; }
+  consteval const char* data() { return static_cast<const char*>(value); }
+
+  char value[N];
+
+private:
+  struct static_format_result_data {
+    char data[N];
+  };
 };

--- a/source/extensions/bootstrap/dynamic_extension_loader/handle.cc
+++ b/source/extensions/bootstrap/dynamic_extension_loader/handle.cc
@@ -32,7 +32,7 @@ absl::Status DynamicExtensionHandle::dynamicExtensionInit(Envoy::Server::Instanc
     }
   } else {
     if (abi_dynamic_extension_init_no_config_ != nullptr) {
-      ENVOY_LOG_MISC(debug, "calling dynamicExtensionInit for extension {} (no configuration)");
+      ENVOY_LOG_MISC(debug, "calling dynamicExtensionInit for extension {} (no configuration)", info_.metadata.id);
       abi_dynamic_extension_init_no_config_(instance);
     } else if (abi_dynamic_extension_init_ != nullptr) {
       return absl::InvalidArgumentError(fmt::format(

--- a/source/extensions/bootstrap/dynamic_extension_loader/loader.cc
+++ b/source/extensions/bootstrap/dynamic_extension_loader/loader.cc
@@ -44,6 +44,15 @@ void ExtensionLoader::onServerInitialized(Envoy::Server::Instance& server) {
         .err = stat,
       });
       handle.reset();
+    } else {
+      // Set RTLD_NODELETE on the extension, since dynamicExtensionInit may register Envoy
+      // factories, which have no (intended) deregistration mechanism. If the extension is unloaded
+      // after startup (i.e. when the handles are deleted during server teardown) could cause
+      // references to the factory registered in the extension to become garbage.
+      // Note: this still increases the handle's internal refcount. Calling dlclose after this is
+      // a no-op and won't decrease the refcount.
+      auto* h = dlopen(handle->info().path.c_str(), RTLD_NOW | RTLD_NOLOAD | RTLD_NODELETE);
+      RELEASE_ASSERT(h != nullptr, "dlopen on loaded extension failed");
     }
   }
   std::erase_if(handles_, [](auto& entry) { return entry == nullptr; });

--- a/test/common/dynamic_extensions/BUILD
+++ b/test/common/dynamic_extensions/BUILD
@@ -9,6 +9,7 @@ envoy_cc_test(
         "dynamic_extensions_test.cc",
     ],
     data = [
+        "//test/common/dynamic_extensions/test:test_http_factory",
         "//test/common/dynamic_extensions/test:test_invalid_id",
         "//test/common/dynamic_extensions/test:test_md_unknown_keys",
         "//test/common/dynamic_extensions/test:test_missing_symbol",
@@ -28,12 +29,15 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     shard_count = 8,
-    tags = ["no_san"],
     deps = [
         "//api/extensions/bootstrap/dynamic_extension_loader:pkg_cc_proto",
         "//source/extensions/bootstrap/dynamic_extension_loader",
+        "@envoy//source/extensions/filters/http/router:config",
+        "@envoy//source/extensions/filters/network/http_connection_manager:config",
         "@envoy//test/integration:integration_lib",
         "@envoy//test/test_common:status_utility_lib",
+        "@envoy_api//envoy/extensions/filters/http/router/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/common/dynamic_extensions/dynamic_extensions_test.cc
+++ b/test/common/dynamic_extensions/dynamic_extensions_test.cc
@@ -15,8 +15,7 @@ class DynamicExtensionsIntegrationTest : public testing::Test,
                                          public Envoy::BaseIntegrationTest {
 public:
   DynamicExtensionsIntegrationTest()
-      : Envoy::BaseIntegrationTest(Envoy::Network::Address::IpVersion::v4,
-                                   Envoy::ConfigHelper::baseConfigNoListeners()) {
+      : Envoy::BaseIntegrationTest(Envoy::Network::Address::IpVersion::v4) {
   }
 
   void initialize() override {
@@ -185,9 +184,11 @@ public:
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
       "test/common/dynamic_extensions/test/libtest_no_config.so", "pomerium_envoy");
 
+#if !__has_feature(address_sanitizer)
     auto result = RunReadExtension({"--check", SelfPath(), extension_path_});
     ASSERT_OK(result.status());
     ASSERT_EQ(result->exit_code, 0) << result->out;
+#endif
   }
 
   std::string extension_path_;
@@ -231,9 +232,11 @@ public:
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
       "test/common/dynamic_extensions/test/libtest_optional_config.so", "pomerium_envoy");
 
+#if !__has_feature(address_sanitizer)
     auto result = RunReadExtension({"--check", SelfPath(), extension_path_});
     ASSERT_OK(result.status());
     ASSERT_EQ(result->exit_code, 0) << result->out;
+#endif
   }
 
   std::string extension_path_;
@@ -277,9 +280,11 @@ public:
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
       "test/common/dynamic_extensions/test/libtest_required_config.so", "pomerium_envoy");
 
+#if !__has_feature(address_sanitizer)
     auto result = RunReadExtension({"--check", SelfPath(), extension_path_});
     ASSERT_OK(result.status());
     ASSERT_EQ(result->exit_code, 0) << result->out;
+#endif
   }
 
   std::string extension_path_;
@@ -319,9 +324,11 @@ public:
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
       "test/common/dynamic_extensions/test/libtest_no_init.so", "pomerium_envoy");
 
+#if !__has_feature(address_sanitizer)
     auto result = RunReadExtension({"--check", SelfPath(), extension_path_});
     ASSERT_OK(result.status());
     ASSERT_EQ(result->exit_code, 0) << result->out;
+#endif
   }
 
   std::string extension_path_;
@@ -357,10 +364,12 @@ public:
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
       "test/common/dynamic_extensions/test/libtest_missing_symbol.so", "pomerium_envoy");
 
+#if !__has_feature(address_sanitizer)
     auto result = RunReadExtension({"--check", SelfPath(), "--demangle", extension_path_});
     ASSERT_OK(result.status());
     EXPECT_NE(result->exit_code, 0);
     ASSERT_THAT(result->out, testing::HasSubstr("missing symbol required by extension: symbolNotAvailableInExtensionHost()"));
+#endif
   }
 
   std::string extension_path_;
@@ -419,9 +428,11 @@ public:
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
       "test/common/dynamic_extensions/test/libtest_tls.so", "pomerium_envoy");
 
+#if !__has_feature(address_sanitizer)
     auto result = RunReadExtension({"--check", SelfPath(), extension_path_});
     ASSERT_OK(result.status());
     ASSERT_EQ(result->exit_code, 0) << result->out;
+#endif
   }
 
   std::string extension_path_;
@@ -450,6 +461,44 @@ TEST_F(ThreadLocalStorageTest, TestTLS) {
   std::sort(test_data.begin(), test_data.end());
   auto expected = std::vector<std::string>{{"main_thread", "worker_0", "worker_1", "worker_2", "worker_3"}};
   EXPECT_EQ(expected, test_data);
+}
+
+std::atomic<int> test_extension_http_filters_created;
+std::atomic<int> test_extension_http_filters_destroyed;
+
+class FactoryRegistrationTest : public DynamicExtensionsIntegrationTest {
+public:
+  FactoryRegistrationTest() {
+    test_extension_http_filters_created = 0;
+    test_extension_http_filters_destroyed = 0;
+    autonomous_allow_incomplete_streams_ = true;
+    autonomous_upstream_ = true;
+
+    // from Envoy::HttpIntegrationTest::HttpIntegrationTest
+    config_helper_.renameListener("http");
+    config_helper_.addRuntimeOverride("envoy.reloadable_features.no_extension_lookup_by_name",
+                                      "false");
+  }
+  void SetUp() override {
+    extension_path_ = Envoy::TestEnvironment::runfilesPath(
+      "test/common/dynamic_extensions/test/libtest_http_factory.so", "pomerium_envoy");
+  }
+  std::string extension_path_;
+};
+
+TEST_F(FactoryRegistrationTest, TestExtensionRegistersHttpFilterFactory) {
+  ConfigureExtensionLoader({extension_path_});
+  config_helper_.prependFilter("{ name: test.dynamic_extensions.http_filter }");
+  initialize();
+
+  auto response = Envoy::IntegrationUtil::makeSingleRequest(
+    lookupPort("http"), "GET", "/",
+    "", Envoy::Http::CodecType::HTTP1, version_);
+  ASSERT_TRUE(response->complete());
+  ASSERT_EQ("200", response->headers().getStatusValue());
+
+  ASSERT_EQ(test_extension_http_filters_created.load(), 1);
+  ASSERT_EQ(test_extension_http_filters_destroyed.load(), 1);
 }
 
 TEST_F(DynamicExtensionsIntegrationTest, TestAdminApiMethodNotAllowed) {

--- a/test/common/dynamic_extensions/dynamic_extensions_test.cc
+++ b/test/common/dynamic_extensions/dynamic_extensions_test.cc
@@ -9,6 +9,10 @@
 
 using namespace std::literals;
 
+#if __has_feature(address_sanitizer) || __has_feature(thread_sanitizer) || __has_feature(memory_sanitizer)
+#define SANITIZER_ENABLED
+#endif
+
 // NOLINTBEGIN(readability-identifier-naming)
 
 class DynamicExtensionsIntegrationTest : public testing::Test,
@@ -184,7 +188,7 @@ public:
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
       "test/common/dynamic_extensions/test/libtest_no_config.so", "pomerium_envoy");
 
-#if !__has_feature(address_sanitizer)
+#ifndef SANITIZER_ENABLED
     auto result = RunReadExtension({"--check", SelfPath(), extension_path_});
     ASSERT_OK(result.status());
     ASSERT_EQ(result->exit_code, 0) << result->out;
@@ -232,7 +236,7 @@ public:
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
       "test/common/dynamic_extensions/test/libtest_optional_config.so", "pomerium_envoy");
 
-#if !__has_feature(address_sanitizer)
+#ifndef SANITIZER_ENABLED
     auto result = RunReadExtension({"--check", SelfPath(), extension_path_});
     ASSERT_OK(result.status());
     ASSERT_EQ(result->exit_code, 0) << result->out;
@@ -280,7 +284,7 @@ public:
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
       "test/common/dynamic_extensions/test/libtest_required_config.so", "pomerium_envoy");
 
-#if !__has_feature(address_sanitizer)
+#ifndef SANITIZER_ENABLED
     auto result = RunReadExtension({"--check", SelfPath(), extension_path_});
     ASSERT_OK(result.status());
     ASSERT_EQ(result->exit_code, 0) << result->out;
@@ -324,7 +328,7 @@ public:
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
       "test/common/dynamic_extensions/test/libtest_no_init.so", "pomerium_envoy");
 
-#if !__has_feature(address_sanitizer)
+#ifndef SANITIZER_ENABLED
     auto result = RunReadExtension({"--check", SelfPath(), extension_path_});
     ASSERT_OK(result.status());
     ASSERT_EQ(result->exit_code, 0) << result->out;
@@ -364,7 +368,7 @@ public:
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
       "test/common/dynamic_extensions/test/libtest_missing_symbol.so", "pomerium_envoy");
 
-#if !__has_feature(address_sanitizer)
+#ifndef SANITIZER_ENABLED
     auto result = RunReadExtension({"--check", SelfPath(), "--demangle", extension_path_});
     ASSERT_OK(result.status());
     EXPECT_NE(result->exit_code, 0);
@@ -428,7 +432,7 @@ public:
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
       "test/common/dynamic_extensions/test/libtest_tls.so", "pomerium_envoy");
 
-#if !__has_feature(address_sanitizer)
+#ifndef SANITIZER_ENABLED
     auto result = RunReadExtension({"--check", SelfPath(), extension_path_});
     ASSERT_OK(result.status());
     ASSERT_EQ(result->exit_code, 0) << result->out;

--- a/test/common/dynamic_extensions/test/BUILD
+++ b/test/common/dynamic_extensions/test/BUILD
@@ -77,6 +77,9 @@ cc_library(
     srcs = ["invalid_version.cc"],
     hdrs = ["invalid_version.h"],
     linkstatic = True,
+    deps = [
+        "//source/common/dynamic_extensions:version_lib",
+    ],
     alwayslink = True,
 )
 
@@ -104,5 +107,17 @@ cc_dynamic_extension(
     name = "test_tls",
     srcs = [
         "test_tls.cc",
+    ],
+)
+
+cc_dynamic_extension(
+    name = "test_http_factory",
+    testonly = 1,
+    srcs = [
+        "test_http_factory.cc",
+    ],
+    host_deps = [
+        "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
+        "@envoy//test/extensions/filters/http/common:empty_http_filter_config_lib",
     ],
 )

--- a/test/common/dynamic_extensions/test/test_http_factory.cc
+++ b/test/common/dynamic_extensions/test/test_http_factory.cc
@@ -1,0 +1,44 @@
+#include "source/common/dynamic_extensions/extension.h"
+#include "source/common/dynamic_extensions/factory.h"
+#include "envoy/server/instance.h"
+#include "test/extensions/filters/http/common/empty_http_filter_config.h"
+#include "source/extensions/filters/http/common/pass_through_filter.h"
+
+DYNAMIC_EXTENSION("test-http-factory");
+DYNAMIC_EXTENSION_LICENSE("Apache-2.0");
+
+extern std::atomic<int> test_extension_http_filters_created;
+extern std::atomic<int> test_extension_http_filters_destroyed;
+
+class TestExtensionHttpFilter : public Envoy::Http::PassThroughFilter {
+public:
+  TestExtensionHttpFilter() {
+    test_extension_http_filters_created++;
+  }
+  ~TestExtensionHttpFilter() {
+    test_extension_http_filters_destroyed++;
+  }
+};
+
+class TestExtensionHttpFilterFactory : public Envoy::Extensions::HttpFilters::Common::EmptyHttpDualFilterConfig {
+public:
+  TestExtensionHttpFilterFactory() : EmptyHttpDualFilterConfig("test.dynamic_extensions.http_filter") {
+    ENVOY_LOG_MISC(info, "TestExtensionHttpFilterFactory loaded");
+  }
+  ~TestExtensionHttpFilterFactory() {
+    ENVOY_LOG_MISC(info, "TestExtensionHttpFilterFactory destroyed");
+  }
+
+  absl::StatusOr<Envoy::Http::FilterFactoryCb>
+  createDualFilter(const std::string&, Envoy::Server::Configuration::ServerFactoryContext&) override {
+    return [](Envoy::Http::FilterChainFactoryCallbacks& callbacks) -> void {
+      callbacks.addStreamFilter(std::make_shared<TestExtensionHttpFilter>());
+    };
+  }
+};
+
+DYNAMIC_EXTENSION_USE_FACTORY_BASE(Envoy::Server::Configuration::NamedHttpFilterConfigFactory);
+
+DYNAMIC_EXTENSION_EXPORT void dynamicExtensionInit(Envoy::Server::Instance& server) {
+  DYNAMIC_EXTENSION_REGISTER_FACTORY(TestExtensionHttpFilterFactory, Envoy::Server::Configuration::NamedHttpFilterConfigFactory);
+}

--- a/test/common/dynamic_extensions/test/test_tls.cc
+++ b/test/common/dynamic_extensions/test/test_tls.cc
@@ -13,12 +13,18 @@ public:
   std::string data_;
 };
 
-static std::unique_ptr<Envoy::ThreadLocal::TypedSlot<TestThreadLocalData>> test_thread_local_slot_;
+static Envoy::ThreadLocal::TypedSlotPtr<TestThreadLocalData> test_thread_local_slot_;
+static Envoy::Server::ServerLifecycleNotifier::HandlePtr test_shutdown_callback_handle_;
 
 extern absl::Notification test_wait_tls_init;
 extern void writeTestData(const std::string& data);
 
 DYNAMIC_EXTENSION_EXPORT void dynamicExtensionInit(Envoy::Server::Instance& server) {
+  std::atexit(+[] {
+    RELEASE_ASSERT(test_thread_local_slot_ == nullptr, "bug: test_thread_local_slot_ was not deleted before exit");
+    RELEASE_ASSERT(test_shutdown_callback_handle_ == nullptr, "bug: test_shutdown_callback_handle_ was not deleted before exit");
+  });
+
   test_thread_local_slot_ = Envoy::ThreadLocal::TypedSlot<TestThreadLocalData>::makeUnique(server.threadLocal());
 
   test_thread_local_slot_->set([](Envoy::Event::Dispatcher& d) {
@@ -31,5 +37,22 @@ DYNAMIC_EXTENSION_EXPORT void dynamicExtensionInit(Envoy::Server::Instance& serv
     },
     [&] {
       test_wait_tls_init.Notify();
+    });
+
+  // The slot must be deleted manually here; static destructors are called at program exit, so it
+  // would outlive the server otherwise. (this is specific to this test, thread local slots are
+  // normally not declared as static globals)
+  // Note: this is only relevant because extensions have RTLD_NODELETE enabled. If the extension
+  // were really unloaded on dlclose() (called from ~DynamicExtensionHandle()) the slot would be
+  // destroyed when the extension loader instance is destroyed. From here, there isn't a good place
+  // to store data that is "global" but scoped to the lifetime of the server instance, but doing so
+  // should not be required outside of tests.
+  test_shutdown_callback_handle_ = server.lifecycleNotifier().registerCallback(
+    Envoy::Server::ServerLifecycleNotifier::Stage::ShutdownExit,
+    []() {
+      test_thread_local_slot_.reset();
+      // also delete the handle itself, as it too would outlive the server instance
+      // (deleting the handle inside the callback is allowed)
+      test_shutdown_callback_handle_.reset();
     });
 }

--- a/tools/read_extension.cc
+++ b/tools/read_extension.cc
@@ -185,7 +185,7 @@ std::string_view strtabCStrView(bytes_view view) {
 
 bool flag_demangle;
 
-absl::StatusOr<SymbolTableView> readDynamicSymbols(const MmapFileHandle& f, SymbolKindFilter kind_filter) {
+absl::Status sanityCheck(const MmapFileHandle& f) {
   if (f.info_.st_size < sizeof(Elf64_Ehdr)) {
     return absl::InvalidArgumentError("file is not an ELF binary");
   }
@@ -203,9 +203,15 @@ absl::StatusOr<SymbolTableView> readDynamicSymbols(const MmapFileHandle& f, Symb
     return absl::InvalidArgumentError("ELF binary is not supported");
   }
 
-  // read all section headers
   if (f.info_.st_size < header->e_shoff + header->e_shnum * sizeof(Elf64_Shdr)) {
     return absl::InvalidArgumentError("failed to read section headers");
+  }
+  return absl::OkStatus();
+}
+
+absl::StatusOr<SymbolTableView> readDynamicSymbols(const MmapFileHandle& f, SymbolKindFilter kind_filter) {
+  if (auto stat = sanityCheck(f); !stat.ok()) {
+    return stat;
   }
 
   bool showUndefined = (kind_filter & SymbolKindFilter::Undefined) == SymbolKindFilter::Undefined;
@@ -221,6 +227,8 @@ absl::StatusOr<SymbolTableView> readDynamicSymbols(const MmapFileHandle& f, Symb
   const Elf64_Shdr* sh_gnu_verdef{};  // .gnu.version_d
   const Elf64_Shdr* sh_gnu_verneed{}; // .gnu.version_r
 
+  // read all section headers
+  auto* header = reinterpret_cast<const Elf64_Ehdr*>(f.addr_);
   for (int shIdx = 0; shIdx < header->e_shnum; shIdx++) {
     auto* sectionHeader = reinterpret_cast<const Elf64_Shdr*>(
       extension_data.subspan(header->e_shoff + shIdx * sizeof(Elf64_Shdr), sizeof(Elf64_Shdr)).data());
@@ -371,6 +379,56 @@ absl::StatusOr<SymbolTableView> readDynamicSymbols(const MmapFileHandle& f, Symb
         auto versionId = *reinterpret_cast<const Elf64_Half*>(
           versymTable.subspan(i * sizeof(Elf64_Half), sizeof(Elf64_Half)).data());
         out.items.emplace_back(symName, SymbolInfo{.index = i, .symbol = sym, .version_id = versionId});
+      }
+    }
+  }
+
+  std::sort(out.items.begin(), out.items.end(), [](const auto& a, const auto& b) {
+    return std::get<0>(a) < std::get<0>(b);
+  });
+
+  return std::move(out);
+}
+
+absl::StatusOr<SymbolTableView> readSymbols(const MmapFileHandle& f, SymbolKindFilter kind_filter) {
+  if (auto stat = sanityCheck(f); !stat.ok()) {
+    return stat;
+  }
+
+  bool showUndefined = (kind_filter & SymbolKindFilter::Undefined) == SymbolKindFilter::Undefined;
+  bool showDefined = (kind_filter & SymbolKindFilter::Defined) == SymbolKindFilter::Defined;
+
+  SymbolTableView out;
+
+  auto extension_data = f.view();
+
+  const Elf64_Shdr* sh_symtab{};
+  auto* header = reinterpret_cast<const Elf64_Ehdr*>(f.addr_);
+  for (int shIdx = 0; shIdx < header->e_shnum; shIdx++) {
+    auto* sectionHeader = reinterpret_cast<const Elf64_Shdr*>(
+      extension_data.subspan(header->e_shoff + shIdx * sizeof(Elf64_Shdr), sizeof(Elf64_Shdr)).data());
+    if (sectionHeader->sh_type == SHT_SYMTAB) {
+      sh_symtab = sectionHeader;
+      break;
+    }
+  }
+  if (sh_symtab == nullptr) {
+    return absl::InvalidArgumentError("missing section: .symtab");
+  }
+
+  auto* symbolStrTabHdr = reinterpret_cast<const Elf64_Shdr*>(
+    extension_data.subspan(header->e_shoff + sh_symtab->sh_link * sizeof(Elf64_Shdr), sizeof(Elf64_Shdr)).data());
+  auto symbolStringTable = extension_data.subspan(symbolStrTabHdr->sh_offset, symbolStrTabHdr->sh_size);
+
+  auto symEntries = extension_data.subspan(sh_symtab->sh_offset, sh_symtab->sh_size);
+  out.items.reserve(sh_symtab->sh_size / sizeof(Elf64_Sym));
+  for (size_t i = 0; i < sh_symtab->sh_size / sizeof(Elf64_Sym); i++) {
+    auto* sym = reinterpret_cast<const Elf64_Sym*>(symEntries.subspan(i * sizeof(Elf64_Sym), sizeof(Elf64_Sym)).data());
+    if (sym->st_name != 0) {
+      bool isUndefined = sym->st_shndx == SHN_UNDEF;
+      if ((isUndefined && showUndefined) || (!isUndefined && showDefined)) {
+        auto symName = strtabCStrView(symbolStringTable.subspan(sym->st_name));
+        out.items.emplace_back(symName, SymbolInfo{.index = i, .symbol = sym});
       }
     }
   }
@@ -600,6 +658,63 @@ absl::StatusOr<CompatibilityInfo> checkCompatibility(const MmapFileHandle& host,
   };
 }
 
+struct LintResult {
+  std::string category;
+  std::string msg;
+  std::vector<std::string> notes;
+};
+
+struct LintResults {
+  std::vector<LintResult> results;
+};
+
+absl::StatusOr<LintResults> runLinters(const MmapFileHandle& ext) {
+  // 1. Check for template instantiations of Envoy::Registry::FactoryRegistry for types in an
+  //    Envoy::* namespace
+
+  auto symbols = readSymbols(ext, SymbolKindFilter::Defined);
+  if (!symbols.ok()) {
+    return symbols.status();
+  }
+
+  LintResults out;
+
+  auto search = std::tuple<std::string_view, SymbolInfo>{"_ZN5Envoy8Registry15FactoryRegistryI", {}};
+  auto it = std::lower_bound(symbols->items.begin(), symbols->items.end(), search, [](const auto& a, const auto& b) {
+    return std::get<0>(a) < std::get<0>(b);
+  });
+  std::unordered_set<std::string> seen;
+  while (it != symbols->items.end()) {
+    const auto& [name, sym] = *it;
+    if (!name.starts_with("_ZN5Envoy8Registry15FactoryRegistryI")) {
+      break;
+    }
+    char* demangledName = abi::__cxa_demangle(name.data(), nullptr, nullptr, nullptr); // NOLINT:bugprone-suspicious-stringview-data-usage
+    std::string_view view{demangledName};
+
+    view.remove_prefix("Envoy::Registry::FactoryRegistry<"sv.size());
+    auto idx = view.find('>');
+    if (idx == std::string::npos) {
+      return absl::InvalidArgumentError("malformed input");
+    }
+    std::string type{view.substr(0, idx)};
+    free(demangledName);
+    if (!seen.contains(type)) {
+      seen.insert(type);
+      if (type.starts_with("Envoy::")) {
+        out.results.push_back(LintResult{
+          .category = "envoy-factory-registration",
+          .msg = fmt::format("extension instantiates Envoy::Registry::FactoryRegistry for type '{}'", type),
+          .notes = {fmt::format("declare DYNAMIC_EXTENSION_USE_FACTORY_BASE({}) to fix", type)},
+        });
+      }
+    }
+    it++;
+  }
+
+  return std::move(out);
+}
+
 int main(int argc, char** argv) {
   argparse::ArgumentParser cmd("read-extension");
   auto& modes = cmd.add_mutually_exclusive_group(true);
@@ -616,6 +731,10 @@ int main(int argc, char** argv) {
   modes.add_argument("-c", "--check")
     .help("Check if the extension is compatible with the given binary")
     .nargs(1);
+
+  modes.add_argument("-l", "--lint")
+    .help("Analyze the extension to find common mistakes")
+    .flag();
 
   cmd.add_argument("-d", "--demangle")
     .help("Demangle C++ symbols")
@@ -714,7 +833,7 @@ int main(int argc, char** argv) {
         return host.status();
       }
       for (const auto& ext : filenames) {
-        auto f = mmapFile(filenames[0]);
+        auto f = mmapFile(ext);
         if (!f.ok()) {
           return f.status();
         }
@@ -734,6 +853,25 @@ int main(int argc, char** argv) {
         }
         std::cout.flush();
       }
+    } else if (cmd.is_used("--lint")) {
+      auto f = mmapFile(filenames[0]);
+      if (!f.ok()) {
+        return f.status();
+      }
+      auto info = runLinters(**f);
+      if (!info.ok()) {
+        return info.status();
+      }
+      if (!info->results.empty()) {
+        ok_exit_code = 2;
+      }
+      for (const auto& result : info->results) {
+        std::cout << fmt::format("[{}] {}\n", result.category, result.msg);
+        for (const auto& note : result.notes) {
+          std::cout << fmt::format(" => note: {}\n", note);
+        }
+      }
+      std::cout.flush();
     }
     return absl::OkStatus();
   }();


### PR DESCRIPTION
After an extension is loaded and if dynamicExtensionInit succeeds, we now add the RTLD_NODELETE flag to the shared object so that it is not unloaded during server shutdown when the bootstrap extension instance is destroyed. The extension handle normally calls dlclose in the destructor; this is used to unload extensions which load successfully but then fail before initialization, for example due to a config error. Because extensions will likely register factories to the global factory registry during initialization, and potentially also interact with other global envoy entities, it makes sense to tie the lifetime of successfully loaded extensions to the lifetime of the program so that it acts as much like a statically compiled extension as possible. 

To make interacting with the global factory registry easier, new macros were added which can be used like this:

```cc

class CustomHttpFilterFactory 
    : public Envoy::Server::Configuration::NamedHttpFilterConfigFactory {
// ...
};

DYNAMIC_EXTENSION_USE_FACTORY_BASE(Envoy::Server::Configuration::NamedHttpFilterConfigFactory);

DYNAMIC_EXTENSION_EXPORT void dynamicExtensionInit(Envoy::Server::Instance& server) {
  DYNAMIC_EXTENSION_REGISTER_FACTORY(CustomHttpFilterFactory, 
                                     Envoy::Server::Configuration::NamedHttpFilterConfigFactory);
}
```

There are other ways in which Envoy::Registry::FactoryRegistry can become instantiated from within an extension (e.g. the extension needs to directly look up a factory by name), so I also added a lint mode to the read-extension tool that can detect these cases (for now it flags types whose namespace starts with Envoy::, so extensions must define factories they register directly in their own namespace)

```
# in this example, the extension looks up a compressor from the available factories
# that are compiled into the host binary

$ read-extension --lint /path/to/extension.so
[envoy-factory-registration] extension instantiates Envoy::Registry::FactoryRegistry for type 'Envoy::Compression::Compressor::NamedCompressorLibraryConfigFactory'
 => note: declare DYNAMIC_EXTENSION_USE_FACTORY_BASE(Envoy::Compression::Compressor::NamedCompressorLibraryConfigFactory) to fix
```