### PR TITLE
refactor ChannelOpen message handling

### DIFF
--- a/source/extensions/filters/network/ssh/channel.cc
+++ b/source/extensions/filters/network/ssh/channel.cc
@@ -8,13 +8,20 @@ Channel::~Channel() {
   }
 };
 
-absl::Status Channel::setChannelCallbacks(ChannelCallbacks& callbacks) {
+void Channel::setChannelCallbacks(ChannelCallbacks& callbacks) {
   callbacks_ = &callbacks;
-  return absl::OkStatus();
+}
+
+absl::Status PassthroughChannel::readChannelOpen(wire::ChannelOpenMsg&& msg) {
+  return callbacks_->sendMessageRemote(std::move(msg));
 }
 
 absl::Status PassthroughChannel::readMessage(wire::ChannelMessage&& msg) {
   return callbacks_->sendMessageRemote(std::move(msg));
+}
+
+absl::Status ForceCloseChannel::readChannelOpen(wire::ChannelOpenMsg&&) {
+  throw Envoy::EnvoyException("bug: invalid call to ForceCloseChannel::readChannelOpen()");
 }
 
 absl::Status ForceCloseChannel::readMessage(wire::ChannelMessage&& msg) {

--- a/source/extensions/filters/network/ssh/channel.h
+++ b/source/extensions/filters/network/ssh/channel.h
@@ -83,10 +83,14 @@ public:
 class Channel {
 public:
   virtual ~Channel();
-  virtual absl::Status setChannelCallbacks(ChannelCallbacks& callbacks);
+  virtual void setChannelCallbacks(ChannelCallbacks& callbacks);
 
-  // Handles a channel message (see concept ChannelMsg) read from the local peer, to be sent to
-  // the remote peer.
+  // Handles a channel open message from the local peer.
+  // Note: if this returns an error, the connection service will assume that this message will not
+  // have been forwarded to the remote peer.
+  virtual absl::Status readChannelOpen(wire::ChannelOpenMsg&& msg) PURE;
+
+  // Handles a channel message read from the local peer, to be sent to the remote peer.
   virtual absl::Status readMessage(wire::ChannelMessage&& msg) PURE;
 
 protected:
@@ -97,6 +101,7 @@ class PassthroughChannel : public Channel {
 public:
   PassthroughChannel() = default;
 
+  absl::Status readChannelOpen(wire::ChannelOpenMsg&& msg) override;
   absl::Status readMessage(wire::ChannelMessage&& msg) override;
 };
 
@@ -104,6 +109,7 @@ class ForceCloseChannel : public Channel, public Logger::Loggable<Logger::Id::fi
 public:
   ForceCloseChannel() = default;
 
+  absl::Status readChannelOpen(wire::ChannelOpenMsg&&) override;
   absl::Status readMessage(wire::ChannelMessage&& msg) override;
 };
 

--- a/source/extensions/filters/network/ssh/client_transport.cc
+++ b/source/extensions/filters/network/ssh/client_transport.cc
@@ -274,6 +274,11 @@ public:
       : info_(info),
         handoff_callbacks_(callbacks) {}
 
+  absl::Status readChannelOpen(wire::ChannelOpenMsg&& msg) override {
+    callbacks_->sendMessageLocal(std::move(msg));
+    return absl::OkStatus();
+  }
+
   absl::Status readMessage(wire::ChannelMessage&& msg) override {
     if (handoff_complete_) {
       return callbacks_->sendMessageRemote(std::move(msg));
@@ -345,20 +350,21 @@ absl::StatusOr<MiddlewareResult> HandoffMiddleware::interceptMessage(wire::Messa
   return ssh_msg.visit(
     // 1: User auth request
     [&](wire::UserAuthSuccessMsg&) -> absl::StatusOr<MiddlewareResult> {
-      auto channel = std::make_unique<HandoffChannel>(info, parent_);
-      auto internalId = parent_.connection_svc_->startChannel(
-        std::move(channel), info.channel_info->internal_upstream_channel_id());
-      ASSERT(internalId.ok()); // should not be able to fail
-
-      // Build and send the ChannelOpen message to the upstream
       wire::ChannelOpenMsg open;
       open.request = wire::SessionChannelOpenMsg{};
-      open.sender_channel = *internalId;
+      open.sender_channel = info.channel_info->internal_upstream_channel_id();
       open.initial_window_size = info.channel_info->initial_window_size();
       open.max_packet_size = info.channel_info->max_packet_size();
 
-      auto stat = parent_.sendMessageToConnection(std::move(open));
-      ASSERT(stat.ok()); // should not be able to fail
+      auto channel = std::make_unique<HandoffChannel>(info, parent_);
+      auto internalId = parent_.connection_svc_->startChannel(
+        std::move(channel),
+        {
+          .allocated_channel_id = info.channel_info->internal_upstream_channel_id(),
+          .channel_open = open,
+          .skip_auto_bind = true,
+        });
+      ASSERT(internalId.ok()); // should not be able to fail
 
       // this message won't be dispatched to the upstream userauth service, so we need to handle a
       // couple of post-auth-success actions that it would normally do

--- a/source/extensions/filters/network/ssh/reverse_tunnel.cc
+++ b/source/extensions/filters/network/ssh/reverse_tunnel.cc
@@ -783,19 +783,14 @@ public:
     }
   }
 
-  // Local thread
-  absl::Status setChannelCallbacks(ChannelCallbacks& callbacks) override {
-    auto stat = Channel::setChannelCallbacks(callbacks);
-    ASSERT(stat.ok()); // default implementation always succeeds
+  void setChannelCallbacks(ChannelCallbacks& callbacks) override {
+    Channel::setChannelCallbacks(callbacks);
 
     channel_id_ = callbacks_->channelId();
+    callbacks_->setStatsProvider(*this);
+  }
 
-    callbacks.setStatsProvider(*this);
-
-    // Build and send the ChannelOpen message to the downstream.
-    // Normally channels don't send their own ChannelOpen messages, but this is somewhat of a
-    // special case, because the channel is owned internally.
-
+  absl::Status readChannelOpen(wire::ChannelOpenMsg&&) override {
     wire::ForwardedTcpipChannelOpenMsg req;
     if (metadata_.matched_permission().requested_host().empty()) {
       // wildcard mode
@@ -821,7 +816,7 @@ public:
     };
     ENVOY_LOG(debug, "channel {}: flow control: local window initialized to {}", channel_id_, wire::ChannelWindowSize);
 
-    callbacks.sendMessageLocal(std::move(open));
+    callbacks_->sendMessageLocal(std::move(open));
     return absl::OkStatus();
   }
 
@@ -884,7 +879,6 @@ public:
     RemoteError error_;
   };
 
-  // Local thread
   absl::Status readMessage(wire::ChannelMessage&& msg) override {
     return msg.visit(
       [&](const wire::ChannelDataMsg& msg) {
@@ -928,7 +922,6 @@ public:
   }
 
 private:
-  // Local thread
   void onChannelOpened(const wire::ChannelOpenConfirmationMsg& confirm) {
     if (host_draining_) {
       // See comment in onHostDraining() for details
@@ -1272,7 +1265,17 @@ public:
                                                              upstreamAddr,
                                                              hostContext->clusterContext(),
                                                              passthroughState);
-        auto id = ctx->streamCallbacks().startChannel(std::move(c), std::nullopt);
+
+        // It's simpler for the channel to construct its own ChannelOpenMsg, otherwise we would have
+        // to duplicate obtaining metadata and downstream address here, which the channel already
+        // needs for other things. Setting channel_open below triggers the readChannelOpen callback.
+        auto id = ctx->streamCallbacks().startChannel(
+          std::move(c),
+          {
+            .channel_open = wire::ChannelOpenMsg{},
+            .skip_auto_bind = true,
+          });
+
         if (!id.ok()) {
           ENVOY_LOG(warn, "failed to start channel: {}", statusToString(id.status()));
         } else {

--- a/source/extensions/filters/network/ssh/service_connection.cc
+++ b/source/extensions/filters/network/ssh/service_connection.cc
@@ -34,25 +34,51 @@ void ConnectionService::registerMessageHandlers(SshMessageDispatcher& dispatcher
   dispatcher.registerHandler(wire::SshMessageType::ChannelFailure, this);
 }
 
-absl::StatusOr<uint32_t> ConnectionService::startChannel(std::unique_ptr<Channel> channel, std::optional<uint32_t> channel_id) {
-  if (!channel_id.has_value()) {
+absl::StatusOr<uint32_t> ConnectionService::startChannel(std::unique_ptr<Channel> channel, StartChannelOpts opts) {
+  auto channelId = opts.allocated_channel_id;
+  if (!channelId.has_value()) {
     auto internalId = transport_.channelIdManager().allocateNewChannel(local_peer_);
     if (!internalId.ok()) {
       return internalId.status();
     }
-    channel_id = *internalId;
+    channelId = *internalId;
   }
-  auto callbacks = std::make_unique<ChannelCallbacksImpl>(*this, *channel_id, local_peer_);
-  if (auto stat = channel->setChannelCallbacks(*callbacks); !stat.ok()) {
-    return stat;
-  }
+
+  ENVOY_LOG(debug, "starting new internal channel: {}", *channelId);
+  RELEASE_ASSERT(!channels_.contains(*channelId), fmt::format("bug: channel with ID {} already exists", *channelId));
+
+  auto callbacks = std::make_unique<ChannelCallbacksImpl>(*this, *channelId, local_peer_);
+
+  channel->setChannelCallbacks(*callbacks);
+  // Note: order is important here; if readChannelOpen below fails, the callbacks cleanup routine
+  // is invoked when the channel is destroyed, which will unlink it from channel_callbacks_.
   LinkedList::moveIntoList(std::move(callbacks), channel_callbacks_);
 
-  ENVOY_LOG(debug, "starting new internal channel: {}", *channel_id);
-  RELEASE_ASSERT(!channels_.contains(*channel_id), fmt::format("bug: channel with ID {} already exists", *channel_id));
-  channels_[*channel_id] = std::move(channel);
+  if (opts.channel_open.has_value()) {
+    if (!opts.skip_auto_bind) {
+      auto stat = transport_.channelIdManager().bindChannelID(
+        *channelId, PeerLocalID{
+                      .channel_id = opts.channel_open->sender_channel,
+                      .local_peer = local_peer_,
+                    },
+        opts.bind_expect_remote.value_or(true));
+      ASSERT(stat.ok());
+    }
 
-  return *channel_id;
+    if (auto stat = channel->readChannelOpen(std::move(opts.channel_open).value()); !stat.ok()) {
+      // If sending the channel open message fails, the peer's ID may still be in the Pending state,
+      // but it will never have received the channel open, so the ID will not be released.
+      if (!opts.skip_auto_bind && opts.bind_expect_remote.value_or(true)) {
+
+        transport_.channelIdManager().releaseChannelID(*channelId,
+                                                       local_peer_ == Downstream ? Upstream : Downstream);
+      }
+      return stat;
+    }
+  }
+
+  channels_[*channelId] = std::move(channel);
+  return *channelId;
 }
 
 absl::Status ConnectionService::handleMessage(wire::Message&& msg) {
@@ -60,21 +86,10 @@ absl::Status ConnectionService::handleMessage(wire::Message&& msg) {
     [&](wire::ChannelOpenMsg& msg) {
       ENVOY_LOG(debug, "starting new passthrough channel");
       auto passthrough = std::make_unique<PassthroughChannel>();
-      auto id = startChannel(std::move(passthrough));
+      auto id = startChannel(std::move(passthrough), {.channel_open{std::move(msg)}});
       if (!id.ok()) {
         return statusf("error starting passthrough channel: {}", id.status());
       }
-      auto stat = transport_.channelIdManager().bindChannelID(*id, PeerLocalID{
-                                                                     .channel_id = msg.sender_channel,
-                                                                     .local_peer = local_peer_,
-                                                                   });
-      ASSERT(stat.ok());
-      // replace the sender channel id with the internal channel id
-      msg.sender_channel = *id;
-      // forward the message
-      ENVOY_LOG(debug, "forwarding ChannelOpen message for passthrough channel: {}", *msg.sender_channel);
-      transport_.forward(std::move(msg));
-
       return absl::OkStatus();
     },
     [&](wire::ChannelOpenConfirmationMsg& msg) {
@@ -104,7 +119,7 @@ absl::Status ConnectionService::handleMessage(wire::Message&& msg) {
       // by the opposite peer, a passthrough channel is initialized for this ID.
       // Note: even if the channel is owned by the opposite peer, a local channel for that ID
       // can still be started ahead of time and will be used instead of a passthrough channel.
-      if (auto stat = maybeStartPassthroughChannel(msg.recipient_channel); !stat.ok()) {
+      if (auto stat = maybeStartNonOwningPassthroughChannel(msg.recipient_channel); !stat.ok()) {
         return stat;
       }
 
@@ -123,7 +138,7 @@ absl::Status ConnectionService::handleMessage(wire::Message&& msg) {
     [&](wire::ChannelOpenFailureMsg& msg) {
       // the channel will be immediately deleted after this, but the PassthroughChannel contains
       // the logic to forward the message, and this keeps things consistent
-      if (auto stat = maybeStartPassthroughChannel(msg.recipient_channel); !stat.ok()) {
+      if (auto stat = maybeStartNonOwningPassthroughChannel(msg.recipient_channel); !stat.ok()) {
         return statusf("received invalid ChannelOpenFailure message: {}", stat);
       }
 
@@ -164,7 +179,7 @@ absl::Status ConnectionService::handleMessage(wire::Message&& msg) {
     });
 }
 
-absl::Status ConnectionService::maybeStartPassthroughChannel(uint32_t internal_id) {
+absl::Status ConnectionService::maybeStartNonOwningPassthroughChannel(uint32_t internal_id) {
   if (channels_.contains(internal_id)) {
     return absl::OkStatus();
   }
@@ -205,10 +220,10 @@ absl::Status ConnectionService::maybeStartPassthroughChannel(uint32_t internal_i
     // PassthroughChannel, use a special channel type called ForceCloseChannel which will, upon
     // being started, simply attempt to close itself. Once it is closed, then the channel ID will
     // be released and freed (since at this point, the downstream channel will be bereft).
-    return startChannel(std::make_unique<ForceCloseChannel>(), internal_id).status();
+    return startChannel(std::make_unique<ForceCloseChannel>(), {.allocated_channel_id = internal_id}).status();
   }
   auto passthrough = std::make_unique<PassthroughChannel>();
-  return startChannel(std::move(passthrough), internal_id).status();
+  return startChannel(std::move(passthrough), {.allocated_channel_id = internal_id}).status();
 }
 
 Envoy::Common::CallbackHandlePtr ConnectionService::onServerDraining(std::chrono::milliseconds delay, Envoy::Event::Dispatcher& dispatcher, std::function<void()> complete_cb) {
@@ -322,6 +337,12 @@ void ConnectionService::ChannelCallbacksImpl::sendMessageLocal(wire::Message&& m
 
 absl::Status ConnectionService::ChannelCallbacksImpl::sendMessageRemote(wire::Message&& msg) {
   return msg.visit(
+    [&](wire::ChannelOpenMsg& msg) {
+      ENVOY_LOG(debug, "sending ChannelOpen message to remote for channel {}", channel_id_);
+      msg.sender_channel = channel_id_;
+      parent_.transport_.forward(std::move(msg));
+      return absl::OkStatus();
+    },
     [&](wire::ChannelMsg auto& msg) {
       msg.recipient_channel = channel_id_;
       auto sendOk = channel_id_mgr_.processOutgoingChannelMsg(msg, local_peer_ == Peer::Downstream
@@ -390,12 +411,10 @@ class HijackedChannel : public Channel,
 public:
   HijackedChannel(HijackedChannelCallbacks& hijack_callbacks,
                   std::unique_ptr<ChannelStreamServiceClient> channel_client,
-                  const pomerium::extensions::ssh::InternalTarget& config,
-                  const wire::ChannelOpenMsg& channel_open)
+                  const pomerium::extensions::ssh::InternalTarget& config)
       : hijack_callbacks_(hijack_callbacks),
         channel_client_(std::move(channel_client)),
-        config_(config),
-        channel_open_(channel_open) {}
+        config_(config) {}
 
   void onStreamClosed(absl::Status err) override {
     // In some cases the stream is expected to be closed: after handoff starts, or if a channel
@@ -454,14 +473,7 @@ public:
     });
   }
 
-  absl::Status setChannelCallbacks(ChannelCallbacks& callbacks) override {
-    auto stat = Channel::setChannelCallbacks(callbacks);
-    ASSERT(stat.ok()); // default implementation always succeeds
-
-    // Note: we're still inside of ConnectionService::startChannel() here, so the downstream ID has
-    // not been bound yet. This callback doesn't send anything to the downstream currently, but if
-    // it ever needs to then the ID will need to be bound earlier.
-
+  absl::Status readChannelOpen(wire::ChannelOpenMsg&& msg) override {
     // Start the stream and send the downstream's saved ChannelOpen message. The stream expects
     // the first message to be ChannelOpen (after the metadata is sent). It will respond with a
     // success or failure message.
@@ -487,7 +499,7 @@ public:
     typedMetadata["com.pomerium.ssh"].PackFrom(sshMetadata);
     channel_client_->start(this, std::move(metadata));
 
-    sendMessageToStream(std::move(channel_open_)); // clear channel_open_
+    sendMessageToStream(std::move(msg));
     return absl::OkStatus();
   }
 
@@ -669,7 +681,6 @@ private:
   HijackedChannelCallbacks& hijack_callbacks_;
   std::unique_ptr<ChannelStreamServiceClient> channel_client_;
   pomerium::extensions::ssh::InternalTarget config_;
-  wire::ChannelOpenMsg channel_open_;
   Common::CallbackHandlePtr interrupt_callback_handle_;
 };
 
@@ -699,26 +710,14 @@ absl::StatusOr<MiddlewareResult> OpenHijackedChannelMiddleware::interceptMessage
     [&](wire::ChannelOpenMsg& msg) -> absl::StatusOr<MiddlewareResult> {
       auto client = std::make_unique<ChannelStreamServiceClient>(grpc_client_);
 
-      auto channel = std::make_unique<HijackedChannel>(hijack_callbacks_, std::move(client), config_, msg);
-
-      auto internalId = parent_.startChannel(std::move(channel), std::nullopt);
+      auto channel = std::make_unique<HijackedChannel>(hijack_callbacks_, std::move(client), config_);
+      auto internalId = parent_.startChannel(std::move(channel), {
+                                                                   .channel_open{std::move(msg)},
+                                                                   .bind_expect_remote = false,
+                                                                 });
       if (!internalId.ok()) {
         return statusf("error starting channel: {}", internalId.status());
       }
-
-      // This normally happens when ConnectionService::handleMessage processes an outgoing
-      // ChannelOpenMsg, but we are going to drop the message here, and have it be handled by
-      // the grpc server instead (the ConnectionService would otherwise create a PassthroughChannel
-      // and forward the message).
-      auto stat = parent_.transport_.channelIdManager().bindChannelID(
-        *internalId,
-        PeerLocalID{
-          .channel_id = msg.sender_channel,
-          .local_peer = Peer::Downstream,
-        },
-        false); // <- Important: set mark_remote_pending=false
-      // this can't fail, we allocated the internal ID just now
-      THROW_IF_NOT_OK(stat);
 
       return MiddlewareResult::Break;
     },

--- a/source/extensions/filters/network/ssh/service_connection.h
+++ b/source/extensions/filters/network/ssh/service_connection.h
@@ -37,11 +37,11 @@ public:
   // ChannelClose message by replying with their own ChannelClose message on the channel if they
   // have not done so already (i.e. if the ChannelClose was received as an expected response to
   // one sent previously).
-  absl::StatusOr<uint32_t> startChannel(std::unique_ptr<Channel> channel, std::optional<uint32_t> channel_id = std::nullopt) final;
+  absl::StatusOr<uint32_t> startChannel(std::unique_ptr<Channel> channel, StartChannelOpts opts = {}) final;
   Envoy::Common::CallbackHandlePtr onServerDraining(std::chrono::milliseconds delay, Envoy::Event::Dispatcher& dispatcher, std::function<void()> complete_cb) final;
 
   absl::Status handleMessage(wire::Message&& ssh_msg) override;
-  absl::Status maybeStartPassthroughChannel(uint32_t internal_id);
+  absl::Status maybeStartNonOwningPassthroughChannel(uint32_t internal_id);
   void registerMessageHandlers(SshMessageDispatcher& dispatcher) override;
   void shutdown(absl::Status err);
 
@@ -149,6 +149,7 @@ protected:
 
   ConnectionServiceOptions options_;
   TransportCallbacks& transport_;
+
   const Peer local_peer_;
   Envoy::OptRef<MessageDispatcher<wire::Message>> msg_dispatcher_;
 

--- a/source/extensions/filters/network/ssh/stream_tracker.h
+++ b/source/extensions/filters/network/ssh/stream_tracker.h
@@ -16,7 +16,28 @@ namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 class StreamCallbacks {
 public:
   virtual ~StreamCallbacks() = default;
-  virtual absl::StatusOr<uint32_t> startChannel(std::unique_ptr<Channel> channel, std::optional<uint32_t> channel_id = std::nullopt) PURE;
+
+  struct StartChannelOpts {
+    // Optional previously allocated internal channel ID to use for this channel, instead of
+    // allocating a new one.
+    std::optional<uint32_t> allocated_channel_id;
+
+    // If set, startChannel will call Channel::readChannelOpen with this message after
+    // Channel::setChannelCallbacks is called, and after binding the sender_channel in this message
+    // to the local peer (if requested).
+    std::optional<wire::ChannelOpenMsg> channel_open;
+
+    // If true, startChannel will not bind the sender_channel of the ChannelOpenMsg set in the
+    // channel_open option. This has no effect if channel_open is unset.
+    bool skip_auto_bind{};
+
+    // If channel_open is set, and skip_auto_bind is false, this value will be used as the
+    // 'expect_remote' argument to ChannelIDManager::bindChannelID() (default true if unset)
+    std::optional<bool> bind_expect_remote;
+  };
+
+  virtual absl::StatusOr<uint32_t> startChannel(std::unique_ptr<Channel> channel, StartChannelOpts opts) PURE;
+
   [[nodiscard]]
   virtual Envoy::Common::CallbackHandlePtr onServerDraining(std::chrono::milliseconds delay, Envoy::Event::Dispatcher& dispatcher, std::function<void()> complete_cb) PURE;
 };

--- a/test/extensions/filters/network/ssh/reverse_tunnel_test.cc
+++ b/test/extensions/filters/network/ssh/reverse_tunnel_test.cc
@@ -858,12 +858,19 @@ TEST_P(StaticPortForwardTest, UpstreamPacketEmpty) {
 }
 
 TEST_P(StaticPortForwardTest, UpstreamSendsInvalidWindowAdjust) {
+  Tasks::Channel channel;
   auto th = driver->createTask<Tasks::AcceptReversePortForward>(route_name, route_port, 1)
-              .then(driver->createTask<Tasks::SendWindowAdjust>(std::numeric_limits<uint32_t>::max())
-                      .then(driver->createTask<Tasks::WaitForChannelCloseByPeer>()))
+              .saveOutput(&channel)
               .start();
+
   auto downstream = makeTcpConnectionWithServerName(route_port, route_name);
   ASSERT_TRUE(driver->wait(th));
+
+  auto th2 = driver->createTask<Tasks::SendWindowAdjust>(std::numeric_limits<uint32_t>::max())
+               .then(driver->createTask<Tasks::WaitForChannelCloseByPeer>())
+               .start(channel);
+
+  ASSERT_TRUE(driver->wait(th2));
 
   downstream->close();
 }

--- a/test/extensions/filters/network/ssh/service_connection_impl_test.cc
+++ b/test/extensions/filters/network/ssh/service_connection_impl_test.cc
@@ -137,9 +137,8 @@ TEST_F(DownstreamConnectionServiceTest, TestStatsTimer) {
   MockChannelStatsProvider ch1Stats;
   EXPECT_CALL(*ch1, setChannelCallbacks)
     .WillOnce([ch1 = ch1.get(), &ch1Stats](ChannelCallbacks& cb) {
-      ch1->Channel::setChannelCallbacks(cb).IgnoreError();
+      ch1->Channel::setChannelCallbacks(cb);
       cb.setStatsProvider(ch1Stats);
-      return absl::OkStatus();
     });
   EXPECT_CALL(ch1Stats, populateChannelStats)
     .WillRepeatedly(Invoke([](pomerium::extensions::ssh::ChannelStats& stats) {
@@ -151,9 +150,8 @@ TEST_F(DownstreamConnectionServiceTest, TestStatsTimer) {
   MockChannelStatsProvider ch2Stats;
   EXPECT_CALL(*ch2, setChannelCallbacks)
     .WillOnce([ch2 = ch2.get(), &ch2Stats](ChannelCallbacks& cb) {
-      ch2->Channel::setChannelCallbacks(cb).IgnoreError();
+      ch2->Channel::setChannelCallbacks(cb);
       cb.setStatsProvider(ch2Stats);
-      return absl::OkStatus();
     });
   EXPECT_CALL(ch2Stats, populateChannelStats)
     .WillRepeatedly(Invoke([](pomerium::extensions::ssh::ChannelStats& stats) {

--- a/test/extensions/filters/network/ssh/service_connection_test.cc
+++ b/test/extensions/filters/network/ssh/service_connection_test.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstdlib>
 
+#include "envoy/common/exception.h"
 #include "source/common/types.h"
 #include "source/extensions/filters/network/ssh/channel.h"
 #include "source/extensions/filters/network/ssh/frame.h"
@@ -31,13 +32,22 @@ public:
 
   using ConnectionService::preempt;
 
-  ChannelCallbacksImpl& getChannelCallbacks(uint32_t id) {
+  ChannelCallbacksImpl& GetChannelCallbacks(uint32_t id) {
     for (auto& cc : channel_callbacks_) {
       if (cc->channelId() == id) {
         return *cc;
       }
     }
     PANIC("test bug: channel id does not exist");
+  }
+
+  AssertionResult AssertChannelCountEq(size_t count) {
+    if (channel_callbacks_.size() == count && channels_.size() == count) {
+      return AssertionSuccess();
+    }
+    return AssertionFailure() << fmt::format(
+             "expected channel count to equal {} (actual: callbacks={}, channels={})",
+             count, channel_callbacks_.size(), channels_.size());
   }
 };
 
@@ -94,7 +104,7 @@ TEST_P(ConnectionServiceTest, StartChannel_ExistingID) {
   IN_SEQUENCE;
   EXPECT_CALL(*ch1, setChannelCallbacks);
   EXPECT_CALL(*ch1, Die);
-  auto id = service_.startChannel(std::move(ch1), newId);
+  auto id = service_.startChannel(std::move(ch1), {.allocated_channel_id = newId});
   ASSERT_OK(id);
   EXPECT_EQ(101, id.value());
 }
@@ -107,27 +117,105 @@ TEST_P(ConnectionServiceTest, StartChannel_ErrorAllocatingID) {
   EXPECT_CALL(*ch1, Die);
   auto id = service_.startChannel(std::move(ch1));
   ASSERT_EQ(absl::ResourceExhaustedError("failed to allocate ID"), id.status());
+
+  EXPECT_TRUE(service_.AssertChannelCountEq(0));
 }
 
-TEST_P(ConnectionServiceTest, StartChannel_ChannelCallbacksError) {
+TEST_P(ConnectionServiceTest, StartChannel_ReadChannelOpen) {
   auto ch1 = std::make_unique<testing::StrictMock<MockChannel>>();
   IN_SEQUENCE;
-  EXPECT_CALL(*ch1, setChannelCallbacks)
-    .WillOnce([&](ChannelCallbacks&) {
-      return absl::InternalError("test error");
-    });
+  EXPECT_CALL(*ch1, setChannelCallbacks);
+  wire::ChannelOpenMsg msg{
+    .sender_channel = 1,
+    .request = wire::SessionChannelOpenMsg{},
+  };
+
+  EXPECT_CALL(*ch1, readChannelOpen(auto(msg)))
+    .WillOnce(Return(absl::OkStatus()));
   EXPECT_CALL(*ch1, Die);
-  auto id = service_.startChannel(std::move(ch1));
+  auto id = service_.startChannel(std::move(ch1), {.channel_open = msg});
+  ASSERT_OK(id);
+
+  ASSERT_TRUE(channel_id_manager_.owner(*id).has_value());
+  ASSERT_EQ(LocalPeer(), channel_id_manager_.owner(*id));
+
+  EXPECT_EQ(ChannelIDState::Pending, channel_id_manager_.peerState(*id, RemotePeer())); // expect_remote=true
+  EXPECT_EQ(ChannelIDState::Bound, channel_id_manager_.peerState(*id, LocalPeer()));
+}
+
+TEST_P(ConnectionServiceTest, StartChannel_SkipAutoBind) {
+  auto ch1 = std::make_unique<testing::StrictMock<MockChannel>>();
+  IN_SEQUENCE;
+  EXPECT_CALL(*ch1, setChannelCallbacks);
+  wire::ChannelOpenMsg msg{
+    .sender_channel = 1,
+    .request = wire::SessionChannelOpenMsg{},
+  };
+
+  EXPECT_CALL(*ch1, readChannelOpen(auto(msg)))
+    .WillOnce(Return(absl::OkStatus()));
+  EXPECT_CALL(*ch1, Die);
+  auto id = service_.startChannel(std::move(ch1), {
+                                                    .channel_open = msg,
+                                                    .skip_auto_bind = true,
+                                                  });
+  ASSERT_OK(id);
+
+  EXPECT_EQ(ChannelIDState::Unbound, channel_id_manager_.peerState(*id, RemotePeer()));
+  EXPECT_EQ(ChannelIDState::Unbound, channel_id_manager_.peerState(*id, LocalPeer()));
+}
+
+TEST_P(ConnectionServiceTest, StartChannel_BindExpectRemote) {
+  auto ch1 = std::make_unique<testing::StrictMock<MockChannel>>();
+  IN_SEQUENCE;
+  EXPECT_CALL(*ch1, setChannelCallbacks);
+  wire::ChannelOpenMsg msg{
+    .sender_channel = 1,
+    .request = wire::SessionChannelOpenMsg{},
+  };
+
+  EXPECT_CALL(*ch1, readChannelOpen(auto(msg)))
+    .WillOnce(Return(absl::OkStatus()));
+  EXPECT_CALL(*ch1, Die);
+  auto id = service_.startChannel(std::move(ch1), {
+                                                    .channel_open = msg,
+                                                    .bind_expect_remote = false,
+                                                  });
+  ASSERT_OK(id);
+
+  ASSERT_TRUE(channel_id_manager_.owner(*id).has_value());
+
+  EXPECT_EQ(ChannelIDState::Unbound, channel_id_manager_.peerState(*id, RemotePeer()));
+  EXPECT_EQ(ChannelIDState::Bound, channel_id_manager_.peerState(*id, LocalPeer()));
+}
+
+TEST_P(ConnectionServiceTest, StartChannel_ErrorReadingChannelOpen) {
+  auto ch1 = std::make_unique<testing::StrictMock<MockChannel>>();
+  IN_SEQUENCE;
+  EXPECT_CALL(*ch1, setChannelCallbacks);
+  EXPECT_CALL(*ch1, readChannelOpen)
+    .WillOnce(Return(absl::InternalError("test error")));
+  EXPECT_CALL(*ch1, Die);
+  auto id = service_.startChannel(std::move(ch1), {.channel_open = wire::ChannelOpenMsg{}});
   ASSERT_EQ(absl::InternalError("test error"), id.status());
+
+  // Check that allocated IDs are freed if readChannelOpen fails. Because bind_expect_remote is
+  // unset (which defaults to true), the remote peer's ID will briefly be in the Pending state,
+  // but should be released before startChannel returns. The local peer's ID will briefly be in the
+  // Bound state, and will be releaed when the Channel is destroyed, freeing the internal id.
+  ASSERT_EQ(0, channel_id_manager_.numActiveChannels());
+
+  // make sure that errors during channel start don't leave around channel objects
+  EXPECT_TRUE(service_.AssertChannelCountEq(0));
 }
 
 TEST_P(ConnectionServiceTest, SetChannelCallbacks) {
   auto ch1 = std::make_unique<testing::StrictMock<MockChannel>>();
   IN_SEQUENCE;
-  EXPECT_CALL(*ch1, setChannelCallbacks).WillOnce([](ChannelCallbacks& cb) {
+  EXPECT_CALL(*ch1, setChannelCallbacks).WillOnce([ch1 = ch1.get()](ChannelCallbacks& cb) {
+    ch1->Channel::setChannelCallbacks(cb);
     EXPECT_EQ(100, cb.channelId());
     EXPECT_NE(nullptr, &cb.scope());
-    return absl::OkStatus();
   });
   EXPECT_CALL(*ch1, Die);
   auto id = service_.startChannel(std::move(ch1));
@@ -373,7 +461,7 @@ TEST_P(ConnectionServiceTest, InterruptInternalChannel) {
     }));
 
   ASSERT_TRUE(channel_id_manager_.isPreemptable(id, LocalPeer()));
-  service_.preempt(service_.getChannelCallbacks(id), absl::InternalError("test error"));
+  service_.preempt(service_.GetChannelCallbacks(id), absl::InternalError("test error"));
 }
 
 TEST_P(ConnectionServiceTest, InterruptLocalPassthroughChannel) {
@@ -395,7 +483,7 @@ TEST_P(ConnectionServiceTest, InterruptLocalPassthroughChannel) {
                                                      .local_peer = RemotePeer(),
                                                    }));
   auto interruptCallbackHandle =
-    service_.getChannelCallbacks(100)
+    service_.GetChannelCallbacks(100)
       .addInterruptCallback(
         [](absl::Status err, TransportCallbacks& transport_callbacks) {
           EXPECT_EQ(absl::InternalError("test error"), err);
@@ -423,7 +511,7 @@ TEST_P(ConnectionServiceTest, InterruptLocalPassthroughChannel) {
                                   _));
 
   ASSERT_TRUE(channel_id_manager_.isPreemptable(100, LocalPeer()));
-  service_.preempt(service_.getChannelCallbacks(100), absl::InternalError("test error"));
+  service_.preempt(service_.GetChannelCallbacks(100), absl::InternalError("test error"));
 }
 
 TEST_P(ConnectionServiceTest, InterruptRemotePassthroughChannel) {
@@ -449,7 +537,7 @@ TEST_P(ConnectionServiceTest, InterruptRemotePassthroughChannel) {
     .sender_channel = 1u,
   }));
   auto interruptCallbackHandle =
-    service_.getChannelCallbacks(internalChannel)
+    service_.GetChannelCallbacks(internalChannel)
       .addInterruptCallback(
         [](absl::Status err, TransportCallbacks& transport_callbacks) {
           EXPECT_EQ(absl::InternalError("test error"), err);
@@ -477,7 +565,15 @@ TEST_P(ConnectionServiceTest, InterruptRemotePassthroughChannel) {
                                   _));
 
   ASSERT_TRUE(channel_id_manager_.isPreemptable(internalChannel, LocalPeer()));
-  service_.preempt(service_.getChannelCallbacks(internalChannel), absl::InternalError("test error"));
+  service_.preempt(service_.GetChannelCallbacks(internalChannel), absl::InternalError("test error"));
+}
+
+TEST(ConnectionServiceMiscTest, TestForceCloseChannel_ReadChannelOpen) {
+  // ForceCloseChannel::readChannelOpen should not be called.
+  ForceCloseChannel c;
+  EXPECT_THROW_WITH_MESSAGE(c.readChannelOpen(wire::ChannelOpenMsg{}).IgnoreError(),
+                            Envoy::EnvoyException,
+                            "bug: invalid call to ForceCloseChannel::readChannelOpen()")
 }
 
 TEST_P(ConnectionServiceTest, CloseLocalPassthroughChannelWithNoRemoteRef) {
@@ -623,11 +719,11 @@ TEST_P(ConnectionServiceTest, PassthroughNonChannelData) {
 TEST_P(ConnectionServiceTest, SendNonChannelDataInternal) {
   auto ch1 = std::make_unique<testing::StrictMock<MockChannel>>();
   auto& c1 = EXPECT_CALL(*ch1, setChannelCallbacks)
-               .WillOnce([&](ChannelCallbacks& cb) {
+               .WillOnce([&, ch1 = ch1.get()](ChannelCallbacks& cb) {
+                 ch1->Channel::setChannelCallbacks(cb);
                  EXPECT_CALL(transport_, sendMessageToConnection(MSG(wire::IgnoreMsg, _)))
                    .WillOnce(Return(0));
                  cb.sendMessageLocal(wire::IgnoreMsg{});
-                 return absl::OkStatus();
                });
   EXPECT_CALL(*ch1, Die)
     .After(c1);
@@ -637,12 +733,12 @@ TEST_P(ConnectionServiceTest, SendNonChannelDataInternal) {
 TEST_P(ConnectionServiceTest, SendNonChannelDataInternal_ErrorSendingMessageLocal) {
   auto ch1 = std::make_unique<testing::StrictMock<MockChannel>>();
   auto& c1 = EXPECT_CALL(*ch1, setChannelCallbacks)
-               .WillOnce([&](ChannelCallbacks& cb) {
+               .WillOnce([&, ch1 = ch1.get()](ChannelCallbacks& cb) {
+                 ch1->Channel::setChannelCallbacks(cb);
                  EXPECT_CALL(transport_, sendMessageToConnection(MSG(wire::IgnoreMsg, _)))
                    .WillOnce(Return(absl::InternalError("test error")));
                  EXPECT_CALL(transport_, terminate(absl::InternalError("test error")));
                  cb.sendMessageLocal(wire::IgnoreMsg{});
-                 return absl::OkStatus();
                });
   EXPECT_CALL(*ch1, Die)
     .After(c1);
@@ -714,7 +810,7 @@ TEST_P(ConnectionServiceTest, PreemptChannelCloseSequenceLocal) {
   ASSERT_EQ(ChannelIDState::Bound, channel_id_manager_.peerState(internalId, RemotePeer()));
   ASSERT_EQ(ChannelIDState::Bound, channel_id_manager_.peerState(internalId, LocalPeer()));
 
-  service_.preempt(service_.getChannelCallbacks(internalId), absl::InternalError("test error"));
+  service_.preempt(service_.GetChannelCallbacks(internalId), absl::InternalError("test error"));
   check.Call(1);
 
   ASSERT_EQ(ChannelIDState::Bound, channel_id_manager_.peerState(internalId, RemotePeer()));
@@ -818,7 +914,7 @@ TEST_P(ConnectionServiceTest, PreemptChannelCloseRace) {
   ASSERT_EQ(ChannelIDState::Preempted, channel_id_manager_.peerState(internalId, LocalPeer()));
 
   // this message should be dropped
-  service_.getChannelCallbacks(internalId).sendMessageLocal(wire::ChannelCloseMsg{
+  service_.GetChannelCallbacks(internalId).sendMessageLocal(wire::ChannelCloseMsg{
     .recipient_channel = internalId,
   });
 
@@ -923,7 +1019,7 @@ TEST_P(ShutdownTest, Shutdown) {
   auto [channel4, channel4Local] = *NewLocalOwnedChannel();
   EXPECT_CALL(transport_, sendMessageToConnection(MSG(wire::ChannelCloseMsg, FIELD_EQ(recipient_channel, channel4Local))))
     .WillOnce(Return(0));
-  service_.preempt(service_.getChannelCallbacks(channel4), absl::CancelledError("test error"));
+  service_.preempt(service_.GetChannelCallbacks(channel4), absl::CancelledError("test error"));
   ASSERT_EQ(ChannelIDState::Bound, channel_id_manager_.peerState(channel4, RemotePeer()));
   ASSERT_EQ(ChannelIDState::Preempted, channel_id_manager_.peerState(channel4, LocalPeer()));
 

--- a/test/extensions/filters/network/ssh/ssh_upstream.cc
+++ b/test/extensions/filters/network/ssh/ssh_upstream.cc
@@ -45,16 +45,13 @@ absl::Status SshFakeUpstreamHandler::FakeUpstreamConnectionService::handleMessag
       if (!parent_.opts_->on_channel_open_request) {
         PANIC("test bug: on_channel_open_request callback unset but required");
       }
-      auto id = transport_.channelIdManager().allocateNewChannel(local_peer_);
-      RETURN_IF_NOT_OK(id.status());
-      auto stat = transport_.channelIdManager().bindChannelID(*id, PeerLocalID{
-                                                                     .channel_id = msg.sender_channel,
-                                                                     .local_peer = local_peer_,
-                                                                   },
-                                                              false);
-      ASSERT(stat.ok());
+
       auto ch = std::make_unique<FakeUpstreamChannel>(parent_.opts_->on_channel_open_request(msg));
-      RETURN_IF_NOT_OK(startChannel(std::move(ch), *id).status());
+      RETURN_IF_NOT_OK(startChannel(std::move(ch), {
+                                                     .channel_open = msg,
+                                                     .bind_expect_remote = false,
+                                                   })
+                         .status());
       return absl::OkStatus();
     },
     [&](wire::ChannelOpenConfirmationMsg&& msg) {
@@ -69,7 +66,7 @@ absl::Status SshFakeUpstreamHandler::FakeUpstreamConnectionService::handleMessag
         PANIC("test bug: on_channel_accepted callback unset but required");
       }
       auto ch = std::make_unique<FakeUpstreamChannel>(parent_.opts_->on_channel_accepted(msg));
-      RETURN_IF_NOT_OK(startChannel(std::move(ch), id).status());
+      RETURN_IF_NOT_OK(startChannel(std::move(ch), {.allocated_channel_id = id}).status());
       msg.sender_channel = msg.recipient_channel;
       return channels_[id]->readMessage(std::move(msg));
     },
@@ -79,7 +76,7 @@ absl::Status SshFakeUpstreamHandler::FakeUpstreamConnectionService::handleMessag
         PANIC("test bug: on_channel_rejected callback unset but required");
       }
       auto ch = std::make_unique<FakeUpstreamChannel>(parent_.opts_->on_channel_rejected(msg));
-      RETURN_IF_NOT_OK(startChannel(std::move(ch), id).status());
+      RETURN_IF_NOT_OK(startChannel(std::move(ch), {.allocated_channel_id = id}).status());
       return channels_[id]->readMessage(std::move(msg));
     },
     [&](auto&& msg) {

--- a/test/extensions/filters/network/ssh/ssh_upstream.h
+++ b/test/extensions/filters/network/ssh/ssh_upstream.h
@@ -42,17 +42,17 @@ public:
   FakeUpstreamChannel(ChannelMsgHandlerFunc msg_handler)
       : msg_handler_(std::move(msg_handler)) {}
 
-  absl::Status setChannelCallbacks(ChannelCallbacks& callbacks) override {
-    RETURN_IF_NOT_OK(Channel::setChannelCallbacks(callbacks));
+  absl::Status readChannelOpen(wire::ChannelOpenMsg&& msg) override {
     callbacks_->sendMessageLocal(
       wire::ChannelOpenConfirmationMsg{
-        .recipient_channel = callbacks_->channelId(),
+        .recipient_channel = msg.sender_channel,
         .sender_channel = callbacks_->channelId(),
-        .initial_window_size = wire::ChannelWindowSize,
-        .max_packet_size = wire::ChannelMaxPacketSize,
+        .initial_window_size = msg.initial_window_size,
+        .max_packet_size = msg.max_packet_size,
       });
     return absl::OkStatus();
   }
+
   absl::Status readMessage(wire::ChannelMessage&& msg) override {
     return msg_handler_(std::move(msg), *callbacks_);
   }

--- a/test/extensions/filters/network/ssh/stream_tracker_test.cc
+++ b/test/extensions/filters/network/ssh/stream_tracker_test.cc
@@ -1,3 +1,4 @@
+#include "source/extensions/filters/network/ssh/channel.h"
 #include "source/extensions/filters/network/ssh/common.h"
 #include "source/extensions/filters/network/ssh/stream_tracker.h"
 
@@ -41,7 +42,7 @@ TEST_F(StreamTrackerTest, FromContext) {
 class TestStreamCallbacks : public StreamCallbacks, public ChannelEventCallbacks {
 public:
   virtual ~TestStreamCallbacks() = default;
-  MOCK_METHOD(absl::StatusOr<uint32_t>, startChannel, (std::unique_ptr<Channel>, std::optional<uint32_t>));
+  MOCK_METHOD(absl::StatusOr<uint32_t>, startChannel, (std::unique_ptr<Channel>, StreamCallbacks::StartChannelOpts));
   MOCK_METHOD(void, sendChannelEvent, (const pomerium::extensions::ssh::ChannelEvent&));
   MOCK_METHOD(void, onServerDraining, (std::chrono::milliseconds delay));
   MOCK_METHOD(Envoy::Common::CallbackHandlePtr, onServerDraining, (std::chrono::milliseconds, Envoy::Event::Dispatcher&, std::function<void()>));

--- a/test/extensions/filters/network/ssh/test_mocks.cc
+++ b/test/extensions/filters/network/ssh/test_mocks.cc
@@ -40,7 +40,7 @@ MockHijackedChannelCallbacks::~MockHijackedChannelCallbacks() {}
 MockChannel::MockChannel() {
   ON_CALL(*this, setChannelCallbacks)
     .WillByDefault([this](ChannelCallbacks& cb) {
-      return this->Channel::setChannelCallbacks(cb);
+      this->Channel::setChannelCallbacks(cb);
     });
 }
 MockChannel::~MockChannel() {

--- a/test/extensions/filters/network/ssh/test_mocks.h
+++ b/test/extensions/filters/network/ssh/test_mocks.h
@@ -97,8 +97,9 @@ class MockChannel : public Channel {
 public:
   MockChannel();
   virtual ~MockChannel();
-  MOCK_METHOD(void, Die, ());                                          // NOLINT
-  MOCK_METHOD(absl::Status, setChannelCallbacks, (ChannelCallbacks&)); // has a default implementation
+  MOCK_METHOD(void, Die, ());                                  // NOLINT
+  MOCK_METHOD(void, setChannelCallbacks, (ChannelCallbacks&)); // has a default implementation
+  MOCK_METHOD(absl::Status, readChannelOpen, (wire::ChannelOpenMsg&&));
   MOCK_METHOD(absl::Status, readMessage, (wire::ChannelMessage&&));
   MOCK_METHOD(void, terminate, (absl::Status));
 };


### PR DESCRIPTION
This refactors code related to creating and opening channels to minimize the amount of "out of band" setup required to create a channel and forward a ChannelOpen message.

Since ChannelOpen messages are not channel messages, historically we have avoided having Channel instances manage sending them, instead sending them separately after the channel is created. However, this limits how much a Channel can know about itself. It would be useful for any channel to know what its type is, for example. It also causes some code duplication, specifically around ID binding. Some implementations also needed to use the setChannelCallbacks hook to send the ChannelOpen message or do other initialization, which could be bugprone due to order of operations (setChannelCallbacks is called by ConnectionService::startChannel, but it didn't bind the channel ID yet so sending remote messages via channel callbacks wouldn't work).


Instead, Channel implementations have a new readChannelOpen function which is responsible for receiving and forwarding (if applicable) a ChannelOpen message. This function is called by startChannel if a ChannelOpen message is set in StartChannelOpts. Additionally, startChannel will now by default bind the sender channel ID in the ChannelOpen message. It does this before invoking readChannelOpen, so that the Channel can use ChannelCallbacks::sendMessageRemote/sendMessageLocal to send the message.


