### PR TITLE
add channel filter extension point

### DIFF
--- a/api/extensions/filters/network/ssh/ssh.pb.go
+++ b/api/extensions/filters/network/ssh/ssh.pb.go
@@ -193,9 +193,10 @@ type CodecConfig struct {
 	// Max number of concurrent open channels. Default (and max) is 32768
 	MaxConcurrentChannels uint32 `protobuf:"varint,5,opt,name=max_concurrent_channels,json=maxConcurrentChannels,proto3" json:"max_concurrent_channels,omitempty"`
 	// Starting value for internal channel IDs. Defaults to 0. Can be set > 0 for easier debugging.
-	InternalChannelIdStart   uint32                    `protobuf:"varint,6,opt,name=internal_channel_id_start,json=internalChannelIdStart,proto3" json:"internal_channel_id_start,omitempty"`
-	AlgorithmOptions         *AlgorithmOptions         `protobuf:"bytes,7,opt,name=algorithm_options,json=algorithmOptions,proto3" json:"algorithm_options,omitempty"`
-	ConnectionServiceOptions *ConnectionServiceOptions `protobuf:"bytes,8,opt,name=connection_service_options,json=connectionServiceOptions,proto3" json:"connection_service_options,omitempty"`
+	InternalChannelIdStart   uint32                     `protobuf:"varint,6,opt,name=internal_channel_id_start,json=internalChannelIdStart,proto3" json:"internal_channel_id_start,omitempty"`
+	AlgorithmOptions         *AlgorithmOptions          `protobuf:"bytes,7,opt,name=algorithm_options,json=algorithmOptions,proto3" json:"algorithm_options,omitempty"`
+	ConnectionServiceOptions *ConnectionServiceOptions  `protobuf:"bytes,8,opt,name=connection_service_options,json=connectionServiceOptions,proto3" json:"connection_service_options,omitempty"`
+	EnabledChannelFilters    []*v3.TypedExtensionConfig `protobuf:"bytes,9,rep,name=enabled_channel_filters,json=enabledChannelFilters,proto3" json:"enabled_channel_filters,omitempty"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache
 }
@@ -282,6 +283,13 @@ func (x *CodecConfig) GetAlgorithmOptions() *AlgorithmOptions {
 func (x *CodecConfig) GetConnectionServiceOptions() *ConnectionServiceOptions {
 	if x != nil {
 		return x.ConnectionServiceOptions
+	}
+	return nil
+}
+
+func (x *CodecConfig) GetEnabledChannelFilters() []*v3.TypedExtensionConfig {
+	if x != nil {
+		return x.EnabledChannelFilters
 	}
 	return nil
 }
@@ -2004,14 +2012,13 @@ func (*AllowResponse_Internal) isAllowResponse_Target() {}
 func (*AllowResponse_MirrorSession) isAllowResponse_Target() {}
 
 type UpstreamTarget struct {
-	state                  protoimpl.MessageState     `protogen:"open.v1"`
-	Hostname               string                     `protobuf:"bytes,1,opt,name=hostname,proto3" json:"hostname,omitempty"`
-	AllowMirrorConnections bool                       `protobuf:"varint,2,opt,name=allow_mirror_connections,json=allowMirrorConnections,proto3" json:"allow_mirror_connections,omitempty"`
-	DirectTcpip            bool                       `protobuf:"varint,3,opt,name=direct_tcpip,json=directTcpip,proto3" json:"direct_tcpip,omitempty"`
-	AllowedMethods         []*AllowedMethod           `protobuf:"bytes,4,rep,name=allowed_methods,json=allowedMethods,proto3" json:"allowed_methods,omitempty"`
-	Extensions             []*v3.TypedExtensionConfig `protobuf:"bytes,5,rep,name=extensions,proto3" json:"extensions,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	state          protoimpl.MessageState     `protogen:"open.v1"`
+	Hostname       string                     `protobuf:"bytes,1,opt,name=hostname,proto3" json:"hostname,omitempty"`
+	DirectTcpip    bool                       `protobuf:"varint,3,opt,name=direct_tcpip,json=directTcpip,proto3" json:"direct_tcpip,omitempty"`
+	AllowedMethods []*AllowedMethod           `protobuf:"bytes,4,rep,name=allowed_methods,json=allowedMethods,proto3" json:"allowed_methods,omitempty"`
+	ChannelFilters []*v3.TypedExtensionConfig `protobuf:"bytes,5,rep,name=channel_filters,json=channelFilters,proto3" json:"channel_filters,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *UpstreamTarget) Reset() {
@@ -2051,13 +2058,6 @@ func (x *UpstreamTarget) GetHostname() string {
 	return ""
 }
 
-func (x *UpstreamTarget) GetAllowMirrorConnections() bool {
-	if x != nil {
-		return x.AllowMirrorConnections
-	}
-	return false
-}
-
 func (x *UpstreamTarget) GetDirectTcpip() bool {
 	if x != nil {
 		return x.DirectTcpip
@@ -2072,9 +2072,9 @@ func (x *UpstreamTarget) GetAllowedMethods() []*AllowedMethod {
 	return nil
 }
 
-func (x *UpstreamTarget) GetExtensions() []*v3.TypedExtensionConfig {
+func (x *UpstreamTarget) GetChannelFilters() []*v3.TypedExtensionConfig {
 	if x != nil {
-		return x.Extensions
+		return x.ChannelFilters
 	}
 	return nil
 }
@@ -3689,7 +3689,7 @@ var File_github_com_pomerium_envoy_custom_api_extensions_filters_network_ssh_ssh
 
 const file_github_com_pomerium_envoy_custom_api_extensions_filters_network_ssh_ssh_proto_rawDesc = "" +
 	"\n" +
-	"Mgithub.com/pomerium/envoy-custom/api/extensions/filters/network/ssh/ssh.proto\x12\x17pomerium.extensions.ssh\x1a\"envoy/config/core/v3/address.proto\x1a\x1fenvoy/config/core/v3/base.proto\x1a(envoy/config/core/v3/config_source.proto\x1a$envoy/config/core/v3/extension.proto\x1a'envoy/config/core/v3/grpc_service.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1aAgithub.com/envoyproxy/protoc-gen-validate/validate/validate.proto\"\x97\x05\n" +
+	"Mgithub.com/pomerium/envoy-custom/api/extensions/filters/network/ssh/ssh.proto\x12\x17pomerium.extensions.ssh\x1a\"envoy/config/core/v3/address.proto\x1a\x1fenvoy/config/core/v3/base.proto\x1a(envoy/config/core/v3/config_source.proto\x1a$envoy/config/core/v3/extension.proto\x1a'envoy/config/core/v3/grpc_service.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1aAgithub.com/envoyproxy/protoc-gen-validate/validate/validate.proto\"\xfb\x05\n" +
 	"\vCodecConfig\x12N\n" +
 	"\thost_keys\x18\x01 \x03(\v2 .envoy.config.core.v3.DataSourceB\x0f\xfaB\f\x92\x01\t\b\x01\"\x05\x8a\x01\x02\x10\x01R\bhostKeys\x12J\n" +
 	"\vuser_ca_key\x18\x02 \x01(\v2 .envoy.config.core.v3.DataSourceB\b\xfaB\x05\x8a\x01\x02\x10\x01R\tuserCaKey\x12U\n" +
@@ -3698,7 +3698,8 @@ const file_github_com_pomerium_envoy_custom_api_extensions_filters_network_ssh_s
 	"\x17max_concurrent_channels\x18\x05 \x01(\rB\t\xfaB\x06*\x04\x18\x80\x80\x02R\x15maxConcurrentChannels\x129\n" +
 	"\x19internal_channel_id_start\x18\x06 \x01(\rR\x16internalChannelIdStart\x12V\n" +
 	"\x11algorithm_options\x18\a \x01(\v2).pomerium.extensions.ssh.AlgorithmOptionsR\x10algorithmOptions\x12o\n" +
-	"\x1aconnection_service_options\x18\b \x01(\v21.pomerium.extensions.ssh.ConnectionServiceOptionsR\x18connectionServiceOptions\"\x91\x01\n" +
+	"\x1aconnection_service_options\x18\b \x01(\v21.pomerium.extensions.ssh.ConnectionServiceOptionsR\x18connectionServiceOptions\x12b\n" +
+	"\x17enabled_channel_filters\x18\t \x03(\v2*.envoy.config.core.v3.TypedExtensionConfigR\x15enabledChannelFilters\"\x91\x01\n" +
 	"\x10AlgorithmOptions\x124\n" +
 	"\x16disable_kex_algorithms\x18\x01 \x03(\tR\x14disableKexAlgorithms\x12G\n" +
 	" disable_packet_cipher_algorithms\x18\x02 \x03(\tR\x1ddisablePacketCipherAlgorithms\"\x83\x01\n" +
@@ -3823,15 +3824,12 @@ const file_github_com_pomerium_envoy_custom_api_extensions_filters_network_ssh_s
 	"\bupstream\x18\x02 \x01(\v2'.pomerium.extensions.ssh.UpstreamTargetH\x00R\bupstream\x12E\n" +
 	"\binternal\x18\x03 \x01(\v2'.pomerium.extensions.ssh.InternalTargetH\x00R\binternal\x12U\n" +
 	"\x0emirror_session\x18\x04 \x01(\v2,.pomerium.extensions.ssh.MirrorSessionTargetH\x00R\rmirrorSessionB\b\n" +
-	"\x06target\"\xa6\x02\n" +
+	"\x06target\"\xf5\x01\n" +
 	"\x0eUpstreamTarget\x12\x1a\n" +
-	"\bhostname\x18\x01 \x01(\tR\bhostname\x128\n" +
-	"\x18allow_mirror_connections\x18\x02 \x01(\bR\x16allowMirrorConnections\x12!\n" +
+	"\bhostname\x18\x01 \x01(\tR\bhostname\x12!\n" +
 	"\fdirect_tcpip\x18\x03 \x01(\bR\vdirectTcpip\x12O\n" +
-	"\x0fallowed_methods\x18\x04 \x03(\v2&.pomerium.extensions.ssh.AllowedMethodR\x0eallowedMethods\x12J\n" +
-	"\n" +
-	"extensions\x18\x05 \x03(\v2*.envoy.config.core.v3.TypedExtensionConfigR\n" +
-	"extensions\"S\n" +
+	"\x0fallowed_methods\x18\x04 \x03(\v2&.pomerium.extensions.ssh.AllowedMethodR\x0eallowedMethods\x12S\n" +
+	"\x0fchannel_filters\x18\x05 \x03(\v2*.envoy.config.core.v3.TypedExtensionConfigR\x0echannelFilters\"S\n" +
 	"\x0eInternalTarget\x12A\n" +
 	"\fset_metadata\x18\x01 \x01(\v2\x1e.envoy.config.core.v3.MetadataR\vsetMetadata\"\xa0\x01\n" +
 	"\x13MirrorSessionTarget\x12\x1b\n" +
@@ -4031,14 +4029,14 @@ var file_github_com_pomerium_envoy_custom_api_extensions_filters_network_ssh_ssh
 	(*v3.DataSource)(nil),              // 57: envoy.config.core.v3.DataSource
 	(*wrapperspb.UInt64Value)(nil),     // 58: google.protobuf.UInt64Value
 	(*v3.GrpcService)(nil),             // 59: envoy.config.core.v3.GrpcService
-	(*durationpb.Duration)(nil),        // 60: google.protobuf.Duration
-	(*v3.ConfigSource)(nil),            // 61: envoy.config.core.v3.ConfigSource
-	(*v3.Metadata)(nil),                // 62: envoy.config.core.v3.Metadata
-	(*wrapperspb.BytesValue)(nil),      // 63: google.protobuf.BytesValue
-	(*anypb.Any)(nil),                  // 64: google.protobuf.Any
-	(*v3.Address)(nil),                 // 65: envoy.config.core.v3.Address
-	(*timestamppb.Timestamp)(nil),      // 66: google.protobuf.Timestamp
-	(*v3.TypedExtensionConfig)(nil),    // 67: envoy.config.core.v3.TypedExtensionConfig
+	(*v3.TypedExtensionConfig)(nil),    // 60: envoy.config.core.v3.TypedExtensionConfig
+	(*durationpb.Duration)(nil),        // 61: google.protobuf.Duration
+	(*v3.ConfigSource)(nil),            // 62: envoy.config.core.v3.ConfigSource
+	(*v3.Metadata)(nil),                // 63: envoy.config.core.v3.Metadata
+	(*wrapperspb.BytesValue)(nil),      // 64: google.protobuf.BytesValue
+	(*anypb.Any)(nil),                  // 65: google.protobuf.Any
+	(*v3.Address)(nil),                 // 66: envoy.config.core.v3.Address
+	(*timestamppb.Timestamp)(nil),      // 67: google.protobuf.Timestamp
 	(*structpb.ListValue)(nil),         // 68: google.protobuf.ListValue
 }
 var file_github_com_pomerium_envoy_custom_api_extensions_filters_network_ssh_ssh_proto_depIdxs = []int32{
@@ -4048,75 +4046,76 @@ var file_github_com_pomerium_envoy_custom_api_extensions_filters_network_ssh_ssh
 	59, // 3: pomerium.extensions.ssh.CodecConfig.grpc_service:type_name -> envoy.config.core.v3.GrpcService
 	4,  // 4: pomerium.extensions.ssh.CodecConfig.algorithm_options:type_name -> pomerium.extensions.ssh.AlgorithmOptions
 	5,  // 5: pomerium.extensions.ssh.CodecConfig.connection_service_options:type_name -> pomerium.extensions.ssh.ConnectionServiceOptions
-	60, // 6: pomerium.extensions.ssh.ConnectionServiceOptions.channel_close_response_grace_period:type_name -> google.protobuf.Duration
-	61, // 7: pomerium.extensions.ssh.ReverseTunnelCluster.eds_config:type_name -> envoy.config.core.v3.ConfigSource
-	62, // 8: pomerium.extensions.ssh.ChannelMessage.metadata:type_name -> envoy.config.core.v3.Metadata
-	63, // 9: pomerium.extensions.ssh.ChannelMessage.raw_bytes:type_name -> google.protobuf.BytesValue
-	8,  // 10: pomerium.extensions.ssh.ChannelMessage.channel_control:type_name -> pomerium.extensions.ssh.ChannelControl
-	64, // 11: pomerium.extensions.ssh.ChannelControl.control_action:type_name -> google.protobuf.Any
-	10, // 12: pomerium.extensions.ssh.ClientMessage.event:type_name -> pomerium.extensions.ssh.StreamEvent
-	23, // 13: pomerium.extensions.ssh.ClientMessage.auth_request:type_name -> pomerium.extensions.ssh.AuthenticationRequest
-	24, // 14: pomerium.extensions.ssh.ClientMessage.info_response:type_name -> pomerium.extensions.ssh.InfoResponse
-	18, // 15: pomerium.extensions.ssh.ClientMessage.global_request:type_name -> pomerium.extensions.ssh.GlobalRequest
-	11, // 16: pomerium.extensions.ssh.StreamEvent.downstream_connected:type_name -> pomerium.extensions.ssh.DownstreamConnectEvent
-	12, // 17: pomerium.extensions.ssh.StreamEvent.downstream_disconnected:type_name -> pomerium.extensions.ssh.DownstreamDisconnectedEvent
-	13, // 18: pomerium.extensions.ssh.StreamEvent.upstream_connected:type_name -> pomerium.extensions.ssh.UpstreamConnectEvent
-	17, // 19: pomerium.extensions.ssh.StreamEvent.channel_event:type_name -> pomerium.extensions.ssh.ChannelEvent
-	65, // 20: pomerium.extensions.ssh.DownstreamConnectEvent.source_address:type_name -> envoy.config.core.v3.Address
-	1,  // 21: pomerium.extensions.ssh.Diagnostic.severity:type_name -> pomerium.extensions.ssh.Diagnostic.Severity
-	16, // 22: pomerium.extensions.ssh.ChannelStatsList.items:type_name -> pomerium.extensions.ssh.ChannelStats
-	66, // 23: pomerium.extensions.ssh.ChannelStats.start_time:type_name -> google.protobuf.Timestamp
-	66, // 24: pomerium.extensions.ssh.ChannelStats.end_time:type_name -> google.protobuf.Timestamp
-	48, // 25: pomerium.extensions.ssh.ChannelEvent.internal_channel_opened:type_name -> pomerium.extensions.ssh.ChannelEvent.InternalChannelOpenedEvent
-	49, // 26: pomerium.extensions.ssh.ChannelEvent.internal_channel_closed:type_name -> pomerium.extensions.ssh.ChannelEvent.InternalChannelClosedEvent
-	50, // 27: pomerium.extensions.ssh.ChannelEvent.channel_stats:type_name -> pomerium.extensions.ssh.ChannelEvent.ChannelStatsEvent
-	19, // 28: pomerium.extensions.ssh.GlobalRequest.tcpip_forward_request:type_name -> pomerium.extensions.ssh.TcpipForwardRequest
-	20, // 29: pomerium.extensions.ssh.GlobalRequest.cancel_tcpip_forward_request:type_name -> pomerium.extensions.ssh.CancelTcpipForwardRequest
-	22, // 30: pomerium.extensions.ssh.GlobalRequestResponse.tcpip_forward_response:type_name -> pomerium.extensions.ssh.TcpipForwardResponse
-	64, // 31: pomerium.extensions.ssh.AuthenticationRequest.method_request:type_name -> google.protobuf.Any
-	64, // 32: pomerium.extensions.ssh.InfoResponse.response:type_name -> google.protobuf.Any
-	26, // 33: pomerium.extensions.ssh.ServerMessage.auth_response:type_name -> pomerium.extensions.ssh.AuthenticationResponse
-	21, // 34: pomerium.extensions.ssh.ServerMessage.global_request_response:type_name -> pomerium.extensions.ssh.GlobalRequestResponse
-	27, // 35: pomerium.extensions.ssh.AuthenticationResponse.allow:type_name -> pomerium.extensions.ssh.AllowResponse
-	32, // 36: pomerium.extensions.ssh.AuthenticationResponse.deny:type_name -> pomerium.extensions.ssh.DenyResponse
-	33, // 37: pomerium.extensions.ssh.AuthenticationResponse.info_request:type_name -> pomerium.extensions.ssh.InfoRequest
-	28, // 38: pomerium.extensions.ssh.AllowResponse.upstream:type_name -> pomerium.extensions.ssh.UpstreamTarget
-	29, // 39: pomerium.extensions.ssh.AllowResponse.internal:type_name -> pomerium.extensions.ssh.InternalTarget
-	30, // 40: pomerium.extensions.ssh.AllowResponse.mirror_session:type_name -> pomerium.extensions.ssh.MirrorSessionTarget
-	31, // 41: pomerium.extensions.ssh.UpstreamTarget.allowed_methods:type_name -> pomerium.extensions.ssh.AllowedMethod
-	67, // 42: pomerium.extensions.ssh.UpstreamTarget.extensions:type_name -> envoy.config.core.v3.TypedExtensionConfig
-	62, // 43: pomerium.extensions.ssh.InternalTarget.set_metadata:type_name -> envoy.config.core.v3.Metadata
-	2,  // 44: pomerium.extensions.ssh.MirrorSessionTarget.mode:type_name -> pomerium.extensions.ssh.MirrorSessionTarget.Mode
-	64, // 45: pomerium.extensions.ssh.AllowedMethod.method_data:type_name -> google.protobuf.Any
-	64, // 46: pomerium.extensions.ssh.InfoRequest.request:type_name -> google.protobuf.Any
-	51, // 47: pomerium.extensions.ssh.SSHChannelControlAction.hand_off:type_name -> pomerium.extensions.ssh.SSHChannelControlAction.HandOffUpstream
-	52, // 48: pomerium.extensions.ssh.SSHChannelControlAction.set_interrupt_options:type_name -> pomerium.extensions.ssh.SSHChannelControlAction.InterruptOptions
-	43, // 49: pomerium.extensions.ssh.PublicKeyAllowResponse.permissions:type_name -> pomerium.extensions.ssh.Permissions
-	53, // 50: pomerium.extensions.ssh.KeyboardInteractiveAllowResponse.claims:type_name -> pomerium.extensions.ssh.KeyboardInteractiveAllowResponse.ClaimsEntry
-	54, // 51: pomerium.extensions.ssh.KeyboardInteractiveInfoPrompts.prompts:type_name -> pomerium.extensions.ssh.KeyboardInteractiveInfoPrompts.Prompt
-	66, // 52: pomerium.extensions.ssh.Permissions.valid_start_time:type_name -> google.protobuf.Timestamp
-	66, // 53: pomerium.extensions.ssh.Permissions.valid_end_time:type_name -> google.protobuf.Timestamp
-	55, // 54: pomerium.extensions.ssh.Permissions.force_env:type_name -> pomerium.extensions.ssh.Permissions.ForceEnvEntry
-	0,  // 55: pomerium.extensions.ssh.FilterMetadata.mode_hint:type_name -> pomerium.extensions.ssh.InternalCLIModeHint
-	45, // 56: pomerium.extensions.ssh.EndpointMetadata.server_port:type_name -> pomerium.extensions.ssh.ServerPort
-	46, // 57: pomerium.extensions.ssh.EndpointMetadata.matched_permission:type_name -> pomerium.extensions.ssh.PortForwardPermission
-	56, // 58: pomerium.extensions.ssh.EndpointMetadata.pomerium_route_info:type_name -> pomerium.extensions.ssh.EndpointMetadata.RouteInfo
-	16, // 59: pomerium.extensions.ssh.ChannelEvent.InternalChannelClosedEvent.stats:type_name -> pomerium.extensions.ssh.ChannelStats
-	14, // 60: pomerium.extensions.ssh.ChannelEvent.InternalChannelClosedEvent.diagnostics:type_name -> pomerium.extensions.ssh.Diagnostic
-	15, // 61: pomerium.extensions.ssh.ChannelEvent.ChannelStatsEvent.stats_list:type_name -> pomerium.extensions.ssh.ChannelStatsList
-	34, // 62: pomerium.extensions.ssh.SSHChannelControlAction.HandOffUpstream.downstream_channel_info:type_name -> pomerium.extensions.ssh.SSHDownstreamChannelInfo
-	35, // 63: pomerium.extensions.ssh.SSHChannelControlAction.HandOffUpstream.downstream_pty_info:type_name -> pomerium.extensions.ssh.SSHDownstreamPTYInfo
-	27, // 64: pomerium.extensions.ssh.SSHChannelControlAction.HandOffUpstream.upstream_auth:type_name -> pomerium.extensions.ssh.AllowResponse
-	68, // 65: pomerium.extensions.ssh.KeyboardInteractiveAllowResponse.ClaimsEntry.value:type_name -> google.protobuf.ListValue
-	9,  // 66: pomerium.extensions.ssh.StreamManagement.ManageStream:input_type -> pomerium.extensions.ssh.ClientMessage
-	7,  // 67: pomerium.extensions.ssh.StreamManagement.ServeChannel:input_type -> pomerium.extensions.ssh.ChannelMessage
-	25, // 68: pomerium.extensions.ssh.StreamManagement.ManageStream:output_type -> pomerium.extensions.ssh.ServerMessage
-	7,  // 69: pomerium.extensions.ssh.StreamManagement.ServeChannel:output_type -> pomerium.extensions.ssh.ChannelMessage
-	68, // [68:70] is the sub-list for method output_type
-	66, // [66:68] is the sub-list for method input_type
-	66, // [66:66] is the sub-list for extension type_name
-	66, // [66:66] is the sub-list for extension extendee
-	0,  // [0:66] is the sub-list for field type_name
+	60, // 6: pomerium.extensions.ssh.CodecConfig.enabled_channel_filters:type_name -> envoy.config.core.v3.TypedExtensionConfig
+	61, // 7: pomerium.extensions.ssh.ConnectionServiceOptions.channel_close_response_grace_period:type_name -> google.protobuf.Duration
+	62, // 8: pomerium.extensions.ssh.ReverseTunnelCluster.eds_config:type_name -> envoy.config.core.v3.ConfigSource
+	63, // 9: pomerium.extensions.ssh.ChannelMessage.metadata:type_name -> envoy.config.core.v3.Metadata
+	64, // 10: pomerium.extensions.ssh.ChannelMessage.raw_bytes:type_name -> google.protobuf.BytesValue
+	8,  // 11: pomerium.extensions.ssh.ChannelMessage.channel_control:type_name -> pomerium.extensions.ssh.ChannelControl
+	65, // 12: pomerium.extensions.ssh.ChannelControl.control_action:type_name -> google.protobuf.Any
+	10, // 13: pomerium.extensions.ssh.ClientMessage.event:type_name -> pomerium.extensions.ssh.StreamEvent
+	23, // 14: pomerium.extensions.ssh.ClientMessage.auth_request:type_name -> pomerium.extensions.ssh.AuthenticationRequest
+	24, // 15: pomerium.extensions.ssh.ClientMessage.info_response:type_name -> pomerium.extensions.ssh.InfoResponse
+	18, // 16: pomerium.extensions.ssh.ClientMessage.global_request:type_name -> pomerium.extensions.ssh.GlobalRequest
+	11, // 17: pomerium.extensions.ssh.StreamEvent.downstream_connected:type_name -> pomerium.extensions.ssh.DownstreamConnectEvent
+	12, // 18: pomerium.extensions.ssh.StreamEvent.downstream_disconnected:type_name -> pomerium.extensions.ssh.DownstreamDisconnectedEvent
+	13, // 19: pomerium.extensions.ssh.StreamEvent.upstream_connected:type_name -> pomerium.extensions.ssh.UpstreamConnectEvent
+	17, // 20: pomerium.extensions.ssh.StreamEvent.channel_event:type_name -> pomerium.extensions.ssh.ChannelEvent
+	66, // 21: pomerium.extensions.ssh.DownstreamConnectEvent.source_address:type_name -> envoy.config.core.v3.Address
+	1,  // 22: pomerium.extensions.ssh.Diagnostic.severity:type_name -> pomerium.extensions.ssh.Diagnostic.Severity
+	16, // 23: pomerium.extensions.ssh.ChannelStatsList.items:type_name -> pomerium.extensions.ssh.ChannelStats
+	67, // 24: pomerium.extensions.ssh.ChannelStats.start_time:type_name -> google.protobuf.Timestamp
+	67, // 25: pomerium.extensions.ssh.ChannelStats.end_time:type_name -> google.protobuf.Timestamp
+	48, // 26: pomerium.extensions.ssh.ChannelEvent.internal_channel_opened:type_name -> pomerium.extensions.ssh.ChannelEvent.InternalChannelOpenedEvent
+	49, // 27: pomerium.extensions.ssh.ChannelEvent.internal_channel_closed:type_name -> pomerium.extensions.ssh.ChannelEvent.InternalChannelClosedEvent
+	50, // 28: pomerium.extensions.ssh.ChannelEvent.channel_stats:type_name -> pomerium.extensions.ssh.ChannelEvent.ChannelStatsEvent
+	19, // 29: pomerium.extensions.ssh.GlobalRequest.tcpip_forward_request:type_name -> pomerium.extensions.ssh.TcpipForwardRequest
+	20, // 30: pomerium.extensions.ssh.GlobalRequest.cancel_tcpip_forward_request:type_name -> pomerium.extensions.ssh.CancelTcpipForwardRequest
+	22, // 31: pomerium.extensions.ssh.GlobalRequestResponse.tcpip_forward_response:type_name -> pomerium.extensions.ssh.TcpipForwardResponse
+	65, // 32: pomerium.extensions.ssh.AuthenticationRequest.method_request:type_name -> google.protobuf.Any
+	65, // 33: pomerium.extensions.ssh.InfoResponse.response:type_name -> google.protobuf.Any
+	26, // 34: pomerium.extensions.ssh.ServerMessage.auth_response:type_name -> pomerium.extensions.ssh.AuthenticationResponse
+	21, // 35: pomerium.extensions.ssh.ServerMessage.global_request_response:type_name -> pomerium.extensions.ssh.GlobalRequestResponse
+	27, // 36: pomerium.extensions.ssh.AuthenticationResponse.allow:type_name -> pomerium.extensions.ssh.AllowResponse
+	32, // 37: pomerium.extensions.ssh.AuthenticationResponse.deny:type_name -> pomerium.extensions.ssh.DenyResponse
+	33, // 38: pomerium.extensions.ssh.AuthenticationResponse.info_request:type_name -> pomerium.extensions.ssh.InfoRequest
+	28, // 39: pomerium.extensions.ssh.AllowResponse.upstream:type_name -> pomerium.extensions.ssh.UpstreamTarget
+	29, // 40: pomerium.extensions.ssh.AllowResponse.internal:type_name -> pomerium.extensions.ssh.InternalTarget
+	30, // 41: pomerium.extensions.ssh.AllowResponse.mirror_session:type_name -> pomerium.extensions.ssh.MirrorSessionTarget
+	31, // 42: pomerium.extensions.ssh.UpstreamTarget.allowed_methods:type_name -> pomerium.extensions.ssh.AllowedMethod
+	60, // 43: pomerium.extensions.ssh.UpstreamTarget.channel_filters:type_name -> envoy.config.core.v3.TypedExtensionConfig
+	63, // 44: pomerium.extensions.ssh.InternalTarget.set_metadata:type_name -> envoy.config.core.v3.Metadata
+	2,  // 45: pomerium.extensions.ssh.MirrorSessionTarget.mode:type_name -> pomerium.extensions.ssh.MirrorSessionTarget.Mode
+	65, // 46: pomerium.extensions.ssh.AllowedMethod.method_data:type_name -> google.protobuf.Any
+	65, // 47: pomerium.extensions.ssh.InfoRequest.request:type_name -> google.protobuf.Any
+	51, // 48: pomerium.extensions.ssh.SSHChannelControlAction.hand_off:type_name -> pomerium.extensions.ssh.SSHChannelControlAction.HandOffUpstream
+	52, // 49: pomerium.extensions.ssh.SSHChannelControlAction.set_interrupt_options:type_name -> pomerium.extensions.ssh.SSHChannelControlAction.InterruptOptions
+	43, // 50: pomerium.extensions.ssh.PublicKeyAllowResponse.permissions:type_name -> pomerium.extensions.ssh.Permissions
+	53, // 51: pomerium.extensions.ssh.KeyboardInteractiveAllowResponse.claims:type_name -> pomerium.extensions.ssh.KeyboardInteractiveAllowResponse.ClaimsEntry
+	54, // 52: pomerium.extensions.ssh.KeyboardInteractiveInfoPrompts.prompts:type_name -> pomerium.extensions.ssh.KeyboardInteractiveInfoPrompts.Prompt
+	67, // 53: pomerium.extensions.ssh.Permissions.valid_start_time:type_name -> google.protobuf.Timestamp
+	67, // 54: pomerium.extensions.ssh.Permissions.valid_end_time:type_name -> google.protobuf.Timestamp
+	55, // 55: pomerium.extensions.ssh.Permissions.force_env:type_name -> pomerium.extensions.ssh.Permissions.ForceEnvEntry
+	0,  // 56: pomerium.extensions.ssh.FilterMetadata.mode_hint:type_name -> pomerium.extensions.ssh.InternalCLIModeHint
+	45, // 57: pomerium.extensions.ssh.EndpointMetadata.server_port:type_name -> pomerium.extensions.ssh.ServerPort
+	46, // 58: pomerium.extensions.ssh.EndpointMetadata.matched_permission:type_name -> pomerium.extensions.ssh.PortForwardPermission
+	56, // 59: pomerium.extensions.ssh.EndpointMetadata.pomerium_route_info:type_name -> pomerium.extensions.ssh.EndpointMetadata.RouteInfo
+	16, // 60: pomerium.extensions.ssh.ChannelEvent.InternalChannelClosedEvent.stats:type_name -> pomerium.extensions.ssh.ChannelStats
+	14, // 61: pomerium.extensions.ssh.ChannelEvent.InternalChannelClosedEvent.diagnostics:type_name -> pomerium.extensions.ssh.Diagnostic
+	15, // 62: pomerium.extensions.ssh.ChannelEvent.ChannelStatsEvent.stats_list:type_name -> pomerium.extensions.ssh.ChannelStatsList
+	34, // 63: pomerium.extensions.ssh.SSHChannelControlAction.HandOffUpstream.downstream_channel_info:type_name -> pomerium.extensions.ssh.SSHDownstreamChannelInfo
+	35, // 64: pomerium.extensions.ssh.SSHChannelControlAction.HandOffUpstream.downstream_pty_info:type_name -> pomerium.extensions.ssh.SSHDownstreamPTYInfo
+	27, // 65: pomerium.extensions.ssh.SSHChannelControlAction.HandOffUpstream.upstream_auth:type_name -> pomerium.extensions.ssh.AllowResponse
+	68, // 66: pomerium.extensions.ssh.KeyboardInteractiveAllowResponse.ClaimsEntry.value:type_name -> google.protobuf.ListValue
+	9,  // 67: pomerium.extensions.ssh.StreamManagement.ManageStream:input_type -> pomerium.extensions.ssh.ClientMessage
+	7,  // 68: pomerium.extensions.ssh.StreamManagement.ServeChannel:input_type -> pomerium.extensions.ssh.ChannelMessage
+	25, // 69: pomerium.extensions.ssh.StreamManagement.ManageStream:output_type -> pomerium.extensions.ssh.ServerMessage
+	7,  // 70: pomerium.extensions.ssh.StreamManagement.ServeChannel:output_type -> pomerium.extensions.ssh.ChannelMessage
+	69, // [69:71] is the sub-list for method output_type
+	67, // [67:69] is the sub-list for method input_type
+	67, // [67:67] is the sub-list for extension type_name
+	67, // [67:67] is the sub-list for extension extendee
+	0,  // [0:67] is the sub-list for field type_name
 }
 
 func init() {

--- a/api/extensions/filters/network/ssh/ssh.pb.go
+++ b/api/extensions/filters/network/ssh/ssh.pb.go
@@ -193,12 +193,12 @@ type CodecConfig struct {
 	// Max number of concurrent open channels. Default (and max) is 32768
 	MaxConcurrentChannels uint32 `protobuf:"varint,5,opt,name=max_concurrent_channels,json=maxConcurrentChannels,proto3" json:"max_concurrent_channels,omitempty"`
 	// Starting value for internal channel IDs. Defaults to 0. Can be set > 0 for easier debugging.
-	InternalChannelIdStart   uint32                     `protobuf:"varint,6,opt,name=internal_channel_id_start,json=internalChannelIdStart,proto3" json:"internal_channel_id_start,omitempty"`
-	AlgorithmOptions         *AlgorithmOptions          `protobuf:"bytes,7,opt,name=algorithm_options,json=algorithmOptions,proto3" json:"algorithm_options,omitempty"`
-	ConnectionServiceOptions *ConnectionServiceOptions  `protobuf:"bytes,8,opt,name=connection_service_options,json=connectionServiceOptions,proto3" json:"connection_service_options,omitempty"`
-	EnabledChannelFilters    []*v3.TypedExtensionConfig `protobuf:"bytes,9,rep,name=enabled_channel_filters,json=enabledChannelFilters,proto3" json:"enabled_channel_filters,omitempty"`
-	unknownFields            protoimpl.UnknownFields
-	sizeCache                protoimpl.SizeCache
+	InternalChannelIdStart        uint32                     `protobuf:"varint,6,opt,name=internal_channel_id_start,json=internalChannelIdStart,proto3" json:"internal_channel_id_start,omitempty"`
+	AlgorithmOptions              *AlgorithmOptions          `protobuf:"bytes,7,opt,name=algorithm_options,json=algorithmOptions,proto3" json:"algorithm_options,omitempty"`
+	ConnectionServiceOptions      *ConnectionServiceOptions  `protobuf:"bytes,8,opt,name=connection_service_options,json=connectionServiceOptions,proto3" json:"connection_service_options,omitempty"`
+	EnabledChannelFilterFactories []*v3.TypedExtensionConfig `protobuf:"bytes,9,rep,name=enabled_channel_filter_factories,json=enabledChannelFilterFactories,proto3" json:"enabled_channel_filter_factories,omitempty"`
+	unknownFields                 protoimpl.UnknownFields
+	sizeCache                     protoimpl.SizeCache
 }
 
 func (x *CodecConfig) Reset() {
@@ -287,9 +287,9 @@ func (x *CodecConfig) GetConnectionServiceOptions() *ConnectionServiceOptions {
 	return nil
 }
 
-func (x *CodecConfig) GetEnabledChannelFilters() []*v3.TypedExtensionConfig {
+func (x *CodecConfig) GetEnabledChannelFilterFactories() []*v3.TypedExtensionConfig {
 	if x != nil {
-		return x.EnabledChannelFilters
+		return x.EnabledChannelFilterFactories
 	}
 	return nil
 }
@@ -3689,7 +3689,7 @@ var File_github_com_pomerium_envoy_custom_api_extensions_filters_network_ssh_ssh
 
 const file_github_com_pomerium_envoy_custom_api_extensions_filters_network_ssh_ssh_proto_rawDesc = "" +
 	"\n" +
-	"Mgithub.com/pomerium/envoy-custom/api/extensions/filters/network/ssh/ssh.proto\x12\x17pomerium.extensions.ssh\x1a\"envoy/config/core/v3/address.proto\x1a\x1fenvoy/config/core/v3/base.proto\x1a(envoy/config/core/v3/config_source.proto\x1a$envoy/config/core/v3/extension.proto\x1a'envoy/config/core/v3/grpc_service.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1aAgithub.com/envoyproxy/protoc-gen-validate/validate/validate.proto\"\xfb\x05\n" +
+	"Mgithub.com/pomerium/envoy-custom/api/extensions/filters/network/ssh/ssh.proto\x12\x17pomerium.extensions.ssh\x1a\"envoy/config/core/v3/address.proto\x1a\x1fenvoy/config/core/v3/base.proto\x1a(envoy/config/core/v3/config_source.proto\x1a$envoy/config/core/v3/extension.proto\x1a'envoy/config/core/v3/grpc_service.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1aAgithub.com/envoyproxy/protoc-gen-validate/validate/validate.proto\"\x8c\x06\n" +
 	"\vCodecConfig\x12N\n" +
 	"\thost_keys\x18\x01 \x03(\v2 .envoy.config.core.v3.DataSourceB\x0f\xfaB\f\x92\x01\t\b\x01\"\x05\x8a\x01\x02\x10\x01R\bhostKeys\x12J\n" +
 	"\vuser_ca_key\x18\x02 \x01(\v2 .envoy.config.core.v3.DataSourceB\b\xfaB\x05\x8a\x01\x02\x10\x01R\tuserCaKey\x12U\n" +
@@ -3698,8 +3698,8 @@ const file_github_com_pomerium_envoy_custom_api_extensions_filters_network_ssh_s
 	"\x17max_concurrent_channels\x18\x05 \x01(\rB\t\xfaB\x06*\x04\x18\x80\x80\x02R\x15maxConcurrentChannels\x129\n" +
 	"\x19internal_channel_id_start\x18\x06 \x01(\rR\x16internalChannelIdStart\x12V\n" +
 	"\x11algorithm_options\x18\a \x01(\v2).pomerium.extensions.ssh.AlgorithmOptionsR\x10algorithmOptions\x12o\n" +
-	"\x1aconnection_service_options\x18\b \x01(\v21.pomerium.extensions.ssh.ConnectionServiceOptionsR\x18connectionServiceOptions\x12b\n" +
-	"\x17enabled_channel_filters\x18\t \x03(\v2*.envoy.config.core.v3.TypedExtensionConfigR\x15enabledChannelFilters\"\x91\x01\n" +
+	"\x1aconnection_service_options\x18\b \x01(\v21.pomerium.extensions.ssh.ConnectionServiceOptionsR\x18connectionServiceOptions\x12s\n" +
+	" enabled_channel_filter_factories\x18\t \x03(\v2*.envoy.config.core.v3.TypedExtensionConfigR\x1denabledChannelFilterFactories\"\x91\x01\n" +
 	"\x10AlgorithmOptions\x124\n" +
 	"\x16disable_kex_algorithms\x18\x01 \x03(\tR\x14disableKexAlgorithms\x12G\n" +
 	" disable_packet_cipher_algorithms\x18\x02 \x03(\tR\x1ddisablePacketCipherAlgorithms\"\x83\x01\n" +
@@ -4046,7 +4046,7 @@ var file_github_com_pomerium_envoy_custom_api_extensions_filters_network_ssh_ssh
 	59, // 3: pomerium.extensions.ssh.CodecConfig.grpc_service:type_name -> envoy.config.core.v3.GrpcService
 	4,  // 4: pomerium.extensions.ssh.CodecConfig.algorithm_options:type_name -> pomerium.extensions.ssh.AlgorithmOptions
 	5,  // 5: pomerium.extensions.ssh.CodecConfig.connection_service_options:type_name -> pomerium.extensions.ssh.ConnectionServiceOptions
-	60, // 6: pomerium.extensions.ssh.CodecConfig.enabled_channel_filters:type_name -> envoy.config.core.v3.TypedExtensionConfig
+	60, // 6: pomerium.extensions.ssh.CodecConfig.enabled_channel_filter_factories:type_name -> envoy.config.core.v3.TypedExtensionConfig
 	61, // 7: pomerium.extensions.ssh.ConnectionServiceOptions.channel_close_response_grace_period:type_name -> google.protobuf.Duration
 	62, // 8: pomerium.extensions.ssh.ReverseTunnelCluster.eds_config:type_name -> envoy.config.core.v3.ConfigSource
 	63, // 9: pomerium.extensions.ssh.ChannelMessage.metadata:type_name -> envoy.config.core.v3.Metadata

--- a/api/extensions/filters/network/ssh/ssh.proto
+++ b/api/extensions/filters/network/ssh/ssh.proto
@@ -54,6 +54,8 @@ message CodecConfig {
   AlgorithmOptions algorithm_options = 7;
 
   ConnectionServiceOptions connection_service_options = 8;
+
+  repeated string enabled_channel_filters = 9;
 }
 
 message AlgorithmOptions {
@@ -288,11 +290,10 @@ message AllowResponse {
 }
 
 message UpstreamTarget {
-  string                 hostname                 = 1;
-  bool                   allow_mirror_connections = 2;
-  bool                   direct_tcpip             = 3;
-  repeated AllowedMethod allowed_methods          = 4;
-  repeated envoy.config.core.v3.TypedExtensionConfig extensions = 5;
+  string                 hostname        = 1;
+  bool                   direct_tcpip    = 3;
+  repeated AllowedMethod allowed_methods = 4;
+  repeated envoy.config.core.v3.TypedExtensionConfig channel_filters = 5;
 }
 
 message InternalTarget {

--- a/api/extensions/filters/network/ssh/ssh.proto
+++ b/api/extensions/filters/network/ssh/ssh.proto
@@ -55,7 +55,7 @@ message CodecConfig {
 
   ConnectionServiceOptions connection_service_options = 8;
 
-  repeated string enabled_channel_filters = 9;
+  repeated envoy.config.core.v3.TypedExtensionConfig enabled_channel_filters = 9;
 }
 
 message AlgorithmOptions {

--- a/api/extensions/filters/network/ssh/ssh.proto
+++ b/api/extensions/filters/network/ssh/ssh.proto
@@ -55,7 +55,7 @@ message CodecConfig {
 
   ConnectionServiceOptions connection_service_options = 8;
 
-  repeated envoy.config.core.v3.TypedExtensionConfig enabled_channel_filters = 9;
+  repeated envoy.config.core.v3.TypedExtensionConfig enabled_channel_filter_factories = 9;
 }
 
 message AlgorithmOptions {

--- a/source/extensions/filters/network/ssh/BUILD
+++ b/source/extensions/filters/network/ssh/BUILD
@@ -54,6 +54,7 @@ envoy_cc_library(
     ],
     hdrs = [
         "channel.h",
+        "channel_filter.h",
         "client_transport.h",
         "config.h",
         "extension_ping.h",

--- a/source/extensions/filters/network/ssh/BUILD
+++ b/source/extensions/filters/network/ssh/BUILD
@@ -31,6 +31,7 @@ envoy_cc_library(
     name = "pomerium_ssh",
     srcs = [
         "channel.cc",
+        "channel_filter_config.cc",
         "client_transport.cc",
         "config.cc",
         "extension_ping.cc",
@@ -55,6 +56,7 @@ envoy_cc_library(
     hdrs = [
         "channel.h",
         "channel_filter.h",
+        "channel_filter_config.h",
         "client_transport.h",
         "config.h",
         "extension_ping.h",

--- a/source/extensions/filters/network/ssh/BUILD
+++ b/source/extensions/filters/network/ssh/BUILD
@@ -82,6 +82,7 @@ envoy_cc_library(
         "stream_tracker.h",
         "transport.h",
         "transport_base.h",
+        "transport_common.h",
         "version_exchange.h",
     ],
     copts = [

--- a/source/extensions/filters/network/ssh/channel.h
+++ b/source/extensions/filters/network/ssh/channel.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "source/extensions/filters/network/ssh/transport.h"
 #include "source/extensions/filters/network/ssh/wire/messages.h"
 #pragma clang unsafe_buffer_usage begin
 #include "envoy/stats/scope.h"
@@ -18,7 +17,24 @@ public:
   virtual void populateChannelStats(pomerium::extensions::ssh::ChannelStats&) const PURE;
 };
 
-class ChannelCallbacks {
+class ChannelReadOnlyCallbacks {
+public:
+  virtual ~ChannelReadOnlyCallbacks() = default;
+
+  // Returns the channel's internal ID.
+  virtual uint32_t channelId() const PURE;
+
+  // Returns the channel's type, if available. The type will be available if a ChannelOpen message
+  // was passed to sendMessageRemote or sendMessageLocal via Channel::readChannelOpen.
+  virtual std::optional<std::string_view> channelType() const PURE;
+
+  // Base stats scope
+  virtual Stats::Scope& scope() const PURE;
+};
+
+class TransportCallbacks;
+
+class ChannelCallbacks : public ChannelReadOnlyCallbacks {
 public:
   virtual ~ChannelCallbacks() = default;
 
@@ -31,16 +47,6 @@ public:
   // recipient_channel field does not need to be set. It will be set to the current internal
   // channel ID automatically.
   virtual absl::Status sendMessageRemote(wire::Message&& msg) PURE;
-
-  // Returns the channel's internal ID.
-  virtual uint32_t channelId() const PURE;
-
-  // Returns the channel's type, if available. The type will be available if a ChannelOpen message
-  // was passed to sendMessageRemote or sendMessageLocal via Channel::readChannelOpen.
-  virtual std::optional<std::string_view> channelType() const PURE;
-
-  // Base stats scope
-  virtual Stats::Scope& scope() const PURE;
 
   // Sets the stats provider for this channel (usually the channel itself). If set, the stats
   // provider's populateChannelStats() method will be invoked at regular intervals to obtain stats

--- a/source/extensions/filters/network/ssh/channel.h
+++ b/source/extensions/filters/network/ssh/channel.h
@@ -35,6 +35,10 @@ public:
   // Returns the channel's internal ID.
   virtual uint32_t channelId() const PURE;
 
+  // Returns the channel's type, if available. The type will be available if a ChannelOpen message
+  // was passed to sendMessageRemote or sendMessageLocal via Channel::readChannelOpen.
+  virtual std::optional<std::string_view> channelType() const PURE;
+
   // Base stats scope
   virtual Stats::Scope& scope() const PURE;
 

--- a/source/extensions/filters/network/ssh/channel_filter.h
+++ b/source/extensions/filters/network/ssh/channel_filter.h
@@ -3,6 +3,9 @@
 #include "source/extensions/filters/network/ssh/channel.h"
 #include "source/extensions/filters/network/ssh/filter_state_objects.h"
 #include "source/extensions/filters/network/ssh/wire/messages.h"
+#pragma clang unsafe_buffer_usage begin
+#include "envoy/event/dispatcher.h"
+#pragma clang unsafe_buffer_usage end
 
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 
@@ -31,6 +34,11 @@ public:
 
   // Returns this connection's auth info.
   virtual const AuthInfo& authInfo() const PURE;
+
+  // Returns this connection's dispatcher. The dispatcher may be obtained from either the upstream
+  // or downstream connection depending on the direction of this channel, but both dispatchers
+  // will be for the same thread.
+  virtual Envoy::Event::Dispatcher& connectionDispatcher() const PURE;
 };
 
 using ChannelFilterPtr = std::unique_ptr<ChannelFilter>;

--- a/source/extensions/filters/network/ssh/channel_filter.h
+++ b/source/extensions/filters/network/ssh/channel_filter.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "source/extensions/filters/network/ssh/channel.h"
-#include "source/extensions/filters/network/ssh/common.h"
+#include "source/extensions/filters/network/ssh/filter_state_objects.h"
 #include "source/extensions/filters/network/ssh/wire/messages.h"
 
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
@@ -28,6 +28,9 @@ public:
 
   // Returns this channel's stream ID.
   virtual stream_id_t streamId() const PURE;
+
+  // Returns this connection's auth info.
+  virtual const AuthInfo& authInfo() const PURE;
 };
 
 using ChannelFilterPtr = std::unique_ptr<ChannelFilter>;

--- a/source/extensions/filters/network/ssh/channel_filter.h
+++ b/source/extensions/filters/network/ssh/channel_filter.h
@@ -1,70 +1,31 @@
 #pragma once
 
-#pragma clang unsafe_buffer_usage begin
-#include "envoy/config/typed_config.h"
-#include "envoy/server/factory_context.h"
-#pragma clang unsafe_buffer_usage end
+#include "source/extensions/filters/network/ssh/channel.h"
+#include "source/extensions/filters/network/ssh/wire/messages.h"
 
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 
-class ChannelCallbacks;
-
 class ChannelFilter {
 public:
+  virtual ~ChannelFilter() = default;
+  // Called just before a message is about to be forwarded to the peer.
+  virtual void onMessageForward(const wire::Message& msg) PURE;
 };
+
+class ChannelFilterCallbacks : public ChannelReadOnlyCallbacks {
+public:
+  virtual ~ChannelFilterCallbacks() = default;
+  // Initiate a channel close sequence which will close the channel for all peers. All previously
+  // registered interrupt callbacks (ChannelCallbacks::addInterruptCallback) will be invoked. The
+  // provided error is passed to these callbacks.
+  // Returns true if the connection was successfully interrupted, otherwise false. Some channel
+  // states are not interruptable, for example if the channel is already in the process of being
+  // closed.
+  // This does not necessarily terminate the connection, but the downstream client may disconnect
+  // if this was the last open channel. See ConnectionService::preempt for more details.
+  virtual bool interruptChannel(absl::Status err) PURE;
+};
+
 using ChannelFilterPtr = std::unique_ptr<ChannelFilter>;
-
-class ChannelFilterFactory {
-public:
-  virtual ~ChannelFilterFactory() = default;
-  virtual ChannelFilterPtr createReadFilter(const ChannelCallbacks& channel_callbacks) PURE;
-  virtual ChannelFilterPtr createWriteFilter(const ChannelCallbacks& channel_callbacks) PURE;
-};
-using ChannelFilterFactoryPtr = std::unique_ptr<ChannelFilterFactory>;
-
-class ChannelFilterFactoryConfig : public Config::TypedFactory {
-public:
-  virtual ChannelFilterFactoryPtr createChannelFilterFactory(Envoy::Server::Configuration::ServerFactoryContext& context) PURE;
-
-  std::string category() const override {
-    return "pomerium.ssh.channel_filters";
-  }
-};
-
-class ChannelFilterManager : NonCopyable {
-public:
-  ChannelFilterManager(Envoy::Server::Configuration::ServerFactoryContext& context,
-                       std::vector<std::string> names) {
-    for (const auto& name : names) {
-      auto* factoryConfig = Envoy::Registry::FactoryRegistry<ChannelFilterFactoryConfig>::getFactory(name);
-      if (factoryConfig != nullptr) {
-        factories_.push_back(factoryConfig->createChannelFilterFactory(context));
-      }
-    }
-  }
-
-  bool hasFilters() const { return !factories_.empty(); }
-
-  std::vector<ChannelFilterPtr> createReadFilters(const ChannelCallbacks& channel_callbacks) {
-    std::vector<ChannelFilterPtr> out;
-    for (auto& factory : factories_) {
-      out.push_back(factory->createReadFilter(channel_callbacks));
-    }
-    return out;
-  }
-
-  std::vector<ChannelFilterPtr> createWriteFilters(const ChannelCallbacks& channel_callbacks) {
-    std::vector<ChannelFilterPtr> out;
-    for (auto& factory : factories_) {
-      out.push_back(factory->createWriteFilter(channel_callbacks));
-    }
-    return out;
-  }
-
-private:
-  std::vector<ChannelFilterFactoryPtr> factories_;
-};
-
-using ChannelFilterManagerSharedPtr = std::shared_ptr<ChannelFilterManager>;
 
 } // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/source/extensions/filters/network/ssh/channel_filter.h
+++ b/source/extensions/filters/network/ssh/channel_filter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "source/extensions/filters/network/ssh/channel.h"
+#include "source/extensions/filters/network/ssh/common.h"
 #include "source/extensions/filters/network/ssh/wire/messages.h"
 
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
@@ -24,6 +25,9 @@ public:
   // This does not necessarily terminate the connection, but the downstream client may disconnect
   // if this was the last open channel. See ConnectionService::preempt for more details.
   virtual bool interruptChannel(absl::Status err) PURE;
+
+  // Returns this channel's stream ID.
+  virtual stream_id_t streamId() const PURE;
 };
 
 using ChannelFilterPtr = std::unique_ptr<ChannelFilter>;

--- a/source/extensions/filters/network/ssh/channel_filter.h
+++ b/source/extensions/filters/network/ssh/channel_filter.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#pragma clang unsafe_buffer_usage begin
+#include "envoy/config/typed_config.h"
+#include "envoy/server/factory_context.h"
+#pragma clang unsafe_buffer_usage end
+
+namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
+
+class ChannelCallbacks;
+
+class ChannelFilter {
+public:
+};
+using ChannelFilterPtr = std::unique_ptr<ChannelFilter>;
+
+class ChannelFilterFactory {
+public:
+  virtual ~ChannelFilterFactory() = default;
+  virtual ChannelFilterPtr createReadFilter(const ChannelCallbacks& channel_callbacks) PURE;
+  virtual ChannelFilterPtr createWriteFilter(const ChannelCallbacks& channel_callbacks) PURE;
+};
+using ChannelFilterFactoryPtr = std::unique_ptr<ChannelFilterFactory>;
+
+class ChannelFilterFactoryConfig : public Config::TypedFactory {
+public:
+  virtual ChannelFilterFactoryPtr createChannelFilterFactory(Envoy::Server::Configuration::ServerFactoryContext& context) PURE;
+
+  std::string category() const override {
+    return "pomerium.ssh.channel_filters";
+  }
+};
+
+class ChannelFilterManager : NonCopyable {
+public:
+  ChannelFilterManager(Envoy::Server::Configuration::ServerFactoryContext& context,
+                       std::vector<std::string> names) {
+    for (const auto& name : names) {
+      auto* factoryConfig = Envoy::Registry::FactoryRegistry<ChannelFilterFactoryConfig>::getFactory(name);
+      if (factoryConfig != nullptr) {
+        factories_.push_back(factoryConfig->createChannelFilterFactory(context));
+      }
+    }
+  }
+
+  bool hasFilters() const { return !factories_.empty(); }
+
+  std::vector<ChannelFilterPtr> createReadFilters(const ChannelCallbacks& channel_callbacks) {
+    std::vector<ChannelFilterPtr> out;
+    for (auto& factory : factories_) {
+      out.push_back(factory->createReadFilter(channel_callbacks));
+    }
+    return out;
+  }
+
+  std::vector<ChannelFilterPtr> createWriteFilters(const ChannelCallbacks& channel_callbacks) {
+    std::vector<ChannelFilterPtr> out;
+    for (auto& factory : factories_) {
+      out.push_back(factory->createWriteFilter(channel_callbacks));
+    }
+    return out;
+  }
+
+private:
+  std::vector<ChannelFilterFactoryPtr> factories_;
+};
+
+using ChannelFilterManagerSharedPtr = std::shared_ptr<ChannelFilterManager>;
+
+} // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/source/extensions/filters/network/ssh/channel_filter.h
+++ b/source/extensions/filters/network/ssh/channel_filter.h
@@ -16,6 +16,13 @@ public:
   virtual void onMessageForward(const wire::Message& msg) PURE;
 };
 
+class ReadDisableHandle {
+public:
+  virtual ~ReadDisableHandle() = default;
+};
+
+using ReadDisableHandlePtr = std::unique_ptr<ReadDisableHandle>;
+
 class ChannelFilterCallbacks : public ChannelReadOnlyCallbacks {
 public:
   virtual ~ChannelFilterCallbacks() = default;
@@ -39,6 +46,17 @@ public:
   // or downstream connection depending on the direction of this channel, but both dispatchers
   // will be for the same thread.
   virtual Envoy::Event::Dispatcher& connectionDispatcher() const PURE;
+
+  // Temporarily disable reads for the connection until the returned handle is destroyed. This can
+  // be used to apply backpressure if the filter can't keep up, to avoid blocking the worker thread.
+  // It is strongly recommended to accompany this with a separate timer to avoid keeping the
+  // connection disabled for too long.
+  //
+  // TODO: this is a bit of a hack. The proper way to support this would be to suppress channel
+  // window updates (the way it is handled for reverse tunnels), but we currently don't manage flow
+  // control ourselves for normal channels.
+  [[nodiscard]]
+  virtual ReadDisableHandlePtr connectionReadDisable() PURE;
 };
 
 using ChannelFilterPtr = std::unique_ptr<ChannelFilter>;

--- a/source/extensions/filters/network/ssh/channel_filter_config.cc
+++ b/source/extensions/filters/network/ssh/channel_filter_config.cc
@@ -1,0 +1,41 @@
+#include "source/extensions/filters/network/ssh/channel_filter_config.h"
+
+namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
+
+ChannelFilterManager::ChannelFilterManager(Envoy::Server::Configuration::ServerFactoryContext& context,
+                                           std::vector<std::string> names) {
+  for (const auto& name : names) {
+    auto* factoryConfig = Envoy::Registry::FactoryRegistry<ChannelFilterFactoryConfig>::getFactory(name);
+    if (factoryConfig != nullptr) {
+      factories_.push_back(factoryConfig->createChannelFilterFactory(context));
+    }
+  }
+}
+
+bool ChannelFilterManager::hasFilters() const {
+  return !factories_.empty();
+}
+
+std::vector<ChannelFilterPtr> ChannelFilterManager::createReadFilters(ChannelFilterCallbacks& channel_callbacks) {
+  std::vector<ChannelFilterPtr> out;
+  for (auto& factory : factories_) {
+    auto filter = factory->createReadFilter(channel_callbacks);
+    if (filter != nullptr) {
+      out.push_back(std::move(filter));
+    }
+  }
+  return out;
+}
+
+std::vector<ChannelFilterPtr> ChannelFilterManager::createWriteFilters(ChannelFilterCallbacks& channel_callbacks) {
+  std::vector<ChannelFilterPtr> out;
+  for (auto& factory : factories_) {
+    auto filter = factory->createWriteFilter(channel_callbacks);
+    if (filter != nullptr) {
+      out.push_back(std::move(filter));
+    }
+  }
+  return out;
+}
+
+} // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/source/extensions/filters/network/ssh/channel_filter_config.cc
+++ b/source/extensions/filters/network/ssh/channel_filter_config.cc
@@ -1,25 +1,55 @@
 #include "source/extensions/filters/network/ssh/channel_filter_config.h"
 
+#pragma clang unsafe_buffer_usage begin
+#include "source/common/config/utility.h"
+#pragma clang unsafe_buffer_usage end
+
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 
-ChannelFilterManager::ChannelFilterManager(Envoy::Server::Configuration::ServerFactoryContext& context,
-                                           std::vector<std::string> names) {
-  for (const auto& name : names) {
-    auto* factoryConfig = Envoy::Registry::FactoryRegistry<ChannelFilterFactoryConfig>::getFactory(name);
-    if (factoryConfig != nullptr) {
-      factories_.push_back(factoryConfig->createChannelFilterFactory(context));
+ChannelFilterManager::ChannelFilterManager(const ExtensionConfigList& enabled_channel_filters,
+                                           Envoy::Server::Configuration::ServerFactoryContext& context)
+    : context_(&context) {
+  for (const auto& config : enabled_channel_filters) {
+    auto* factory = Envoy::Registry::FactoryRegistry<ChannelFilterFactoryConfig>::getFactory(config.name());
+    if (factory == nullptr) {
+      throw Envoy::EnvoyException(fmt::format("no registered channel filter factory found for name: {}", config.name()));
     }
+    auto factoryConfigMsg = Envoy::Config::Utility::translateAnyToFactoryConfig(
+      config.typed_config(), context.messageValidationVisitor(), *factory);
+    auto filterFactory = factory->createChannelFilterFactory(*factoryConfigMsg, context);
+    ASSERT(filterFactory != nullptr);
+    factories_[factory->name()] = std::move(filterFactory);
   }
 }
 
-bool ChannelFilterManager::hasFilters() const {
-  return !factories_.empty();
+size_t ChannelFilterManager::numConfiguredFilters() const {
+  return filter_configs_.size();
+}
+
+absl::Status ChannelFilterManager::configureFilters(const ExtensionConfigList& configs) {
+  std::unordered_map<std::string, ProtobufTypes::MessagePtr> updated;
+  for (const auto& config : configs) {
+    if (!factories_.contains(config.name())) {
+      return absl::NotFoundError(fmt::format("channel filter not found: {}", config.name()));
+    }
+    auto& factory = factories_[config.name()];
+    ProtobufTypes::MessagePtr factoryConfig = factory->createEmptyConfigProto();
+    auto stat = Envoy::Config::Utility::translateOpaqueConfig(
+      config.typed_config(), context_->messageValidationContext().dynamicValidationVisitor(), *factoryConfig);
+    if (!stat.ok()) {
+      return absl::InvalidArgumentError(fmt::format("invalid channel filter config: {}", stat.message()));
+    }
+    updated[config.name()] = std::move(factoryConfig);
+  }
+  filter_configs_.swap(updated);
+  return absl::OkStatus();
 }
 
 std::vector<ChannelFilterPtr> ChannelFilterManager::createReadFilters(ChannelFilterCallbacks& channel_callbacks) {
   std::vector<ChannelFilterPtr> out;
-  for (auto& factory : factories_) {
-    auto filter = factory->createReadFilter(channel_callbacks);
+  for (const auto& [name, config] : filter_configs_) {
+    ASSERT(factories_.contains(name));
+    auto filter = factories_[name]->createReadFilter(*config, channel_callbacks);
     if (filter != nullptr) {
       out.push_back(std::move(filter));
     }
@@ -29,8 +59,9 @@ std::vector<ChannelFilterPtr> ChannelFilterManager::createReadFilters(ChannelFil
 
 std::vector<ChannelFilterPtr> ChannelFilterManager::createWriteFilters(ChannelFilterCallbacks& channel_callbacks) {
   std::vector<ChannelFilterPtr> out;
-  for (auto& factory : factories_) {
-    auto filter = factory->createWriteFilter(channel_callbacks);
+  for (const auto& [name, config] : filter_configs_) {
+    ASSERT(factories_.contains(name));
+    auto filter = factories_[name]->createWriteFilter(*config, channel_callbacks);
     if (filter != nullptr) {
       out.push_back(std::move(filter));
     }

--- a/source/extensions/filters/network/ssh/channel_filter_config.cc
+++ b/source/extensions/filters/network/ssh/channel_filter_config.cc
@@ -4,6 +4,9 @@
 #include "source/common/config/utility.h"
 #pragma clang unsafe_buffer_usage end
 
+template class Envoy::Registry::FactoryRegistry<Envoy::Extensions::NetworkFilters::GenericProxy::Codec::ChannelFilterFactoryConfig>;
+template class Envoy::Registry::FactoryRegistryProxyImpl<Envoy::Extensions::NetworkFilters::GenericProxy::Codec::ChannelFilterFactoryConfig>;
+
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 
 ChannelFilterManager::ChannelFilterManager(const ExtensionConfigList& enabled_channel_filters,

--- a/source/extensions/filters/network/ssh/channel_filter_config.cc
+++ b/source/extensions/filters/network/ssh/channel_filter_config.cc
@@ -30,21 +30,21 @@ size_t ChannelFilterManager::numConfiguredFilters() const {
 }
 
 absl::Status ChannelFilterManager::configureFilters(const ExtensionConfigList& configs) {
-  std::unordered_map<std::string, ProtobufTypes::MessagePtr> updated;
+  std::vector<std::pair<std::string, ProtobufTypes::MessagePtr>> updatedConfigs;
   for (const auto& config : configs) {
     if (!factories_.contains(config.name())) {
       return absl::NotFoundError(fmt::format("channel filter not found: {}", config.name()));
     }
     auto& factory = factories_[config.name()];
-    ProtobufTypes::MessagePtr factoryConfig = factory->createEmptyConfigProto();
+    auto factoryConfig = factory->createEmptyConfigProto();
     auto stat = Envoy::Config::Utility::translateOpaqueConfig(
       config.typed_config(), context_->messageValidationContext().dynamicValidationVisitor(), *factoryConfig);
     if (!stat.ok()) {
       return absl::InvalidArgumentError(fmt::format("invalid channel filter config: {}", stat.message()));
     }
-    updated[config.name()] = std::move(factoryConfig);
+    updatedConfigs.emplace_back(config.name(), std::move(factoryConfig));
   }
-  filter_configs_.swap(updated);
+  filter_configs_.swap(updatedConfigs);
   return absl::OkStatus();
 }
 

--- a/source/extensions/filters/network/ssh/channel_filter_config.h
+++ b/source/extensions/filters/network/ssh/channel_filter_config.h
@@ -52,3 +52,6 @@ private:
 using ChannelFilterManagerSharedPtr = std::shared_ptr<ChannelFilterManager>;
 
 } // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec
+
+extern template class Envoy::Registry::FactoryRegistry<Envoy::Extensions::NetworkFilters::GenericProxy::Codec::ChannelFilterFactoryConfig>;
+extern template class Envoy::Registry::FactoryRegistryProxyImpl<Envoy::Extensions::NetworkFilters::GenericProxy::Codec::ChannelFilterFactoryConfig>;

--- a/source/extensions/filters/network/ssh/channel_filter_config.h
+++ b/source/extensions/filters/network/ssh/channel_filter_config.h
@@ -11,26 +11,32 @@ namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 class ChannelFilterFactory {
 public:
   virtual ~ChannelFilterFactory() = default;
-  virtual ChannelFilterPtr createReadFilter(ChannelFilterCallbacks& channel_callbacks) PURE;
-  virtual ChannelFilterPtr createWriteFilter(ChannelFilterCallbacks& channel_callbacks) PURE;
+  virtual ProtobufTypes::MessagePtr createEmptyConfigProto() PURE;
+  virtual ChannelFilterPtr createReadFilter(const google::protobuf::Message& config, ChannelFilterCallbacks& channel_callbacks) PURE;
+  virtual ChannelFilterPtr createWriteFilter(const google::protobuf::Message& config, ChannelFilterCallbacks& channel_callbacks) PURE;
 };
 using ChannelFilterFactoryPtr = std::unique_ptr<ChannelFilterFactory>;
 
 class ChannelFilterFactoryConfig : public Config::TypedFactory {
 public:
-  virtual ChannelFilterFactoryPtr createChannelFilterFactory(Envoy::Server::Configuration::ServerFactoryContext& context) PURE;
+  virtual ChannelFilterFactoryPtr createChannelFilterFactory(const google::protobuf::Message& config,
+                                                             Envoy::Server::Configuration::ServerFactoryContext& context) PURE;
 
   std::string category() const override {
     return "pomerium.ssh.channel_filters";
   }
 };
 
+using ExtensionConfigList = google::protobuf::RepeatedPtrField<envoy::config::core::v3::TypedExtensionConfig>;
+
 class ChannelFilterManager : NonCopyable {
 public:
-  ChannelFilterManager(Envoy::Server::Configuration::ServerFactoryContext& context,
-                       std::vector<std::string> names);
+  ChannelFilterManager(const ExtensionConfigList& enabled_channel_filters,
+                       Envoy::Server::Configuration::ServerFactoryContext& context);
 
-  bool hasFilters() const;
+  size_t numConfiguredFilters() const;
+  absl::Status configureFilters(const ExtensionConfigList& configs);
+
   std::vector<ChannelFilterPtr> createReadFilters(ChannelFilterCallbacks& channel_callbacks);
   std::vector<ChannelFilterPtr> createWriteFilters(ChannelFilterCallbacks& channel_callbacks);
 
@@ -38,7 +44,9 @@ public:
   ChannelFilterManager(unused_in_this_test) {}
 
 private:
-  std::vector<ChannelFilterFactoryPtr> factories_;
+  Envoy::Server::Configuration::ServerFactoryContext* context_{};
+  std::unordered_map<std::string, ChannelFilterFactoryPtr> factories_;
+  std::unordered_map<std::string, ProtobufTypes::MessagePtr> filter_configs_;
 };
 
 using ChannelFilterManagerSharedPtr = std::shared_ptr<ChannelFilterManager>;

--- a/source/extensions/filters/network/ssh/channel_filter_config.h
+++ b/source/extensions/filters/network/ssh/channel_filter_config.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#pragma clang unsafe_buffer_usage begin
+#include "envoy/config/typed_config.h"
+#include "envoy/server/factory_context.h"
+#pragma clang unsafe_buffer_usage end
+#include "source/extensions/filters/network/ssh/channel_filter.h"
+
+namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
+
+class ChannelFilterFactory {
+public:
+  virtual ~ChannelFilterFactory() = default;
+  virtual ChannelFilterPtr createReadFilter(ChannelFilterCallbacks& channel_callbacks) PURE;
+  virtual ChannelFilterPtr createWriteFilter(ChannelFilterCallbacks& channel_callbacks) PURE;
+};
+using ChannelFilterFactoryPtr = std::unique_ptr<ChannelFilterFactory>;
+
+class ChannelFilterFactoryConfig : public Config::TypedFactory {
+public:
+  virtual ChannelFilterFactoryPtr createChannelFilterFactory(Envoy::Server::Configuration::ServerFactoryContext& context) PURE;
+
+  std::string category() const override {
+    return "pomerium.ssh.channel_filters";
+  }
+};
+
+class ChannelFilterManager : NonCopyable {
+public:
+  ChannelFilterManager(Envoy::Server::Configuration::ServerFactoryContext& context,
+                       std::vector<std::string> names);
+
+  bool hasFilters() const;
+  std::vector<ChannelFilterPtr> createReadFilters(ChannelFilterCallbacks& channel_callbacks);
+  std::vector<ChannelFilterPtr> createWriteFilters(ChannelFilterCallbacks& channel_callbacks);
+
+  struct unused_in_this_test {};
+  ChannelFilterManager(unused_in_this_test) {}
+
+private:
+  std::vector<ChannelFilterFactoryPtr> factories_;
+};
+
+using ChannelFilterManagerSharedPtr = std::shared_ptr<ChannelFilterManager>;
+
+} // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/source/extensions/filters/network/ssh/channel_filter_config.h
+++ b/source/extensions/filters/network/ssh/channel_filter_config.h
@@ -29,7 +29,8 @@ public:
 
 using ExtensionConfigList = google::protobuf::RepeatedPtrField<envoy::config::core::v3::TypedExtensionConfig>;
 
-class ChannelFilterManager : NonCopyable {
+class ChannelFilterManager : NonCopyable,
+                             public StreamInfo::FilterState::Object {
 public:
   ChannelFilterManager(const ExtensionConfigList& enabled_channel_filters,
                        Envoy::Server::Configuration::ServerFactoryContext& context);

--- a/source/extensions/filters/network/ssh/channel_filter_config.h
+++ b/source/extensions/filters/network/ssh/channel_filter_config.h
@@ -47,7 +47,7 @@ public:
 private:
   Envoy::Server::Configuration::ServerFactoryContext* context_{};
   std::unordered_map<std::string, ChannelFilterFactoryPtr> factories_;
-  std::unordered_map<std::string, ProtobufTypes::MessagePtr> filter_configs_;
+  std::vector<std::pair<std::string, ProtobufTypes::MessagePtr>> filter_configs_;
 };
 
 using ChannelFilterManagerSharedPtr = std::shared_ptr<ChannelFilterManager>;

--- a/source/extensions/filters/network/ssh/client_transport.cc
+++ b/source/extensions/filters/network/ssh/client_transport.cc
@@ -33,8 +33,10 @@ private:
 SshClientTransport::SshClientTransport(
   Envoy::Server::Configuration::ServerFactoryContext& context,
   std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config,
+  ChannelFilterManagerSharedPtr channel_filter_manager,
   const SecretsProvider& secrets_provider)
-    : TransportBase(context, std::move(config), secrets_provider) {
+    : TransportBase(context, std::move(config), secrets_provider),
+      channel_filter_manager_(channel_filter_manager) {
   wire::ExtInfoMsg extInfo;
   extInfo.extensions->emplace_back(wire::PingExtension{.version = "0"s});
   outgoing_ext_info_ = std::move(extInfo);

--- a/source/extensions/filters/network/ssh/client_transport.cc
+++ b/source/extensions/filters/network/ssh/client_transport.cc
@@ -33,10 +33,8 @@ private:
 SshClientTransport::SshClientTransport(
   Envoy::Server::Configuration::ServerFactoryContext& context,
   std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config,
-  ChannelFilterManagerSharedPtr channel_filter_manager,
   const SecretsProvider& secrets_provider)
-    : TransportBase(context, std::move(config), secrets_provider),
-      channel_filter_manager_(channel_filter_manager) {
+    : TransportBase(context, std::move(config), secrets_provider) {
   wire::ExtInfoMsg extInfo;
   extInfo.extensions->emplace_back(wire::PingExtension{.version = "0"s});
   outgoing_ext_info_ = std::move(extInfo);
@@ -93,6 +91,7 @@ GenericProxy::EncodingResult SshClientTransport::encode(const GenericProxy::Stre
     connection_dispatcher_ = callbacks_->connection()->dispatcher();
 
     ASSERT(filterState->hasDataWithName(ChannelIDManagerFilterStateKey));
+    ASSERT(filterState->hasDataWithName(ChannelFilterManagerFilterStateKey));
     ASSERT(filterState->hasDataWithName(AuthInfoFilterStateKey));
     ASSERT(filterState->hasDataWithName(RequestedServerName::key()));
     ASSERT(filterState->hasDataWithName(DownstreamSourceAddressFilterStateFactory::key()));
@@ -101,6 +100,8 @@ GenericProxy::EncodingResult SshClientTransport::encode(const GenericProxy::Stre
       filterState->getDataSharedMutableGeneric(AuthInfoFilterStateKey));
     channel_id_manager_ = std::dynamic_pointer_cast<ChannelIDManager>(
       filterState->getDataSharedMutableGeneric(ChannelIDManagerFilterStateKey));
+    channel_filter_manager_ = std::dynamic_pointer_cast<ChannelFilterManager>(
+      filterState->getDataSharedMutableGeneric(ChannelFilterManagerFilterStateKey));
     if (auth_info_->channel_mode == ChannelMode::Handoff) {
       if (auth_info_->allow_response->has_upstream()) {
         ASSERT(auth_info_->handoff_info.handoff_in_progress);

--- a/source/extensions/filters/network/ssh/client_transport.h
+++ b/source/extensions/filters/network/ssh/client_transport.h
@@ -10,7 +10,7 @@
 #include "source/extensions/filters/network/ssh/service.h"
 #include "source/extensions/filters/network/ssh/wire/messages.h"
 #include "source/extensions/filters/network/ssh/transport_base.h"
-#include "source/extensions/filters/network/ssh/channel_filter.h"
+#include "source/extensions/filters/network/ssh/channel_filter_config.h"
 
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 

--- a/source/extensions/filters/network/ssh/client_transport.h
+++ b/source/extensions/filters/network/ssh/client_transport.h
@@ -10,6 +10,7 @@
 #include "source/extensions/filters/network/ssh/service.h"
 #include "source/extensions/filters/network/ssh/wire/messages.h"
 #include "source/extensions/filters/network/ssh/transport_base.h"
+#include "source/extensions/filters/network/ssh/channel_filter.h"
 
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 
@@ -30,6 +31,7 @@ class SshClientTransport final : public TransportBase<ClientCodec>,
 public:
   SshClientTransport(Envoy::Server::Configuration::ServerFactoryContext& context,
                      std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config,
+                     ChannelFilterManagerSharedPtr channel_filter_manager,
                      const SecretsProvider& secrets_provider);
   void setCodecCallbacks(GenericProxy::ClientCodecCallbacks& callbacks) override;
 
@@ -53,6 +55,8 @@ public:
     return *channel_id_manager_;
   }
 
+  ChannelFilterManager& channelFilterManager() override { return *channel_filter_manager_; }
+
   void onHandoffComplete() override {
     // handoff is complete, send an empty message to signal the downstream codec
     forwardHeader(wire::IgnoreMsg{}, Sentinel);
@@ -75,6 +79,7 @@ private:
   Envoy::OptRef<Envoy::Event::Dispatcher> connection_dispatcher_;
   std::shared_ptr<ChannelIDManager> channel_id_manager_; // shared with downstream
   std::unique_ptr<PingExtensionHandler> ping_handler_;
+  ChannelFilterManagerSharedPtr channel_filter_manager_;
 
   std::unique_ptr<Envoy::Event::DeferredDeletable> handoff_middleware_;
 

--- a/source/extensions/filters/network/ssh/client_transport.h
+++ b/source/extensions/filters/network/ssh/client_transport.h
@@ -31,7 +31,6 @@ class SshClientTransport final : public TransportBase<ClientCodec>,
 public:
   SshClientTransport(Envoy::Server::Configuration::ServerFactoryContext& context,
                      std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config,
-                     ChannelFilterManagerSharedPtr channel_filter_manager,
                      const SecretsProvider& secrets_provider);
   void setCodecCallbacks(GenericProxy::ClientCodecCallbacks& callbacks) override;
 
@@ -55,7 +54,10 @@ public:
     return *channel_id_manager_;
   }
 
-  ChannelFilterManager& channelFilterManager() override { return *channel_filter_manager_; }
+  ChannelFilterManager& channelFilterManager() override {
+    ASSERT(channel_filter_manager_ != nullptr);
+    return *channel_filter_manager_;
+  }
 
   void onHandoffComplete() override {
     // handoff is complete, send an empty message to signal the downstream codec
@@ -79,7 +81,7 @@ private:
   Envoy::OptRef<Envoy::Event::Dispatcher> connection_dispatcher_;
   std::shared_ptr<ChannelIDManager> channel_id_manager_; // shared with downstream
   std::unique_ptr<PingExtensionHandler> ping_handler_;
-  ChannelFilterManagerSharedPtr channel_filter_manager_;
+  ChannelFilterManagerSharedPtr channel_filter_manager_; // shared with downstream
 
   std::unique_ptr<Envoy::Event::DeferredDeletable> handoff_middleware_;
 

--- a/source/extensions/filters/network/ssh/config.cc
+++ b/source/extensions/filters/network/ssh/config.cc
@@ -48,9 +48,8 @@ SshCodecFactory::SshCodecFactory(Envoy::Server::Configuration::ServerFactoryCont
   }
   host_keys_ = std::move(hostKeys).value();
 
-  std::vector<std::string> channelFilters{config_->enabled_channel_filters().begin(),
-                                          config_->enabled_channel_filters().end()};
-  channel_filter_manager_ = std::make_shared<ChannelFilterManager>(context, channelFilters);
+  channel_filter_manager_ = std::make_shared<ChannelFilterManager>(
+    config->enabled_channel_filters(), context);
 }
 
 ServerCodecPtr SshCodecFactory::createServerCodec() const {

--- a/source/extensions/filters/network/ssh/config.cc
+++ b/source/extensions/filters/network/ssh/config.cc
@@ -47,15 +47,19 @@ SshCodecFactory::SshCodecFactory(Envoy::Server::Configuration::ServerFactoryCont
     throw Envoy::EnvoyException(statusToString(hostKeys.status()));
   }
   host_keys_ = std::move(hostKeys).value();
+
+  std::vector<std::string> channelFilters{config_->enabled_channel_filters().begin(),
+                                          config_->enabled_channel_filters().end()};
+  channel_filter_manager_ = std::make_shared<ChannelFilterManager>(context, channelFilters);
 }
 
 ServerCodecPtr SshCodecFactory::createServerCodec() const {
   return std::make_unique<SshServerTransport>(context_, config_, create_grpc_client_,
-                                              stream_tracker_, *this);
+                                              stream_tracker_, channel_filter_manager_, *this);
 }
 
 ClientCodecPtr SshCodecFactory::createClientCodec() const {
-  return std::make_unique<SshClientTransport>(context_, config_, *this);
+  return std::make_unique<SshClientTransport>(context_, config_, channel_filter_manager_, *this);
 }
 
 ProtobufTypes::MessagePtr SshCodecFactoryConfig::createEmptyConfigProto() {

--- a/source/extensions/filters/network/ssh/config.cc
+++ b/source/extensions/filters/network/ssh/config.cc
@@ -47,18 +47,15 @@ SshCodecFactory::SshCodecFactory(Envoy::Server::Configuration::ServerFactoryCont
     throw Envoy::EnvoyException(statusToString(hostKeys.status()));
   }
   host_keys_ = std::move(hostKeys).value();
-
-  channel_filter_manager_ = std::make_shared<ChannelFilterManager>(
-    config->enabled_channel_filter_factories(), context);
 }
 
 ServerCodecPtr SshCodecFactory::createServerCodec() const {
   return std::make_unique<SshServerTransport>(context_, config_, create_grpc_client_,
-                                              stream_tracker_, channel_filter_manager_, *this);
+                                              stream_tracker_, *this);
 }
 
 ClientCodecPtr SshCodecFactory::createClientCodec() const {
-  return std::make_unique<SshClientTransport>(context_, config_, channel_filter_manager_, *this);
+  return std::make_unique<SshClientTransport>(context_, config_, *this);
 }
 
 ProtobufTypes::MessagePtr SshCodecFactoryConfig::createEmptyConfigProto() {

--- a/source/extensions/filters/network/ssh/config.cc
+++ b/source/extensions/filters/network/ssh/config.cc
@@ -49,7 +49,7 @@ SshCodecFactory::SshCodecFactory(Envoy::Server::Configuration::ServerFactoryCont
   host_keys_ = std::move(hostKeys).value();
 
   channel_filter_manager_ = std::make_shared<ChannelFilterManager>(
-    config->enabled_channel_filters(), context);
+    config->enabled_channel_filter_factories(), context);
 }
 
 ServerCodecPtr SshCodecFactory::createServerCodec() const {

--- a/source/extensions/filters/network/ssh/config.h
+++ b/source/extensions/filters/network/ssh/config.h
@@ -12,7 +12,7 @@
 #include "source/extensions/filters/network/ssh/transport.h"
 #include "source/extensions/filters/network/ssh/stream_tracker.h"
 #include "source/extensions/filters/network/ssh/grpc_client_impl.h"
-#include "source/extensions/filters/network/ssh/channel_filter.h"
+#include "source/extensions/filters/network/ssh/channel_filter_config.h"
 
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 class SshCodecFactoryConfig : public CodecFactoryConfig {

--- a/source/extensions/filters/network/ssh/config.h
+++ b/source/extensions/filters/network/ssh/config.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <cerrno>
-#include <unistd.h>
-
 #include "source/common/apple.h"
 
 #pragma clang unsafe_buffer_usage begin
@@ -15,6 +12,7 @@
 #include "source/extensions/filters/network/ssh/transport.h"
 #include "source/extensions/filters/network/ssh/stream_tracker.h"
 #include "source/extensions/filters/network/ssh/grpc_client_impl.h"
+#include "source/extensions/filters/network/ssh/channel_filter.h"
 
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 class SshCodecFactoryConfig : public CodecFactoryConfig {
@@ -47,6 +45,7 @@ private:
   std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config_;
   CreateGrpcClientFunc create_grpc_client_;
   StreamTrackerSharedPtr stream_tracker_;
+  ChannelFilterManagerSharedPtr channel_filter_manager_;
 
   std::vector<openssh::SSHKeySharedPtr> host_keys_;
   openssh::SSHKeySharedPtr user_ca_key_;

--- a/source/extensions/filters/network/ssh/config.h
+++ b/source/extensions/filters/network/ssh/config.h
@@ -45,7 +45,6 @@ private:
   std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config_;
   CreateGrpcClientFunc create_grpc_client_;
   StreamTrackerSharedPtr stream_tracker_;
-  ChannelFilterManagerSharedPtr channel_filter_manager_;
 
   std::vector<openssh::SSHKeySharedPtr> host_keys_;
   openssh::SSHKeySharedPtr user_ca_key_;

--- a/source/extensions/filters/network/ssh/filter_state_objects.h
+++ b/source/extensions/filters/network/ssh/filter_state_objects.h
@@ -4,6 +4,9 @@
 #include "source/common/network/filter_state_dst_address.h"
 #pragma clang unsafe_buffer_usage end
 
+#include "source/extensions/filters/network/ssh/transport_common.h"
+#include "source/extensions/filters/network/ssh/wire/messages.h"
+
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 
 class DownstreamSourceAddressFilterStateFactory : public Network::BaseAddressObjectFactory {
@@ -51,6 +54,18 @@ public:
     return std::make_unique<RequestedPath>(data);
   }
 };
+
+struct AuthInfo : public StreamInfo::FilterState::Object {
+  std::string server_version;
+  stream_id_t stream_id{}; // unique stream id for both connections
+  ChannelMode channel_mode{};
+  HandoffInfo handoff_info;
+  std::optional<wire::ExtInfoMsg> downstream_ext_info;
+  std::optional<wire::ExtInfoMsg> upstream_ext_info;
+  std::unique_ptr<pomerium::extensions::ssh::AllowResponse> allow_response;
+};
+
+using AuthInfoSharedPtr = std::shared_ptr<AuthInfo>;
 
 constexpr std::string_view ChannelIDManagerFilterStateKey = "pomerium.extensions.ssh.channel_id_manager";
 constexpr std::string_view AuthInfoFilterStateKey = "pomerium.extensions.ssh.auth_info";

--- a/source/extensions/filters/network/ssh/filter_state_objects.h
+++ b/source/extensions/filters/network/ssh/filter_state_objects.h
@@ -68,6 +68,7 @@ struct AuthInfo : public StreamInfo::FilterState::Object {
 using AuthInfoSharedPtr = std::shared_ptr<AuthInfo>;
 
 constexpr std::string_view ChannelIDManagerFilterStateKey = "pomerium.extensions.ssh.channel_id_manager";
+constexpr std::string_view ChannelFilterManagerFilterStateKey = "pomerium.extensions.ssh.channel_filter_manager";
 constexpr std::string_view AuthInfoFilterStateKey = "pomerium.extensions.ssh.auth_info";
 
 } // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/source/extensions/filters/network/ssh/id_manager.h
+++ b/source/extensions/filters/network/ssh/id_manager.h
@@ -197,7 +197,7 @@ private:
   IDAllocator<uint32_t> id_alloc_;
   bool draining_{false};
   std::shared_ptr<Envoy::Common::ThreadSafeCallbackManager> drain_cb_ =
-    Common::ThreadSafeCallbackManager::create();
+    Envoy::Common::ThreadSafeCallbackManager::create();
 };
 
 } // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/source/extensions/filters/network/ssh/server_transport.cc
+++ b/source/extensions/filters/network/ssh/server_transport.cc
@@ -380,6 +380,13 @@ void SshServerTransport::initUpstream(AuthInfoSharedPtr auth_info) {
     setRequestedServerName(filterState, hostname);
     setDownstreamSourceAddress(filterState, callbacks_->connection()->streamInfo().downstreamAddressProvider().remoteAddress());
 
+    if (auto stat = channel_filter_manager_->configureFilters(
+          auth_info_->allow_response->upstream().channel_filters());
+        !stat.ok()) {
+      terminate(stat);
+      return;
+    }
+
     auto frame = std::make_unique<SSHRequestHeaderFrame>(hostname, stream_id_);
     callbacks_->onDecodingSuccess(std::move(frame));
     if (respond_called_) {
@@ -406,6 +413,13 @@ void SshServerTransport::initUpstream(AuthInfoSharedPtr auth_info) {
     auto hostname = auth_info_->allow_response->upstream().hostname();
     setRequestedServerName(filterState, hostname);
     setDownstreamSourceAddress(filterState, callbacks_->connection()->streamInfo().downstreamAddressProvider().remoteAddress());
+
+    if (auto stat = channel_filter_manager_->configureFilters(
+          auth_info_->allow_response->upstream().channel_filters());
+        !stat.ok()) {
+      terminate(stat);
+      return;
+    }
 
     auto frame = std::make_unique<SSHRequestHeaderFrame>(hostname, stream_id_);
     ENVOY_LOG(debug, "disabling reads on downstream connection for handoff");

--- a/source/extensions/filters/network/ssh/server_transport.cc
+++ b/source/extensions/filters/network/ssh/server_transport.cc
@@ -59,10 +59,12 @@ SshServerTransport::SshServerTransport(Server::Configuration::ServerFactoryConte
                                        std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config,
                                        CreateGrpcClientFunc create_grpc_client,
                                        StreamTrackerSharedPtr stream_tracker,
+                                       ChannelFilterManagerSharedPtr channel_filter_manager,
                                        const SecretsProvider& secrets_provider)
     : TransportBase(context, std::move(config), secrets_provider),
       DownstreamTransportCallbacks(*this),
-      stream_tracker_(std::move(stream_tracker)) {
+      stream_tracker_(std::move(stream_tracker)),
+      channel_filter_manager_(channel_filter_manager) {
   auto grpcClient = create_grpc_client();
   THROW_IF_NOT_OK_REF(grpcClient.status());
   grpc_client_ = *grpcClient;

--- a/source/extensions/filters/network/ssh/server_transport.cc
+++ b/source/extensions/filters/network/ssh/server_transport.cc
@@ -11,6 +11,7 @@
 #include "source/common/network/utility.h"
 
 #include "source/common/status.h"
+#include "source/extensions/filters/network/ssh/channel_filter_config.h"
 #include "source/extensions/filters/network/ssh/common.h"
 #include "source/extensions/filters/network/ssh/filter_state_objects.h"
 #include "source/extensions/filters/network/ssh/frame.h"
@@ -53,18 +54,26 @@ void setChannelIdManager(const StreamInfo::FilterStateSharedPtr& filter_state, s
                         StreamInfo::FilterState::LifeSpan::Request,
                         StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnectionOnce);
 }
+
+void setChannelFilterManager(const StreamInfo::FilterStateSharedPtr& filter_state, ChannelFilterManagerSharedPtr channel_filter_mgr) {
+  filter_state->setData(ChannelFilterManagerFilterStateKey,
+                        channel_filter_mgr,
+                        StreamInfo::FilterState::StateType::Mutable,
+                        StreamInfo::FilterState::LifeSpan::Request,
+                        StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnectionOnce);
+}
 } // namespace
 
 SshServerTransport::SshServerTransport(Server::Configuration::ServerFactoryContext& context,
                                        std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config,
                                        CreateGrpcClientFunc create_grpc_client,
                                        StreamTrackerSharedPtr stream_tracker,
-                                       ChannelFilterManagerSharedPtr channel_filter_manager,
                                        const SecretsProvider& secrets_provider)
     : TransportBase(context, std::move(config), secrets_provider),
       DownstreamTransportCallbacks(*this),
       stream_tracker_(std::move(stream_tracker)),
-      channel_filter_manager_(channel_filter_manager) {
+      channel_filter_manager_(std::make_shared<ChannelFilterManager>(
+        config_->enabled_channel_filter_factories(), context)) {
   auto grpcClient = create_grpc_client();
   THROW_IF_NOT_OK_REF(grpcClient.status());
   grpc_client_ = *grpcClient;
@@ -109,6 +118,7 @@ void SshServerTransport::onConnected() {
   }
   channel_id_manager_ = std::make_shared<ChannelIDManager>(config_->internal_channel_id_start(), maxConcurrentChannels);
   setChannelIdManager(conn.streamInfo().filterState(), channel_id_manager_);
+  setChannelFilterManager(conn.streamInfo().filterState(), channel_filter_manager_);
   initServices();
   mgmt_client_->setOnRemoteCloseCallback([this](Grpc::Status::GrpcStatus status, std::string message) {
     if (status != Grpc::Status::PermissionDenied) {

--- a/source/extensions/filters/network/ssh/server_transport.h
+++ b/source/extensions/filters/network/ssh/server_transport.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "source/extensions/filters/network/ssh/channel_filter.h"
 #pragma clang unsafe_buffer_usage begin
 #include "source/extensions/filters/network/generic_proxy/codec_callbacks.h"
 #include "api/extensions/filters/network/ssh/ssh.pb.h"
@@ -17,6 +16,7 @@
 #include "source/extensions/filters/network/ssh/wire/messages.h"
 #include "source/extensions/filters/network/ssh/transport_base.h"
 #include "source/extensions/filters/network/ssh/service_connection.h"
+#include "source/extensions/filters/network/ssh/channel_filter_config.h"
 
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 

--- a/source/extensions/filters/network/ssh/server_transport.h
+++ b/source/extensions/filters/network/ssh/server_transport.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "source/extensions/filters/network/ssh/channel_filter.h"
 #pragma clang unsafe_buffer_usage begin
 #include "source/extensions/filters/network/generic_proxy/codec_callbacks.h"
 #include "api/extensions/filters/network/ssh/ssh.pb.h"
@@ -31,6 +32,7 @@ public:
                      std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config,
                      CreateGrpcClientFunc create_grpc_client,
                      StreamTrackerSharedPtr active_stream_tracker,
+                     ChannelFilterManagerSharedPtr channel_filter_manager,
                      const SecretsProvider& secrets_provider);
 
   void onConnected() override;
@@ -53,6 +55,7 @@ public:
   stream_id_t streamId() const override { return stream_id_; }
 
   ChannelIDManager& channelIdManager() override { return *channel_id_manager_; }
+  ChannelFilterManager& channelFilterManager() override { return *channel_filter_manager_; }
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;
@@ -84,6 +87,7 @@ private:
   std::shared_ptr<ChannelIDManager> channel_id_manager_;
   std::unique_ptr<PingExtensionHandler> ping_handler_;
   StreamTrackerSharedPtr stream_tracker_;
+  ChannelFilterManagerSharedPtr channel_filter_manager_;
 
   std::unique_ptr<StreamManagementServiceClient> mgmt_client_;
   std::shared_ptr<ChannelStreamServiceClient> channel_client_;

--- a/source/extensions/filters/network/ssh/server_transport.h
+++ b/source/extensions/filters/network/ssh/server_transport.h
@@ -32,7 +32,6 @@ public:
                      std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config,
                      CreateGrpcClientFunc create_grpc_client,
                      StreamTrackerSharedPtr active_stream_tracker,
-                     ChannelFilterManagerSharedPtr channel_filter_manager,
                      const SecretsProvider& secrets_provider);
 
   void onConnected() override;

--- a/source/extensions/filters/network/ssh/service_connection.cc
+++ b/source/extensions/filters/network/ssh/service_connection.cc
@@ -48,7 +48,7 @@ absl::StatusOr<uint32_t> ConnectionService::startChannel(std::unique_ptr<Channel
   RELEASE_ASSERT(!channels_.contains(*channelId), fmt::format("bug: channel with ID {} already exists", *channelId));
 
   auto callbacks = std::make_unique<ChannelCallbacksImpl>(*this, *channelId, local_peer_);
-  if (auto& filterMgr = transport_.channelFilterManager(); filterMgr.hasFilters()) {
+  if (auto& filterMgr = transport_.channelFilterManager(); filterMgr.numConfiguredFilters() > 0) {
     std::vector<ChannelFilterPtr> filters;
     switch (local_peer_) {
     case Downstream:

--- a/source/extensions/filters/network/ssh/service_connection.cc
+++ b/source/extensions/filters/network/ssh/service_connection.cc
@@ -2,7 +2,6 @@
 
 #include "api/extensions/filters/network/ssh/ssh.pb.h"
 #include "source/common/status.h"
-// #include "source/extensions/filters/network/ssh/channel_filter.h"
 #include "source/extensions/filters/network/ssh/id_manager.h"
 #include "source/extensions/filters/network/ssh/wire/common.h"
 #include "source/extensions/filters/network/ssh/wire/messages.h"
@@ -59,7 +58,9 @@ absl::StatusOr<uint32_t> ConnectionService::startChannel(std::unique_ptr<Channel
       filters = filterMgr.createWriteFilters(*callbacks);
       break;
     }
-    callbacks->setChannelFilters(std::move(filters));
+    if (!filters.empty()) {
+      callbacks->setChannelFilters(std::move(filters));
+    }
   }
 
   channel->setChannelCallbacks(*callbacks);
@@ -139,8 +140,9 @@ absl::Status ConnectionService::handleMessage(wire::Message&& msg) {
       ASSERT(channels_.contains(msg.recipient_channel));
       ENVOY_LOG(debug, "internal channel opened successfully: id={}", *msg.recipient_channel);
       // Before passing the message to be handled by the channel, set both IDs to the internal ID
-      // so that if the channel forwards the message, the sender ID will be correctly rewritten
-      // to the ID we just tracked above
+      // so that if the channel forwards the message, the sender ID will be correct. Only the
+      // recipient_channel fields of channel messages are remapped (ChannelOpenConfirmation is
+      // considered a channel message, unlike ChannelOpen)
       msg.sender_channel = msg.recipient_channel;
       if (auto stat = channels_[msg.sender_channel]->readMessage(std::move(msg)); !stat.ok()) {
         return statusf("error opening channel: {}", stat);
@@ -354,41 +356,55 @@ void ConnectionService::ChannelCallbacksImpl::sendMessageLocal(wire::Message&& m
 }
 
 absl::Status ConnectionService::ChannelCallbacksImpl::sendMessageRemote(wire::Message&& msg) {
-  return msg.visit(
-    [&](wire::ChannelOpenMsg& msg) {
-      ENVOY_LOG(debug, "sending ChannelOpen message to remote for channel {}", channel_id_);
-
+  auto sendOk = msg.visit(
+    [&](wire::ChannelOpenMsg& msg) -> absl::StatusOr<bool> {
       ASSERT(!channel_type_.has_value());
       channel_type_ = msg.channel_type();
 
       msg.sender_channel = channel_id_;
-      parent_.transport_.forward(std::move(msg));
-      return absl::OkStatus();
+      return true;
     },
-    [&](wire::ChannelMsg auto& msg) {
+    [&](wire::ChannelMsg auto& msg) -> absl::StatusOr<bool> {
       msg.recipient_channel = channel_id_;
-      auto sendOk = channel_id_mgr_.processOutgoingChannelMsg(msg, local_peer_ == Peer::Downstream
-                                                                     ? Peer::Upstream
-                                                                     : Peer::Downstream);
-      if (!sendOk.ok()) {
-        return sendOk.status();
-      }
-      if (!*sendOk) {
-        ENVOY_LOG(debug, "message for remote channel {} dropped: {}", channel_id_, msg.msg_type());
-        return absl::OkStatus();
-      }
-      ENVOY_LOG(debug, "sending messsage to remote channel {}: {}", channel_id_, msg.msg_type());
-      parent_.transport_.forward(std::move(msg));
-      return absl::OkStatus();
+      return channel_id_mgr_.processOutgoingChannelMsg(msg, local_peer_ == Peer::Downstream
+                                                              ? Peer::Upstream
+                                                              : Peer::Downstream);
     },
-    [&](auto&) -> absl::Status {
+    [](auto&) -> absl::StatusOr<bool> {
       throw Envoy::EnvoyException("bug: invalid message passed to sendMessageRemote()");
     });
+
+  if (!sendOk.ok()) {
+    return sendOk.status();
+  }
+
+  if (!*sendOk) {
+    ENVOY_LOG(debug, "message for remote channel {} dropped: {}", channel_id_, msg.msg_type());
+    return absl::OkStatus();
+  }
+
+  for (auto& filter : filters_) {
+    filter->onMessageForward(std::as_const(msg));
+  }
+
+  ENVOY_LOG(debug, "sending messsage to remote channel {}: {}", channel_id_, msg.msg_type());
+  parent_.transport_.forward(std::move(msg));
+  return absl::OkStatus();
 }
 
 Envoy::Common::CallbackHandlePtr
 ConnectionService::ChannelCallbacksImpl::addInterruptCallback(std::function<void(absl::Status, TransportCallbacks& transport)> cb) {
   return interrupt_callbacks_->add(std::move(cb));
+}
+
+bool ConnectionService::ChannelCallbacksImpl::interruptChannel(absl::Status err) {
+  ENVOY_LOG(debug, "ssh: stream {}: interrupt requested for channel {} by a channel filter",
+            parent_.transport_.streamId(), channel_id_);
+  if (channel_id_mgr_.isPreemptable(channel_id_, local_peer_)) {
+    parent_.preempt(*this, err);
+    return true;
+  }
+  return false;
 }
 
 void ConnectionService::preempt(ChannelCallbacks& ccb, absl::Status err) {

--- a/source/extensions/filters/network/ssh/service_connection.cc
+++ b/source/extensions/filters/network/ssh/service_connection.cc
@@ -2,6 +2,7 @@
 
 #include "api/extensions/filters/network/ssh/ssh.pb.h"
 #include "source/common/status.h"
+// #include "source/extensions/filters/network/ssh/channel_filter.h"
 #include "source/extensions/filters/network/ssh/id_manager.h"
 #include "source/extensions/filters/network/ssh/wire/common.h"
 #include "source/extensions/filters/network/ssh/wire/messages.h"
@@ -48,6 +49,18 @@ absl::StatusOr<uint32_t> ConnectionService::startChannel(std::unique_ptr<Channel
   RELEASE_ASSERT(!channels_.contains(*channelId), fmt::format("bug: channel with ID {} already exists", *channelId));
 
   auto callbacks = std::make_unique<ChannelCallbacksImpl>(*this, *channelId, local_peer_);
+  if (auto& filterMgr = transport_.channelFilterManager(); filterMgr.hasFilters()) {
+    std::vector<ChannelFilterPtr> filters;
+    switch (local_peer_) {
+    case Downstream:
+      filters = filterMgr.createReadFilters(*callbacks);
+      break;
+    case Upstream:
+      filters = filterMgr.createWriteFilters(*callbacks);
+      break;
+    }
+    callbacks->setChannelFilters(std::move(filters));
+  }
 
   channel->setChannelCallbacks(*callbacks);
   // Note: order is important here; if readChannelOpen below fails, the callbacks cleanup routine
@@ -269,6 +282,11 @@ void ConnectionService::ChannelCallbacksImpl::sendMessageLocal(wire::Message&& m
   std::unique_ptr<Channel> deferredDelete;
 
   bool send = msg.visit(
+    [&](wire::ChannelOpenMsg& msg) {
+      ASSERT(!channel_type_.has_value());
+      channel_type_ = msg.channel_type();
+      return true;
+    },
     [&](wire::ChannelCloseMsg& msg) {
       msg.recipient_channel = channel_id_;
       auto sendOk = channel_id_mgr_.processOutgoingChannelMsg(msg, local_peer_);
@@ -339,6 +357,10 @@ absl::Status ConnectionService::ChannelCallbacksImpl::sendMessageRemote(wire::Me
   return msg.visit(
     [&](wire::ChannelOpenMsg& msg) {
       ENVOY_LOG(debug, "sending ChannelOpen message to remote for channel {}", channel_id_);
+
+      ASSERT(!channel_type_.has_value());
+      channel_type_ = msg.channel_type();
+
       msg.sender_channel = channel_id_;
       parent_.transport_.forward(std::move(msg));
       return absl::OkStatus();

--- a/source/extensions/filters/network/ssh/service_connection.cc
+++ b/source/extensions/filters/network/ssh/service_connection.cc
@@ -398,6 +398,7 @@ ConnectionService::ChannelCallbacksImpl::addInterruptCallback(std::function<void
 }
 
 bool ConnectionService::ChannelCallbacksImpl::interruptChannel(absl::Status err) {
+  ASSERT(parent_.transport_.connectionDispatcher()->isThreadSafe());
   ENVOY_LOG(debug, "ssh: stream {}: interrupt requested for channel {} by a channel filter",
             parent_.transport_.streamId(), channel_id_);
   if (channel_id_mgr_.isPreemptable(channel_id_, local_peer_)) {

--- a/source/extensions/filters/network/ssh/service_connection.cc
+++ b/source/extensions/filters/network/ssh/service_connection.cc
@@ -349,7 +349,7 @@ void ConnectionService::ChannelCallbacksImpl::sendMessageLocal(wire::Message&& m
   // this channel via ChannelCloseMsg, so defer to the transport for error handling and cleanup.
   // The channel calling this function wouldn't be able to do much else about an error at this
   // level either (this is not necessarily the case for sendMessageRemote, though).
-  ENVOY_LOG(debug, "sending message to local channel {}: {}", channel_id_, msg.msg_type());
+  ENVOY_LOG(trace, "sending message to local channel {}: {}", channel_id_, msg.msg_type());
   if (auto stat = parent_.transport_.sendMessageToConnection(std::move(msg)); !stat.ok()) {
     parent_.transport_.terminate(stat.status());
   }
@@ -387,7 +387,7 @@ absl::Status ConnectionService::ChannelCallbacksImpl::sendMessageRemote(wire::Me
     filter->onMessageForward(std::as_const(msg));
   }
 
-  ENVOY_LOG(debug, "sending messsage to remote channel {}: {}", channel_id_, msg.msg_type());
+  ENVOY_LOG(trace, "sending messsage to remote channel {}: {}", channel_id_, msg.msg_type());
   parent_.transport_.forward(std::move(msg));
   return absl::OkStatus();
 }

--- a/source/extensions/filters/network/ssh/service_connection.h
+++ b/source/extensions/filters/network/ssh/service_connection.h
@@ -77,6 +77,9 @@ public:
 
     // ChannelFilterCallbacks
     bool interruptChannel(absl::Status err) override;
+    stream_id_t streamId() const override {
+      return parent_.transport_.streamId();
+    }
 
   private:
     void cleanup() override;

--- a/source/extensions/filters/network/ssh/service_connection.h
+++ b/source/extensions/filters/network/ssh/service_connection.h
@@ -77,9 +77,8 @@ public:
 
     // ChannelFilterCallbacks
     bool interruptChannel(absl::Status err) override;
-    stream_id_t streamId() const override {
-      return parent_.transport_.streamId();
-    }
+    stream_id_t streamId() const override { return parent_.transport_.streamId(); }
+    const AuthInfo& authInfo() const override { return parent_.transport_.authInfo(); }
 
   private:
     void cleanup() override;

--- a/source/extensions/filters/network/ssh/service_connection.h
+++ b/source/extensions/filters/network/ssh/service_connection.h
@@ -47,6 +47,7 @@ public:
   void shutdown(absl::Status err);
 
   class ChannelCallbacksImpl final : public ChannelCallbacks,
+                                     public ChannelFilterCallbacks,
                                      public LinkedObject<ChannelCallbacksImpl> {
   public:
     ChannelCallbacksImpl(ConnectionService& parent, uint32_t channel_id, Peer local_peer);
@@ -73,6 +74,9 @@ public:
       // deleting them becomes a no-op.
       interrupt_callbacks_ = std::make_unique<Envoy::Common::CallbackManager<void, absl::Status, TransportCallbacks&>>();
     }
+
+    // ChannelFilterCallbacks
+    bool interruptChannel(absl::Status err) override;
 
   private:
     void cleanup() override;

--- a/source/extensions/filters/network/ssh/service_connection.h
+++ b/source/extensions/filters/network/ssh/service_connection.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "source/extensions/filters/network/ssh/channel.h"
+#include "source/extensions/filters/network/ssh/channel_filter.h"
 #include "source/extensions/filters/network/ssh/stream_tracker.h"
 #include "source/extensions/filters/network/ssh/wire/messages.h"
 #include "source/extensions/filters/network/ssh/service.h"
@@ -52,11 +53,15 @@ public:
     void sendMessageLocal(wire::Message&& msg) override;
     absl::Status sendMessageRemote(wire::Message&& msg) override;
     uint32_t channelId() const override { return channel_id_; }
+    std::optional<std::string_view> channelType() const override { return channel_type_; }
     Stats::Scope& scope() const override { return *scope_; }
     void setStatsProvider(ChannelStatsProvider& stats_provider) override { stats_provider_ = stats_provider; }
     Envoy::OptRef<ChannelStatsProvider> statsProvider() const { return stats_provider_; }
     void terminate(absl::Status err) override {
       parent_.transport_.terminate(err);
+    }
+    void setChannelFilters(std::vector<ChannelFilterPtr> filters) {
+      filters_ = std::move(filters);
     }
 
     [[nodiscard]]
@@ -74,11 +79,13 @@ public:
     ConnectionService& parent_;
     ChannelIDManager& channel_id_mgr_;
     const uint32_t channel_id_;
+    std::optional<std::string> channel_type_;
     const Peer local_peer_;
     Stats::ScopeSharedPtr scope_;
     Envoy::Event::TimerPtr close_timer_;
     Envoy::OptRef<ChannelStatsProvider> stats_provider_;
     std::unique_ptr<Envoy::Common::CallbackManager<void, absl::Status, TransportCallbacks&>> interrupt_callbacks_;
+    std::vector<ChannelFilterPtr> filters_;
   };
 
 protected:

--- a/source/extensions/filters/network/ssh/service_connection.h
+++ b/source/extensions/filters/network/ssh/service_connection.h
@@ -79,6 +79,9 @@ public:
     bool interruptChannel(absl::Status err) override;
     stream_id_t streamId() const override { return parent_.transport_.streamId(); }
     const AuthInfo& authInfo() const override { return parent_.transport_.authInfo(); }
+    Envoy::Event::Dispatcher& connectionDispatcher() const override {
+      return *parent_.transport_.connectionDispatcher();
+    }
 
   private:
     void cleanup() override;

--- a/source/extensions/filters/network/ssh/service_connection.h
+++ b/source/extensions/filters/network/ssh/service_connection.h
@@ -46,6 +46,24 @@ public:
   void registerMessageHandlers(SshMessageDispatcher& dispatcher) override;
   void shutdown(absl::Status err);
 
+  class ReadDisableHandleImpl : public ReadDisableHandle {
+  public:
+    ReadDisableHandleImpl(Envoy::Event::Dispatcher& dispatcher, absl::AnyInvocable<void()> do_read_enable)
+        : dispatcher_(dispatcher),
+          do_read_enable_(std::move(do_read_enable)) {
+      ASSERT(dispatcher_.isThreadSafe());
+    }
+
+    ~ReadDisableHandleImpl() {
+      ASSERT(dispatcher_.isThreadSafe());
+      std::invoke(std::exchange(do_read_enable_, nullptr));
+    }
+
+  private:
+    Envoy::Event::Dispatcher& dispatcher_;
+    absl::AnyInvocable<void()> do_read_enable_;
+  };
+
   class ChannelCallbacksImpl final : public ChannelCallbacks,
                                      public ChannelFilterCallbacks,
                                      public LinkedObject<ChannelCallbacksImpl> {
@@ -81,6 +99,12 @@ public:
     const AuthInfo& authInfo() const override { return parent_.transport_.authInfo(); }
     Envoy::Event::Dispatcher& connectionDispatcher() const override {
       return *parent_.transport_.connectionDispatcher();
+    }
+    ReadDisableHandlePtr connectionReadDisable() override {
+      parent_.transport_.connectionReadDisable(true);
+      return std::make_unique<ReadDisableHandleImpl>(connectionDispatcher(), [this] {
+        parent_.transport_.connectionReadDisable(false);
+      });
     }
 
   private:

--- a/source/extensions/filters/network/ssh/transport.h
+++ b/source/extensions/filters/network/ssh/transport.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#pragma clang unsafe_buffer_usage begin
-#include "api/extensions/filters/network/ssh/ssh.pb.h"
-#pragma clang unsafe_buffer_usage end
+#include "source/extensions/filters/network/ssh/filter_state_objects.h"
 #include "source/extensions/filters/network/ssh/id_manager.h"
 #include "source/extensions/filters/network/ssh/openssh.h"
 #include "source/extensions/filters/network/ssh/grpc_client_impl.h"
@@ -12,63 +10,6 @@
 #include "source/extensions/filters/network/ssh/channel_filter_config.h"
 
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
-
-static constexpr DirectionTags clientKeys{'A', 'C', 'E'};
-static constexpr DirectionTags serverKeys{'B', 'D', 'F'};
-
-enum class ChannelMode {
-  // Normal mode: the channel is being proxied directly to the upstream.
-  Normal = 1,
-
-  // Hijacked mode: only the server codec is active, and the upstream side of the channel is being
-  // redirected to Pomerium.
-  Hijacked = 2,
-
-  // Handoff mode: the channel was previously in Hijacked mode, but Pomerium has handed off the
-  // upstream side of the channel to the real upstream server. This is a permanent state, and
-  // signals some extra logic such as performing channel ID translation.
-  Handoff = 3,
-
-  // Mirror mode: no upstream; contents are duplicated from a different channel to mirror its state.
-  Mirror = 4,
-};
-
-enum class MultiplexMode {
-  None = 0,
-  Source = 1,
-  Mirror = 2,
-};
-
-enum class ReadWriteMode {
-  ReadOnly = 0,
-  ReadWrite = 1,
-};
-
-struct HandoffInfo {
-  bool handoff_in_progress{};
-  std::unique_ptr<pomerium::extensions::ssh::SSHDownstreamChannelInfo> channel_info;
-  std::unique_ptr<pomerium::extensions::ssh::SSHDownstreamPTYInfo> pty_info;
-};
-
-struct MultiplexingInfo {
-  MultiplexMode multiplex_mode{MultiplexMode::None};
-  ReadWriteMode rw_mode{ReadWriteMode::ReadOnly};
-  stream_id_t source_stream_id{};
-  std::optional<uint32_t> downstream_channel_id;
-};
-
-struct AuthInfo : public StreamInfo::FilterState::Object {
-  std::string server_version;
-  stream_id_t stream_id{}; // unique stream id for both connections
-  ChannelMode channel_mode{};
-  HandoffInfo handoff_info;
-  MultiplexingInfo multiplexing_info;
-  std::optional<wire::ExtInfoMsg> downstream_ext_info;
-  std::optional<wire::ExtInfoMsg> upstream_ext_info;
-  std::unique_ptr<pomerium::extensions::ssh::AllowResponse> allow_response;
-};
-
-using AuthInfoSharedPtr = std::shared_ptr<AuthInfo>;
 
 class SecretsProvider {
 public:

--- a/source/extensions/filters/network/ssh/transport.h
+++ b/source/extensions/filters/network/ssh/transport.h
@@ -9,6 +9,7 @@
 #include "source/extensions/filters/network/ssh/frame.h"
 #include "source/extensions/filters/network/ssh/wire/messages.h"
 #include "source/extensions/filters/network/ssh/common.h"
+#include "source/extensions/filters/network/ssh/channel_filter.h"
 
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 
@@ -96,6 +97,7 @@ public:
   virtual Envoy::OptRef<Envoy::Event::Dispatcher> connectionDispatcher() const PURE;
   virtual void terminate(absl::Status status) PURE;
   virtual ChannelIDManager& channelIdManager() PURE;
+  virtual ChannelFilterManager& channelFilterManager() PURE;
   virtual const SecretsProvider& secretsProvider() const PURE;
   virtual Stats::Scope& statsScope() const PURE;
 

--- a/source/extensions/filters/network/ssh/transport.h
+++ b/source/extensions/filters/network/ssh/transport.h
@@ -9,7 +9,7 @@
 #include "source/extensions/filters/network/ssh/frame.h"
 #include "source/extensions/filters/network/ssh/wire/messages.h"
 #include "source/extensions/filters/network/ssh/common.h"
-#include "source/extensions/filters/network/ssh/channel_filter.h"
+#include "source/extensions/filters/network/ssh/channel_filter_config.h"
 
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 

--- a/source/extensions/filters/network/ssh/transport.h
+++ b/source/extensions/filters/network/ssh/transport.h
@@ -36,6 +36,7 @@ public:
   virtual stream_id_t streamId() const PURE;
   virtual void updatePeerExtInfo(std::optional<wire::ExtInfoMsg> msg) PURE;
   virtual Envoy::OptRef<Envoy::Event::Dispatcher> connectionDispatcher() const PURE;
+  virtual void connectionReadDisable(bool disable) PURE;
   virtual void terminate(absl::Status status) PURE;
   virtual ChannelIDManager& channelIdManager() PURE;
   virtual ChannelFilterManager& channelFilterManager() PURE;

--- a/source/extensions/filters/network/ssh/transport_base.h
+++ b/source/extensions/filters/network/ssh/transport_base.h
@@ -279,6 +279,10 @@ public:
     callbacks_->onDecodingFailure(err.message());
   }
 
+  void connectionReadDisable(bool disable) override {
+    callbacks_->connection()->readDisable(disable);
+  }
+
   const bytes& sessionId() const final { return kex_result_->session_id; }
   const SecretsProvider& secretsProvider() const final { return secrets_provider_; }
   Stats::Scope& statsScope() const override { return *scope_; }

--- a/source/extensions/filters/network/ssh/transport_common.h
+++ b/source/extensions/filters/network/ssh/transport_common.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#pragma clang unsafe_buffer_usage begin
+#include "api/extensions/filters/network/ssh/ssh.pb.h"
+#pragma clang unsafe_buffer_usage end
+#include "source/extensions/filters/network/ssh/common.h"
+
+namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
+
+static constexpr DirectionTags clientKeys{'A', 'C', 'E'};
+static constexpr DirectionTags serverKeys{'B', 'D', 'F'};
+
+enum class ChannelMode {
+  // Normal mode: the channel is being proxied directly to the upstream.
+  Normal = 1,
+
+  // Hijacked mode: only the server codec is active, and the upstream side of the channel is being
+  // redirected to Pomerium.
+  Hijacked = 2,
+
+  // Handoff mode: the channel was previously in Hijacked mode, but Pomerium has handed off the
+  // upstream side of the channel to the real upstream server. This is a permanent state, and
+  // signals some extra logic such as performing channel ID translation.
+  Handoff = 3,
+
+  // Mirror mode: no upstream; contents are duplicated from a different channel to mirror its state.
+  Mirror = 4,
+};
+
+enum class MultiplexMode {
+  None = 0,
+  Source = 1,
+  Mirror = 2,
+};
+
+enum class ReadWriteMode {
+  ReadOnly = 0,
+  ReadWrite = 1,
+};
+
+struct HandoffInfo {
+  bool handoff_in_progress{};
+  std::unique_ptr<pomerium::extensions::ssh::SSHDownstreamChannelInfo> channel_info;
+  std::unique_ptr<pomerium::extensions::ssh::SSHDownstreamPTYInfo> pty_info;
+};
+
+struct MultiplexingInfo {
+  MultiplexMode multiplex_mode{MultiplexMode::None};
+  ReadWriteMode rw_mode{ReadWriteMode::ReadOnly};
+  stream_id_t source_stream_id{};
+  std::optional<uint32_t> downstream_channel_id;
+};
+
+} // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/test/extensions/filters/network/ssh/BUILD
+++ b/test/extensions/filters/network/ssh/BUILD
@@ -309,6 +309,7 @@ envoy_cc_test(
         "@envoy//test/mocks/grpc:grpc_mocks",
         "@envoy//test/mocks/network:connection_mocks",
         "@envoy//test/mocks/server:factory_context_mocks",
+        "@envoy//test/test_common:registry_lib",
     ],
 )
 

--- a/test/extensions/filters/network/ssh/BUILD
+++ b/test/extensions/filters/network/ssh/BUILD
@@ -422,6 +422,17 @@ envoy_cc_test(
     ],
 )
 
+envoy_cc_test(
+    name = "filter_manager_test",
+    srcs = [
+        "filter_manager_test.cc",
+    ],
+    repository = "@envoy",
+    deps = [
+        ":integration_lib",
+    ],
+)
+
 envoy_cc_test_library(
     name = "integration_lib",
     srcs = [

--- a/test/extensions/filters/network/ssh/BUILD
+++ b/test/extensions/filters/network/ssh/BUILD
@@ -217,6 +217,7 @@ envoy_cc_test(
         "@envoy//test/mocks/event:event_mocks",
         "@envoy//test/mocks/grpc:grpc_mocks",
         "@envoy//test/mocks/server:factory_context_mocks",
+        "@envoy//test/test_common:registry_lib",
         "@envoy//test/test_common:utility_lib",
     ],
 )
@@ -402,6 +403,21 @@ envoy_cc_test(
     deps = [
         ":ssh_test_common_lib",
         "@envoy//test/mocks/event:event_mocks",
+    ],
+)
+
+envoy_cc_test(
+    name = "channel_filter_test",
+    srcs = [
+        "channel_filter_test.cc",
+    ],
+    repository = "@envoy",
+    deps = [
+        ":test_mocks",
+        "//source/extensions/filters/network/ssh:pomerium_ssh",
+        "//test/test_common:test_common_lib",
+        "@envoy//test/mocks/server:factory_context_mocks",
+        "@envoy//test/test_common:registry_lib",
     ],
 )
 

--- a/test/extensions/filters/network/ssh/channel_filter_test.cc
+++ b/test/extensions/filters/network/ssh/channel_filter_test.cc
@@ -18,8 +18,8 @@ public:
 };
 
 TEST_F(ChannelFilterTest, ChannelFilterManager_NoFilters) {
-  ChannelFilterManager mgr(server_factory_context_, {});
-  EXPECT_FALSE(mgr.hasFilters());
+  ChannelFilterManager mgr({}, server_factory_context_);
+  EXPECT_EQ(0, mgr.numConfiguredFilters());
 
   testing::StrictMock<MockChannelFilterCallbacks> cb;
 
@@ -36,13 +36,140 @@ TEST_F(ChannelFilterTest, ChannelFilterManager_NoEnabledFilters) {
 
   Registry::InjectFactory<ChannelFilterFactoryConfig> inject(cfg);
 
-  ChannelFilterManager mgr(server_factory_context_, {});
-  EXPECT_FALSE(mgr.hasFilters());
+  ChannelFilterManager mgr({}, server_factory_context_);
+  EXPECT_EQ(0, mgr.numConfiguredFilters());
 
   testing::StrictMock<MockChannelFilterCallbacks> cb;
 
   EXPECT_EQ(0, mgr.createReadFilters(cb).size());
   EXPECT_EQ(0, mgr.createWriteFilters(cb).size());
+}
+
+TEST_F(ChannelFilterTest, ChannelFilterManager_InvalidFactoryConfig) {
+  testing::NiceMock<MockChannelFilterFactoryConfig> cfg;
+  ON_CALL(cfg, createEmptyConfigProto).WillByDefault([] {
+    return std::make_unique<Envoy::Protobuf::StringValue>();
+  });
+  ON_CALL(cfg, name).WillByDefault(Return("test_channel_filter"));
+
+  Registry::InjectFactory<ChannelFilterFactoryConfig> inject(cfg);
+
+  ExtensionConfigList enabledChannelFilters;
+  {
+    auto* cfg = enabledChannelFilters.Add();
+    cfg->set_name("test_channel_filter");
+    Envoy::Protobuf::Int64Value v;
+    v.set_value(1234);
+    cfg->mutable_typed_config()->PackFrom(v);
+  }
+
+  EXPECT_THROW_WITH_REGEX(
+    {
+      ChannelFilterManager mgr(enabledChannelFilters, server_factory_context_);
+    },
+    Envoy::EnvoyException, "Unable to unpack as google\\.protobuf\\.StringValue.*");
+}
+
+TEST_F(ChannelFilterTest, ChannelFilterManager_FactoryNotFound) {
+  ExtensionConfigList enabledChannelFilters;
+  {
+    auto* cfg = enabledChannelFilters.Add();
+    cfg->set_name("test_channel_filter");
+    Envoy::Protobuf::Int64Value v;
+    v.set_value(1234);
+    cfg->mutable_typed_config()->PackFrom(v);
+  }
+
+  EXPECT_THROW_WITH_REGEX(
+    {
+      ChannelFilterManager mgr(enabledChannelFilters, server_factory_context_);
+    },
+    Envoy::EnvoyException, "no registered channel filter factory found for name: test_channel_filter");
+}
+
+TEST_F(ChannelFilterTest, ChannelFilterManager_ConfigureFilters_NotFound) {
+  testing::NiceMock<MockChannelFilterFactoryConfig> cfg;
+  ON_CALL(cfg, createEmptyConfigProto).WillByDefault([] {
+    return std::make_unique<Envoy::Protobuf::StringValue>();
+  });
+  ON_CALL(cfg, name).WillByDefault(Return("test_channel_filter"));
+
+  EXPECT_CALL(cfg, createChannelFilterFactory)
+    .WillOnce([] {
+      auto factory = std::make_unique<testing::StrictMock<MockChannelFilterFactory>>();
+      EXPECT_CALL(*factory, createEmptyConfigProto)
+        .WillOnce([] { return std::make_unique<Envoy::Protobuf::StringValue>(); });
+      return factory;
+    });
+
+  Registry::InjectFactory<ChannelFilterFactoryConfig> inject(cfg);
+
+  ExtensionConfigList enabledChannelFilters;
+  {
+    auto* cfg = enabledChannelFilters.Add();
+    cfg->set_name("test_channel_filter");
+    Envoy::Protobuf::StringValue v;
+    v.set_value("factory_config");
+    cfg->mutable_typed_config()->PackFrom(v);
+  }
+  ChannelFilterManager mgr(enabledChannelFilters, server_factory_context_);
+
+  ExtensionConfigList filterConfigs;
+  {
+    auto* cfg = filterConfigs.Add();
+    cfg->set_name("test_channel_filter");
+    Envoy::Protobuf::StringValue v;
+    v.set_value("filter_config");
+    cfg->mutable_typed_config()->PackFrom(v);
+
+    auto* cfg2 = filterConfigs.Add();
+    cfg2->set_name("nonexistent");
+  }
+  EXPECT_EQ(absl::NotFoundError("channel filter not found: nonexistent"),
+            mgr.configureFilters(filterConfigs));
+  EXPECT_EQ(0, mgr.numConfiguredFilters());
+}
+
+TEST_F(ChannelFilterTest, ChannelFilterManager_ConfigureFilters_InvalidConfig) {
+  testing::NiceMock<MockChannelFilterFactoryConfig> cfg;
+  ON_CALL(cfg, createEmptyConfigProto).WillByDefault([] {
+    return std::make_unique<Envoy::Protobuf::StringValue>();
+  });
+  ON_CALL(cfg, name).WillByDefault(Return("test_channel_filter"));
+
+  EXPECT_CALL(cfg, createChannelFilterFactory)
+    .WillOnce([] {
+      auto factory = std::make_unique<testing::StrictMock<MockChannelFilterFactory>>();
+      EXPECT_CALL(*factory, createEmptyConfigProto)
+        .WillOnce([] {
+          return std::make_unique<Envoy::Protobuf::StringValue>();
+        });
+      return factory;
+    });
+
+  Registry::InjectFactory<ChannelFilterFactoryConfig> inject(cfg);
+
+  ExtensionConfigList enabledChannelFilters;
+  {
+    auto* cfg = enabledChannelFilters.Add();
+    cfg->set_name("test_channel_filter");
+    Envoy::Protobuf::StringValue v;
+    v.set_value("factory_config");
+    cfg->mutable_typed_config()->PackFrom(v);
+  }
+  ChannelFilterManager mgr(enabledChannelFilters, server_factory_context_);
+
+  ExtensionConfigList filterConfigs;
+  {
+    auto* cfg = filterConfigs.Add();
+    cfg->set_name("test_channel_filter");
+    Envoy::Protobuf::Int64Value v;
+    v.set_value(1234);
+    cfg->mutable_typed_config()->PackFrom(v);
+  }
+  EXPECT_THAT(mgr.configureFilters(filterConfigs).message(),
+              HasSubstr("invalid channel filter config: Unable to unpack as google.protobuf.StringValue"));
+  EXPECT_EQ(0, mgr.numConfiguredFilters());
 }
 
 TEST_F(ChannelFilterTest, ChannelFilterManager_NoChannelFiltersCreated) {
@@ -53,20 +180,51 @@ TEST_F(ChannelFilterTest, ChannelFilterManager_NoChannelFiltersCreated) {
   ON_CALL(cfg, name).WillByDefault(Return("test_channel_filter"));
 
   EXPECT_CALL(cfg, createChannelFilterFactory)
-    .WillOnce([] {
+    .WillOnce([](const google::protobuf::Message& config,
+                 Envoy::Server::Configuration::ServerFactoryContext&) {
+      EXPECT_EQ("factory_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
       auto factory = std::make_unique<testing::StrictMock<MockChannelFilterFactory>>();
+      EXPECT_CALL(*factory, createEmptyConfigProto)
+        .WillOnce([] {
+          return std::make_unique<Envoy::Protobuf::StringValue>();
+        });
       EXPECT_CALL(*factory, createReadFilter)
-        .WillOnce(Return(nullptr));
+        .WillOnce([](const google::protobuf::Message& config, ChannelFilterCallbacks&) {
+          EXPECT_EQ("filter_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
+          return nullptr;
+        });
       EXPECT_CALL(*factory, createWriteFilter)
-        .WillOnce(Return(nullptr));
+        .WillOnce([](const google::protobuf::Message& config, ChannelFilterCallbacks&) {
+          EXPECT_EQ("filter_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
+          return nullptr;
+        });
       return factory;
     });
   Registry::InjectFactory<ChannelFilterFactoryConfig> inject(cfg);
 
-  ChannelFilterManager mgr(server_factory_context_, {cfg.name()});
-  EXPECT_TRUE(mgr.hasFilters());
+  ExtensionConfigList enabledChannelFilters;
+  {
+    auto* cfg = enabledChannelFilters.Add();
+    cfg->set_name("test_channel_filter");
+    Envoy::Protobuf::StringValue v;
+    v.set_value("factory_config");
+    cfg->mutable_typed_config()->PackFrom(v);
+  }
+  ExtensionConfigList filterConfigs;
+  {
+    auto* cfg = filterConfigs.Add();
+    cfg->set_name("test_channel_filter");
+    Envoy::Protobuf::StringValue v;
+    v.set_value("filter_config");
+    cfg->mutable_typed_config()->PackFrom(v);
+  }
+
+  ChannelFilterManager mgr(enabledChannelFilters, server_factory_context_);
 
   testing::StrictMock<MockChannelFilterCallbacks> cb;
+
+  EXPECT_OK(mgr.configureFilters(filterConfigs));
+  EXPECT_EQ(1, mgr.numConfiguredFilters());
 
   EXPECT_EQ(0, mgr.createReadFilters(cb).size());
   EXPECT_EQ(0, mgr.createWriteFilters(cb).size());
@@ -80,17 +238,25 @@ TEST_F(ChannelFilterTest, ChannelFilterManager_FiltersCreated) {
   ON_CALL(cfg, name).WillByDefault(Return("test_channel_filter"));
 
   EXPECT_CALL(cfg, createChannelFilterFactory)
-    .WillOnce([] {
+    .WillOnce([](const google::protobuf::Message& config,
+                 Envoy::Server::Configuration::ServerFactoryContext&) {
+      EXPECT_EQ("factory_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
       auto factory = std::make_unique<testing::StrictMock<MockChannelFilterFactory>>();
+      EXPECT_CALL(*factory, createEmptyConfigProto)
+        .WillOnce([] {
+          return std::make_unique<Envoy::Protobuf::StringValue>();
+        });
       EXPECT_CALL(*factory, createReadFilter)
-        .WillOnce([](const ChannelReadOnlyCallbacks& channel_callbacks) {
+        .WillOnce([](const google::protobuf::Message& config, const ChannelFilterCallbacks& channel_callbacks) {
+          EXPECT_EQ("filter_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
           EXPECT_EQ(1234, channel_callbacks.channelId());
           auto filter = std::make_unique<testing::StrictMock<MockChannelFilter>>();
           EXPECT_CALL(*filter, onMessageForward(MSG(wire::ChannelDataMsg, _)));
           return filter;
         });
       EXPECT_CALL(*factory, createWriteFilter)
-        .WillOnce([](const ChannelReadOnlyCallbacks& channel_callbacks) {
+        .WillOnce([](const google::protobuf::Message& config, const ChannelFilterCallbacks& channel_callbacks) {
+          EXPECT_EQ("filter_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
           EXPECT_EQ(1234, channel_callbacks.channelId());
           auto filter = std::make_unique<testing::StrictMock<MockChannelFilter>>();
           EXPECT_CALL(*filter, onMessageForward(MSG(wire::ChannelDataMsg, _)));
@@ -100,13 +266,32 @@ TEST_F(ChannelFilterTest, ChannelFilterManager_FiltersCreated) {
     });
   Registry::InjectFactory<ChannelFilterFactoryConfig> inject(cfg);
 
-  ChannelFilterManager mgr(server_factory_context_, {cfg.name()});
-  EXPECT_TRUE(mgr.hasFilters());
+  ExtensionConfigList enabledChannelFilters;
+  {
+    auto* cfg = enabledChannelFilters.Add();
+    cfg->set_name("test_channel_filter");
+    Envoy::Protobuf::StringValue v;
+    v.set_value("factory_config");
+    cfg->mutable_typed_config()->PackFrom(v);
+  }
+  ExtensionConfigList filterConfigs;
+  {
+    auto* cfg = filterConfigs.Add();
+    cfg->set_name("test_channel_filter");
+    Envoy::Protobuf::StringValue v;
+    v.set_value("filter_config");
+    cfg->mutable_typed_config()->PackFrom(v);
+  }
+
+  ChannelFilterManager mgr(enabledChannelFilters, server_factory_context_);
 
   testing::StrictMock<MockChannelFilterCallbacks> cb;
   EXPECT_CALL(cb, channelId)
     .Times(2)
     .WillRepeatedly(Return(1234));
+
+  EXPECT_OK(mgr.configureFilters(filterConfigs));
+  EXPECT_EQ(1, mgr.numConfiguredFilters());
 
   auto readFilters = mgr.createReadFilters(cb);
   auto writeFilters = mgr.createWriteFilters(cb);

--- a/test/extensions/filters/network/ssh/channel_filter_test.cc
+++ b/test/extensions/filters/network/ssh/channel_filter_test.cc
@@ -1,0 +1,122 @@
+
+#include "source/extensions/filters/network/ssh/channel_filter_config.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "test/extensions/filters/network/ssh/test_mocks.h"
+#include "test/mocks/server/server_factory_context.h"
+#include "test/test_common/test_common.h"
+#include "test/test_common/registry.h"
+
+namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
+namespace test {
+
+class ChannelFilterTest : public testing::Test {
+public:
+  void SetUp() override {
+  }
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context_;
+};
+
+TEST_F(ChannelFilterTest, ChannelFilterManager_NoFilters) {
+  ChannelFilterManager mgr(server_factory_context_, {});
+  EXPECT_FALSE(mgr.hasFilters());
+
+  testing::StrictMock<MockChannelFilterCallbacks> cb;
+
+  EXPECT_EQ(0, mgr.createReadFilters(cb).size());
+  EXPECT_EQ(0, mgr.createWriteFilters(cb).size());
+}
+
+TEST_F(ChannelFilterTest, ChannelFilterManager_NoEnabledFilters) {
+  testing::NiceMock<MockChannelFilterFactoryConfig> cfg;
+  ON_CALL(cfg, createEmptyConfigProto).WillByDefault([] {
+    return std::make_unique<Envoy::Protobuf::StringValue>();
+  });
+  ON_CALL(cfg, name).WillByDefault(Return("test_channel_filter"));
+
+  Registry::InjectFactory<ChannelFilterFactoryConfig> inject(cfg);
+
+  ChannelFilterManager mgr(server_factory_context_, {});
+  EXPECT_FALSE(mgr.hasFilters());
+
+  testing::StrictMock<MockChannelFilterCallbacks> cb;
+
+  EXPECT_EQ(0, mgr.createReadFilters(cb).size());
+  EXPECT_EQ(0, mgr.createWriteFilters(cb).size());
+}
+
+TEST_F(ChannelFilterTest, ChannelFilterManager_NoChannelFiltersCreated) {
+  testing::NiceMock<MockChannelFilterFactoryConfig> cfg;
+  ON_CALL(cfg, createEmptyConfigProto).WillByDefault([] {
+    return std::make_unique<Envoy::Protobuf::StringValue>();
+  });
+  ON_CALL(cfg, name).WillByDefault(Return("test_channel_filter"));
+
+  EXPECT_CALL(cfg, createChannelFilterFactory)
+    .WillOnce([] {
+      auto factory = std::make_unique<testing::StrictMock<MockChannelFilterFactory>>();
+      EXPECT_CALL(*factory, createReadFilter)
+        .WillOnce(Return(nullptr));
+      EXPECT_CALL(*factory, createWriteFilter)
+        .WillOnce(Return(nullptr));
+      return factory;
+    });
+  Registry::InjectFactory<ChannelFilterFactoryConfig> inject(cfg);
+
+  ChannelFilterManager mgr(server_factory_context_, {cfg.name()});
+  EXPECT_TRUE(mgr.hasFilters());
+
+  testing::StrictMock<MockChannelFilterCallbacks> cb;
+
+  EXPECT_EQ(0, mgr.createReadFilters(cb).size());
+  EXPECT_EQ(0, mgr.createWriteFilters(cb).size());
+}
+
+TEST_F(ChannelFilterTest, ChannelFilterManager_FiltersCreated) {
+  testing::NiceMock<MockChannelFilterFactoryConfig> cfg;
+  ON_CALL(cfg, createEmptyConfigProto).WillByDefault([] {
+    return std::make_unique<Envoy::Protobuf::StringValue>();
+  });
+  ON_CALL(cfg, name).WillByDefault(Return("test_channel_filter"));
+
+  EXPECT_CALL(cfg, createChannelFilterFactory)
+    .WillOnce([] {
+      auto factory = std::make_unique<testing::StrictMock<MockChannelFilterFactory>>();
+      EXPECT_CALL(*factory, createReadFilter)
+        .WillOnce([](const ChannelReadOnlyCallbacks& channel_callbacks) {
+          EXPECT_EQ(1234, channel_callbacks.channelId());
+          auto filter = std::make_unique<testing::StrictMock<MockChannelFilter>>();
+          EXPECT_CALL(*filter, onMessageForward(MSG(wire::ChannelDataMsg, _)));
+          return filter;
+        });
+      EXPECT_CALL(*factory, createWriteFilter)
+        .WillOnce([](const ChannelReadOnlyCallbacks& channel_callbacks) {
+          EXPECT_EQ(1234, channel_callbacks.channelId());
+          auto filter = std::make_unique<testing::StrictMock<MockChannelFilter>>();
+          EXPECT_CALL(*filter, onMessageForward(MSG(wire::ChannelDataMsg, _)));
+          return filter;
+        });
+      return factory;
+    });
+  Registry::InjectFactory<ChannelFilterFactoryConfig> inject(cfg);
+
+  ChannelFilterManager mgr(server_factory_context_, {cfg.name()});
+  EXPECT_TRUE(mgr.hasFilters());
+
+  testing::StrictMock<MockChannelFilterCallbacks> cb;
+  EXPECT_CALL(cb, channelId)
+    .Times(2)
+    .WillRepeatedly(Return(1234));
+
+  auto readFilters = mgr.createReadFilters(cb);
+  auto writeFilters = mgr.createWriteFilters(cb);
+  EXPECT_EQ(1, readFilters.size());
+  EXPECT_EQ(1, writeFilters.size());
+
+  wire::Message msg = wire::ChannelDataMsg{};
+  readFilters[0]->onMessageForward(msg);
+  writeFilters[0]->onMessageForward(msg);
+}
+
+} // namespace test
+} // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/test/extensions/filters/network/ssh/channel_filter_test.cc
+++ b/test/extensions/filters/network/ssh/channel_filter_test.cc
@@ -303,5 +303,131 @@ TEST_F(ChannelFilterTest, ChannelFilterManager_FiltersCreated) {
   writeFilters[0]->onMessageForward(msg);
 }
 
+TEST_F(ChannelFilterTest, ChannelFilterManager_MultipleFiltersConfigurationOrder) {
+  std::vector<std::function<ProtobufTypes::MessagePtr()>> filterCfgTypes{
+    [] { return std::make_unique<Envoy::Protobuf::StringValue>(); },
+    [] { return std::make_unique<Envoy::Protobuf::Int32Value>(); },
+    [] { return std::make_unique<Envoy::Protobuf::UInt32Value>(); },
+    [] { return std::make_unique<Envoy::Protobuf::Int64Value>(); },
+    [] { return std::make_unique<Envoy::Protobuf::DoubleValue>(); },
+  };
+  std::vector<std::unique_ptr<testing::NiceMock<MockChannelFilterFactoryConfig>>> filterCfgs;
+  for (size_t i = 0; i < filterCfgTypes.size(); i++) {
+    auto cfg = std::make_unique<decltype(filterCfgs)::value_type::element_type>();
+    ON_CALL(*cfg, createEmptyConfigProto).WillByDefault([i, &filterCfgTypes] {
+      return filterCfgTypes[i]();
+    });
+    ON_CALL(*cfg, name)
+      .WillByDefault(Return(fmt::format("test_channel_filter_{}", i)));
+    filterCfgs.push_back(std::move(cfg));
+  }
+
+  // This sequences checks that filters are created in the same order they are listed in the
+  // configuration
+  testing::Sequence factorySeq;
+  testing::Sequence readFilterSeq;
+  testing::Sequence writeFilterSeq;
+
+  std::vector<std::unique_ptr<testing::StrictMock<MockChannelFilterFactory>>> tmpFactories;
+  std::vector<std::unique_ptr<testing::StrictMock<MockChannelFilter>>> tmpReadFilters;
+  std::vector<std::unique_ptr<testing::StrictMock<MockChannelFilter>>> tmpWriteFilters;
+  for (size_t i = 0; i < filterCfgTypes.size(); i++) {
+    auto factory = std::make_unique<testing::StrictMock<MockChannelFilterFactory>>();
+    EXPECT_CALL(*factory, createEmptyConfigProto)
+      .InSequence(factorySeq)
+      .WillOnce([] {
+        return std::make_unique<Envoy::Protobuf::StringValue>();
+      });
+
+    {
+      auto readFilter = std::make_unique<testing::StrictMock<MockChannelFilter>>();
+      EXPECT_CALL(*readFilter, onMessageForward(MSG(wire::ChannelDataMsg, _)))
+        .InSequence(readFilterSeq);
+      tmpReadFilters.push_back(std::move(readFilter));
+    }
+    {
+      auto writeFilter = std::make_unique<testing::StrictMock<MockChannelFilter>>();
+      EXPECT_CALL(*writeFilter, onMessageForward(MSG(wire::ChannelDataMsg, _)))
+        .InSequence(writeFilterSeq);
+      tmpWriteFilters.push_back(std::move(writeFilter));
+    }
+
+    EXPECT_CALL(*factory, createReadFilter)
+      .WillOnce([i, &tmpReadFilters](const google::protobuf::Message& config, const ChannelFilterCallbacks&) {
+        EXPECT_EQ("filter_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
+        return std::move(tmpReadFilters[i]);
+      });
+    EXPECT_CALL(*factory, createWriteFilter)
+      .WillOnce([i, &tmpWriteFilters](const google::protobuf::Message& config, const ChannelFilterCallbacks&) {
+        EXPECT_EQ("filter_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
+        return std::move(tmpWriteFilters[i]);
+      });
+
+    tmpFactories.push_back(std::move(factory));
+  }
+
+  // Also check that the filter factories are created in order. Calls in this sequence may be
+  // interleaved with calls in the above sequence, but the relative order of each will be enforced.
+  testing::Sequence factoryConfigSeq;
+  for (size_t i = 0; i < filterCfgTypes.size(); i++) {
+    EXPECT_CALL(*filterCfgs[i], createChannelFilterFactory)
+      .InSequence(factoryConfigSeq)
+      .WillOnce([i, &tmpFactories](const google::protobuf::Message&,
+                                   Envoy::Server::Configuration::ServerFactoryContext&) {
+        return std::move(tmpFactories[i]);
+      });
+  }
+
+  std::vector<std::unique_ptr<Registry::InjectFactory<ChannelFilterFactoryConfig>>> inject;
+  for (auto& filterCfg : filterCfgs) {
+    inject.push_back(std::make_unique<Registry::InjectFactory<ChannelFilterFactoryConfig>>(*filterCfg));
+  }
+
+  ExtensionConfigList enabledChannelFilters;
+  ExtensionConfigList filterConfigs;
+  for (size_t i = 0; i < filterCfgTypes.size(); i++) {
+    {
+      auto* cfg = enabledChannelFilters.Add();
+      cfg->set_name(fmt::format("test_channel_filter_{}", i));
+      auto msgPtr = filterCfgTypes[i]();
+      cfg->mutable_typed_config()->PackFrom(*msgPtr);
+    }
+
+    {
+      auto* cfg = filterConfigs.Add();
+      cfg->set_name(fmt::format("test_channel_filter_{}", i));
+      // filter type is always string here, these can have duplicate types
+      Envoy::Protobuf::StringValue v;
+      v.set_value("filter_config");
+      cfg->mutable_typed_config()->PackFrom(v);
+    }
+  }
+
+  ChannelFilterManager mgr(enabledChannelFilters, server_factory_context_);
+
+  testing::StrictMock<MockChannelFilterCallbacks> cb;
+  EXPECT_CALL(cb, channelId)
+    .Times(AnyNumber())
+    .WillRepeatedly(Return(1234));
+
+  EXPECT_OK(mgr.configureFilters(filterConfigs));
+  EXPECT_EQ(filterCfgTypes.size(), mgr.numConfiguredFilters());
+
+  auto readFilters = mgr.createReadFilters(cb);
+  auto writeFilters = mgr.createWriteFilters(cb);
+  EXPECT_EQ(filterCfgTypes.size(), readFilters.size());
+  EXPECT_EQ(filterCfgTypes.size(), writeFilters.size());
+
+  // order of filters returned by create{Read|Write}Filters should match the configuration order,
+  // so the order of onMessageForward calls should match readFilterSeq/writeFilterSeq
+  wire::Message msg{wire::ChannelDataMsg{}};
+  for (auto& rf : readFilters) {
+    rf->onMessageForward(msg);
+  }
+  for (auto& wf : writeFilters) {
+    wf->onMessageForward(msg);
+  }
+}
+
 } // namespace test
 } // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/test/extensions/filters/network/ssh/client_transport_test.cc
+++ b/test/extensions/filters/network/ssh/client_transport_test.cc
@@ -76,7 +76,7 @@ public:
       : config_(newConfig()),
         server_host_key_(*openssh::SSHKey::generate(KEY_ED25519, 256)),
         secrets_provider_(*config_),
-        channel_filter_manager_(std::make_shared<ChannelFilterManager>(server_factory_context_, std::vector<std::string>{})),
+        channel_filter_manager_(std::make_shared<ChannelFilterManager>(ExtensionConfigList{}, server_factory_context_)),
         transport_(server_factory_context_, config_, channel_filter_manager_, secrets_provider_) {}
 
   const wire::KexInitMsg kex_init_ = {

--- a/test/extensions/filters/network/ssh/client_transport_test.cc
+++ b/test/extensions/filters/network/ssh/client_transport_test.cc
@@ -1,4 +1,5 @@
 
+#include "source/extensions/filters/network/ssh/channel_filter_config.h"
 #include "source/extensions/filters/network/ssh/client_transport.h"
 #include "source/extensions/filters/network/ssh/filter_state_objects.h"
 #include "source/extensions/filters/network/ssh/id_manager.h"
@@ -75,7 +76,8 @@ public:
       : config_(newConfig()),
         server_host_key_(*openssh::SSHKey::generate(KEY_ED25519, 256)),
         secrets_provider_(*config_),
-        transport_(server_factory_context_, config_, secrets_provider_) {}
+        channel_filter_manager_(std::make_shared<ChannelFilterManager>(server_factory_context_, std::vector<std::string>{})),
+        transport_(server_factory_context_, config_, channel_filter_manager_, secrets_provider_) {}
 
   const wire::KexInitMsg kex_init_ = {
     .cookie = {{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}},
@@ -512,6 +514,7 @@ public:
   std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config_;
   openssh::SSHKeyPtr server_host_key_;
   TestSecretsProvider secrets_provider_;
+  ChannelFilterManagerSharedPtr channel_filter_manager_;
   testing::NiceMock<Envoy::Network::MockServerConnection> mock_connection_;
   testing::StrictMock<MockClientCodecCallbacks> client_codec_callbacks_;
   std::shared_ptr<ChannelIDManager> channel_id_manager_;

--- a/test/extensions/filters/network/ssh/client_transport_test.cc
+++ b/test/extensions/filters/network/ssh/client_transport_test.cc
@@ -76,8 +76,7 @@ public:
       : config_(newConfig()),
         server_host_key_(*openssh::SSHKey::generate(KEY_ED25519, 256)),
         secrets_provider_(*config_),
-        channel_filter_manager_(std::make_shared<ChannelFilterManager>(ExtensionConfigList{}, server_factory_context_)),
-        transport_(server_factory_context_, config_, channel_filter_manager_, secrets_provider_) {}
+        transport_(server_factory_context_, config_, secrets_provider_) {}
 
   const wire::KexInitMsg kex_init_ = {
     .cookie = {{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}},
@@ -105,9 +104,17 @@ public:
     // Inject a new channel id manager into the mock filter state. This would normally be created
     // by the server transport
     channel_id_manager_ = std::make_shared<ChannelIDManager>(1000, 100);
+    channel_filter_manager_ = std::make_shared<ChannelFilterManager>(ExtensionConfigList{}, server_factory_context_);
     mock_connection_.streamInfo().filterState()->setData(
       ChannelIDManagerFilterStateKey,
       channel_id_manager_,
+      StreamInfo::FilterState::StateType::Mutable,
+      StreamInfo::FilterState::LifeSpan::Connection,
+      StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnectionOnce);
+    // same with channel filter manager
+    mock_connection_.streamInfo().filterState()->setData(
+      ChannelFilterManagerFilterStateKey,
+      channel_filter_manager_,
       StreamInfo::FilterState::StateType::Mutable,
       StreamInfo::FilterState::LifeSpan::Connection,
       StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnectionOnce);
@@ -514,10 +521,10 @@ public:
   std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config_;
   openssh::SSHKeyPtr server_host_key_;
   TestSecretsProvider secrets_provider_;
-  ChannelFilterManagerSharedPtr channel_filter_manager_;
   testing::NiceMock<Envoy::Network::MockServerConnection> mock_connection_;
   testing::StrictMock<MockClientCodecCallbacks> client_codec_callbacks_;
   std::shared_ptr<ChannelIDManager> channel_id_manager_;
+  ChannelFilterManagerSharedPtr channel_filter_manager_;
   SshClientTransport transport_;
 
 private:

--- a/test/extensions/filters/network/ssh/filter_manager_test.cc
+++ b/test/extensions/filters/network/ssh/filter_manager_test.cc
@@ -1,0 +1,356 @@
+
+#include "source/extensions/filters/network/ssh/wire/messages.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "test/extensions/filters/network/ssh/ssh_task.h"
+#include "test/test_common/test_common.h"
+#include "test/extensions/filters/network/ssh/wire/test_field_reflect.h"
+#include "test/extensions/filters/network/ssh/ssh_integration_test.h"
+#include "envoy/extensions/filters/network/generic_proxy/v3/generic_proxy.pb.h"
+
+namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
+namespace test {
+
+enum Direction {
+  Read,
+  Write
+};
+
+using on_channel_filter_created_fn_t = testing::StrictMock<testing::MockFunction<void(uint32_t, uint32_t, std::string, Direction)>>;
+using on_channel_filter_destroyed_fn_t = testing::StrictMock<testing::MockFunction<void(uint32_t, uint32_t, std::string, Direction)>>;
+using on_channel_filter_factory_created_fn_t = testing::StrictMock<testing::MockFunction<void(uint32_t)>>;
+using on_channel_filter_factory_destroyed_fn_t = testing::StrictMock<testing::MockFunction<void(uint32_t)>>;
+using on_message_forward_fn_t = testing::StrictMock<testing::MockFunction<void(uint32_t, uint32_t, std::string, Direction, const wire::Message&)>>;
+
+static Envoy::OptRef<on_channel_filter_created_fn_t> on_channel_filter_created;
+static Envoy::OptRef<on_channel_filter_destroyed_fn_t> on_channel_filter_destroyed;
+static Envoy::OptRef<on_channel_filter_factory_created_fn_t> on_channel_filter_factory_created;
+static Envoy::OptRef<on_channel_filter_factory_destroyed_fn_t> on_channel_filter_factory_destroyed;
+static Envoy::OptRef<on_message_forward_fn_t> on_message_forward;
+
+class TestChannelFilter : public ChannelFilter {
+public:
+  TestChannelFilter(uint32_t instance_num, uint32_t filter_instance_num, const std::string& name, Direction direction)
+      : instance_num_(instance_num),
+        filter_instance_num_(filter_instance_num),
+        name_(name),
+        direction_(direction) {
+    on_channel_filter_created->Call(instance_num_, filter_instance_num_, name_, direction_);
+  }
+  ~TestChannelFilter() {
+    on_channel_filter_destroyed->Call(instance_num_, filter_instance_num_, name_, direction_);
+  }
+
+  void onMessageForward(const wire::Message& msg) override {
+    on_message_forward->Call(instance_num_, filter_instance_num_, name_, direction_, msg);
+  }
+
+private:
+  const uint32_t instance_num_;
+  const uint32_t filter_instance_num_;
+  const std::string name_;
+  const Direction direction_;
+};
+
+class TestChannelFilterFactory : public ChannelFilterFactory {
+public:
+  TestChannelFilterFactory(uint32_t instance_num)
+      : instance_num_(instance_num) {
+    on_channel_filter_factory_created->Call(instance_num_);
+  }
+  ~TestChannelFilterFactory() {
+    on_channel_filter_factory_destroyed->Call(instance_num_);
+  }
+
+  Envoy::ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<Protobuf::StringValue>();
+  }
+
+  Codec::ChannelFilterPtr createReadFilter(const google::protobuf::Message& config,
+                                           Codec::ChannelFilterCallbacks& channel_callbacks) override {
+    EXPECT_EQ(config.GetTypeName(), "google.protobuf.StringValue");
+    (void)channel_callbacks;
+    return std::make_unique<TestChannelFilter>(instance_num_,
+                                               read_filter_instance_num_++,
+                                               dynamic_cast<const Protobuf::StringValue&>(config).value(),
+                                               Read);
+  }
+
+  Codec::ChannelFilterPtr createWriteFilter(const google::protobuf::Message& config,
+                                            Codec::ChannelFilterCallbacks& channel_callbacks) override {
+    EXPECT_EQ(config.GetTypeName(), "google.protobuf.StringValue");
+    (void)channel_callbacks;
+    return std::make_unique<TestChannelFilter>(instance_num_,
+                                               write_filter_instance_num_++,
+                                               dynamic_cast<const Protobuf::StringValue&>(config).value(),
+                                               Write);
+  }
+
+private:
+  const uint32_t instance_num_;
+  uint32_t read_filter_instance_num_{};
+  uint32_t write_filter_instance_num_{};
+};
+
+class TestChannelFilterFactoryConfig : public Codec::ChannelFilterFactoryConfig {
+public:
+  Envoy::ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<google::protobuf::Int32Value>();
+  }
+
+  std::string name() const override {
+    return "test_filter";
+  }
+
+  Codec::ChannelFilterFactoryPtr createChannelFilterFactory(const google::protobuf::Message& config,
+                                                            Envoy::Server::Configuration::ServerFactoryContext&) override {
+    EXPECT_EQ(config.GetTypeName(), "google.protobuf.Int32Value");
+    return std::make_unique<TestChannelFilterFactory>(instance_counter_++);
+  }
+
+private:
+  std::atomic<uint32_t> instance_counter_;
+};
+
+REGISTER_FACTORY(TestChannelFilterFactoryConfig, ChannelFilterFactoryConfig);
+
+// NOLINTBEGIN(readability-identifier-naming)
+class ChannelFilterManagerIntegrationTest : public testing::Test,
+                                            public SshIntegrationTest {
+public:
+  ChannelFilterManagerIntegrationTest()
+      : SshIntegrationTest({"upstream1"}, Network::Address::IpVersion::v4) {
+    config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      for (auto& listener : *bootstrap.mutable_static_resources()->mutable_listeners()) {
+        if (listener.name() != "ssh") {
+          continue;
+        }
+        auto* filter = listener.mutable_filter_chains(0)->mutable_filters(0);
+        ASSERT(filter->name() == "generic_proxy"); // sanity check
+
+        envoy::extensions::filters::network::generic_proxy::v3::GenericProxy genericProxyConfig;
+        filter->typed_config().UnpackTo(&genericProxyConfig);
+
+        pomerium::extensions::ssh::CodecConfig sshCodecConfig;
+        genericProxyConfig.codec_config().typed_config().UnpackTo(&sshCodecConfig);
+
+        auto* factoryConfig = sshCodecConfig.add_enabled_channel_filter_factories();
+        factoryConfig->set_name("test_filter");
+        factoryConfig->mutable_typed_config()->PackFrom(Protobuf::Int32Value{});
+
+        genericProxyConfig.mutable_codec_config()->mutable_typed_config()->PackFrom(sshCodecConfig);
+
+        filter->mutable_typed_config()->PackFrom(genericProxyConfig);
+        break;
+      }
+    });
+  }
+
+  void SetUp() override {
+    ASSERT_FALSE(on_channel_filter_created.has_value());
+    ASSERT_FALSE(on_channel_filter_destroyed.has_value());
+    ASSERT_FALSE(on_channel_filter_factory_created.has_value());
+    ASSERT_FALSE(on_channel_filter_factory_destroyed.has_value());
+    ASSERT_FALSE(on_message_forward.has_value());
+    on_channel_filter_created.emplace(on_channel_filter_created_fn_);
+    on_channel_filter_destroyed.emplace(on_channel_filter_destroyed_fn_);
+    on_channel_filter_factory_created.emplace(on_channel_filter_factory_created_fn_);
+    on_channel_filter_factory_destroyed.emplace(on_channel_filter_factory_destroyed_fn_);
+    on_message_forward.emplace(on_message_forward_fn_);
+    initialize();
+  }
+
+  void TearDown() override {
+    EXPECT_TRUE(driver1_->closed());
+    EXPECT_TRUE(driver2_->closed());
+    cleanup();
+    on_channel_filter_created.reset();
+    on_channel_filter_destroyed.reset();
+    on_channel_filter_factory_created.reset();
+    on_channel_filter_factory_destroyed.reset();
+    on_message_forward.reset();
+  }
+
+  void StartListeningForNewSshConnection() {
+    ASSERT_TRUE(listenForSshConnection(SshFakeUpstreamHandlerOpts{
+      .on_channel_open_request = [](wire::ChannelOpenMsg&) -> ChannelMsgHandlerFunc {
+        return [&](wire::ChannelMessage&& msg, ChannelCallbacks& callbacks) -> absl::Status {
+          return msg.visit(
+            [&](wire::ChannelDataMsg& msg) {
+              callbacks.sendMessageLocal(wire::ChannelDataMsg{
+                .recipient_channel = callbacks.channelId(),
+                .data = msg.data,
+              });
+              return absl::OkStatus();
+            },
+            [&](wire::ChannelCloseMsg&) {
+              callbacks.sendMessageLocal(wire::ChannelCloseMsg{
+                .recipient_channel = callbacks.channelId(),
+              });
+              return absl::OkStatus();
+            },
+            [&](auto&) {
+              return absl::OkStatus();
+            });
+        };
+      },
+    }));
+  }
+  on_channel_filter_created_fn_t on_channel_filter_created_fn_;
+  on_channel_filter_created_fn_t on_channel_filter_destroyed_fn_;
+  on_channel_filter_factory_created_fn_t on_channel_filter_factory_created_fn_;
+  on_channel_filter_factory_destroyed_fn_t on_channel_filter_factory_destroyed_fn_;
+  on_message_forward_fn_t on_message_forward_fn_;
+
+  std::shared_ptr<SshConnectionDriver> driver1_;
+  std::shared_ptr<SshConnectionDriver> driver2_;
+};
+// NOLINTEND(readability-identifier-naming)
+
+TEST_F(ChannelFilterManagerIntegrationTest, TestChannelFilterManagerPerConnection) {
+  // Test that one ChannelFilterManager instance is created for each connection
+
+  EXPECT_CALL(on_channel_filter_factory_created_fn_, Call(0));
+  StartListeningForNewSshConnection();
+  driver1_ = makeSshConnectionDriver();
+  driver1_->connect();
+  ASSERT_TRUE(driver1_->waitForKex());
+
+  EXPECT_CALL(on_channel_filter_factory_created_fn_, Call(1));
+  StartListeningForNewSshConnection();
+  driver2_ = makeSshConnectionDriver();
+  driver2_->connect();
+  ASSERT_TRUE(driver2_->waitForKex());
+
+  ASSERT_TRUE(driver1_->waitForUserAuth("user", "upstream1", [](pomerium::extensions::ssh::AllowResponse& allow) {
+    ASSERT_TRUE(allow.has_upstream()); // sanity check
+    auto* filterConfig = allow.mutable_upstream()->add_channel_filters();
+    filterConfig->set_name("test_filter");
+    Protobuf::StringValue cfg;
+    cfg.set_value("driver1");
+    filterConfig->mutable_typed_config()->PackFrom(cfg);
+  }));
+  ASSERT_TRUE(driver2_->waitForUserAuth("user", "upstream1", [](pomerium::extensions::ssh::AllowResponse& allow) {
+    ASSERT_TRUE(allow.has_upstream()); // sanity check
+    auto* filterConfig = allow.mutable_upstream()->add_channel_filters();
+    filterConfig->set_name("test_filter");
+    Protobuf::StringValue cfg;
+    cfg.set_value("driver2");
+    filterConfig->mutable_typed_config()->PackFrom(cfg);
+  }));
+
+  Tasks::Channel driver1Channel1;
+  Tasks::Channel driver1Channel2;
+  Tasks::Channel driver2Channel1;
+  Tasks::Channel driver2Channel2;
+
+  {
+    IN_SEQUENCE;
+
+    EXPECT_CALL(*on_channel_filter_created, Call(0, 0, "driver1", Read));
+    EXPECT_CALL(*on_message_forward, Call(0, 0, "driver1", Read, MSG(wire::ChannelOpenMsg, _)));
+    EXPECT_CALL(*on_channel_filter_created, Call(0, 0, "driver1", Write));
+    EXPECT_CALL(*on_message_forward, Call(0, 0, "driver1", Write, MSG(wire::ChannelOpenConfirmationMsg, FIELD_EQ(recipient_channel, 1u))));
+    EXPECT_CALL(*on_message_forward, Call(0, 0, "driver1", Read, MSG(wire::ChannelDataMsg, FIELD_EQ(data, "driver 1 channel 1"_bytes))));
+    EXPECT_CALL(*on_message_forward, Call(0, 0, "driver1", Write, MSG(wire::ChannelDataMsg, FIELD_EQ(data, "driver 1 channel 1"_bytes))));
+    ASSERT_TRUE(driver1_->wait(
+      driver1_->createTask<Tasks::OpenSessionChannel>(1)
+        .saveOutput(&driver1Channel1)
+        .then(driver1_->createTask<Tasks::SendChannelData>("driver 1 channel 1")
+                .then(driver1_->createTask<Tasks::WaitForChannelData>("driver 1 channel 1")))
+        .start()));
+
+    EXPECT_CALL(*on_channel_filter_created, Call(0, 1, "driver1", Read));
+    EXPECT_CALL(*on_message_forward, Call(0, 1, "driver1", Read, MSG(wire::ChannelOpenMsg, _)));
+    EXPECT_CALL(*on_channel_filter_created, Call(0, 1, "driver1", Write));
+    EXPECT_CALL(*on_message_forward, Call(0, 1, "driver1", Write, MSG(wire::ChannelOpenConfirmationMsg, FIELD_EQ(recipient_channel, 2u))));
+    EXPECT_CALL(*on_message_forward, Call(0, 1, "driver1", Read, MSG(wire::ChannelDataMsg, FIELD_EQ(data, "driver 1 channel 2"_bytes))));
+    EXPECT_CALL(*on_message_forward, Call(0, 1, "driver1", Write, MSG(wire::ChannelDataMsg, FIELD_EQ(data, "driver 1 channel 2"_bytes))));
+    ASSERT_TRUE(driver1_->wait(
+      driver1_->createTask<Tasks::OpenSessionChannel>(2)
+        .saveOutput(&driver1Channel2)
+        .then(driver1_->createTask<Tasks::SendChannelData>("driver 1 channel 2")
+                .then(driver1_->createTask<Tasks::WaitForChannelData>("driver 1 channel 2")))
+        .start()));
+  }
+
+  {
+    IN_SEQUENCE;
+
+    EXPECT_CALL(on_channel_filter_created_fn_, Call(1, 0, "driver2", Read));
+    EXPECT_CALL(on_message_forward_fn_, Call(1, 0, "driver2", Read, MSG(wire::ChannelOpenMsg, _)));
+    EXPECT_CALL(on_channel_filter_created_fn_, Call(1, 0, "driver2", Write));
+    EXPECT_CALL(on_message_forward_fn_, Call(1, 0, "driver2", Write, MSG(wire::ChannelOpenConfirmationMsg, FIELD_EQ(recipient_channel, 1u))));
+    EXPECT_CALL(on_message_forward_fn_, Call(1, 0, "driver2", Read, MSG(wire::ChannelDataMsg, FIELD_EQ(data, "driver 2 channel 1"_bytes))));
+    EXPECT_CALL(on_message_forward_fn_, Call(1, 0, "driver2", Write, MSG(wire::ChannelDataMsg, FIELD_EQ(data, "driver 2 channel 1"_bytes))));
+    ASSERT_TRUE(driver2_->wait(
+      driver2_->createTask<Tasks::OpenSessionChannel>(1)
+        .saveOutput(&driver2Channel1)
+        .then(driver2_->createTask<Tasks::SendChannelData>("driver 2 channel 1")
+                .then(driver2_->createTask<Tasks::WaitForChannelData>("driver 2 channel 1")))
+        .start()));
+
+    EXPECT_CALL(on_channel_filter_created_fn_, Call(1, 1, "driver2", Read));
+    EXPECT_CALL(on_message_forward_fn_, Call(1, 1, "driver2", Read, MSG(wire::ChannelOpenMsg, _)));
+    EXPECT_CALL(on_channel_filter_created_fn_, Call(1, 1, "driver2", Write));
+    EXPECT_CALL(on_message_forward_fn_, Call(1, 1, "driver2", Write, MSG(wire::ChannelOpenConfirmationMsg, FIELD_EQ(recipient_channel, 2u))));
+    EXPECT_CALL(on_message_forward_fn_, Call(1, 1, "driver2", Read, MSG(wire::ChannelDataMsg, FIELD_EQ(data, "driver 2 channel 2"_bytes))));
+    EXPECT_CALL(on_message_forward_fn_, Call(1, 1, "driver2", Write, MSG(wire::ChannelDataMsg, FIELD_EQ(data, "driver 2 channel 2"_bytes))));
+    ASSERT_TRUE(driver2_->wait(
+      driver2_->createTask<Tasks::OpenSessionChannel>(2)
+        .saveOutput(&driver2Channel2)
+        .then(driver2_->createTask<Tasks::SendChannelData>("driver 2 channel 2")
+                .then(driver2_->createTask<Tasks::WaitForChannelData>("driver 2 channel 2")))
+        .start()));
+  }
+
+  // Close the channels
+
+  {
+    IN_SEQUENCE;
+
+    EXPECT_CALL(on_message_forward_fn_, Call(0, 0, "driver1", Read, MSG(wire::ChannelCloseMsg, FIELD_EQ(recipient_channel, driver1Channel1.remote_id))));
+    EXPECT_CALL(on_channel_filter_destroyed_fn_, Call(0, 0, "driver1", Read));
+    EXPECT_CALL(on_message_forward_fn_, Call(0, 0, "driver1", Write, MSG(wire::ChannelCloseMsg, FIELD_EQ(recipient_channel, driver1Channel1.local_id))));
+    EXPECT_CALL(on_channel_filter_destroyed_fn_, Call(0, 0, "driver1", Write));
+    ASSERT_TRUE(driver1_->wait(
+      driver1_->createTask<Tasks::SendChannelCloseAndWait>()
+        .start(driver1Channel1)));
+
+    EXPECT_CALL(on_message_forward_fn_, Call(0, 1, "driver1", Read, MSG(wire::ChannelCloseMsg, FIELD_EQ(recipient_channel, driver1Channel2.remote_id))));
+    EXPECT_CALL(on_channel_filter_destroyed_fn_, Call(0, 1, "driver1", Read));
+    EXPECT_CALL(on_message_forward_fn_, Call(0, 1, "driver1", Write, MSG(wire::ChannelCloseMsg, FIELD_EQ(recipient_channel, driver1Channel2.local_id))));
+    EXPECT_CALL(on_channel_filter_destroyed_fn_, Call(0, 1, "driver1", Write));
+    ASSERT_TRUE(driver1_->wait(
+      driver1_->createTask<Tasks::SendChannelCloseAndWait>()
+        .start(driver1Channel2)));
+  }
+
+  {
+    IN_SEQUENCE;
+
+    EXPECT_CALL(on_message_forward_fn_, Call(1, 0, "driver2", Read, MSG(wire::ChannelCloseMsg, FIELD_EQ(recipient_channel, driver2Channel1.remote_id))));
+    EXPECT_CALL(on_channel_filter_destroyed_fn_, Call(1, 0, "driver2", Read));
+    EXPECT_CALL(on_message_forward_fn_, Call(1, 0, "driver2", Write, MSG(wire::ChannelCloseMsg, FIELD_EQ(recipient_channel, driver2Channel1.local_id))));
+    EXPECT_CALL(on_channel_filter_destroyed_fn_, Call(1, 0, "driver2", Write));
+    ASSERT_TRUE(driver2_->wait(
+      driver2_->createTask<Tasks::SendChannelCloseAndWait>()
+        .start(driver2Channel1)));
+
+    EXPECT_CALL(on_message_forward_fn_, Call(1, 1, "driver2", Read, MSG(wire::ChannelCloseMsg, FIELD_EQ(recipient_channel, driver2Channel2.remote_id))));
+    EXPECT_CALL(on_channel_filter_destroyed_fn_, Call(1, 1, "driver2", Read));
+    EXPECT_CALL(on_message_forward_fn_, Call(1, 1, "driver2", Write, MSG(wire::ChannelCloseMsg, FIELD_EQ(recipient_channel, driver2Channel2.local_id))));
+    EXPECT_CALL(on_channel_filter_destroyed_fn_, Call(1, 1, "driver2", Write));
+    ASSERT_TRUE(driver2_->wait(
+      driver2_->createTask<Tasks::SendChannelCloseAndWait>()
+        .start(driver2Channel2)));
+  }
+
+  EXPECT_CALL(on_channel_filter_factory_destroyed_fn_, Call(0));
+  ASSERT_TRUE(driver1_->disconnect());
+  EXPECT_CALL(on_channel_filter_factory_destroyed_fn_, Call(1));
+  ASSERT_TRUE(driver2_->disconnect());
+}
+
+} // namespace test
+} // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/test/extensions/filters/network/ssh/filter_manager_test.cc
+++ b/test/extensions/filters/network/ssh/filter_manager_test.cc
@@ -17,15 +17,11 @@ enum Direction {
 };
 
 using on_channel_filter_created_fn_t = testing::StrictMock<testing::MockFunction<void(uint32_t, uint32_t, std::string, Direction)>>;
-using on_channel_filter_destroyed_fn_t = testing::StrictMock<testing::MockFunction<void(uint32_t, uint32_t, std::string, Direction)>>;
 using on_channel_filter_factory_created_fn_t = testing::StrictMock<testing::MockFunction<void(uint32_t)>>;
-using on_channel_filter_factory_destroyed_fn_t = testing::StrictMock<testing::MockFunction<void(uint32_t)>>;
 using on_message_forward_fn_t = testing::StrictMock<testing::MockFunction<void(uint32_t, uint32_t, std::string, Direction, const wire::Message&)>>;
 
 static Envoy::OptRef<on_channel_filter_created_fn_t> on_channel_filter_created;
-static Envoy::OptRef<on_channel_filter_destroyed_fn_t> on_channel_filter_destroyed;
 static Envoy::OptRef<on_channel_filter_factory_created_fn_t> on_channel_filter_factory_created;
-static Envoy::OptRef<on_channel_filter_factory_destroyed_fn_t> on_channel_filter_factory_destroyed;
 static Envoy::OptRef<on_message_forward_fn_t> on_message_forward;
 
 class TestChannelFilter : public ChannelFilter {
@@ -36,9 +32,6 @@ public:
         name_(name),
         direction_(direction) {
     on_channel_filter_created->Call(instance_num_, filter_instance_num_, name_, direction_);
-  }
-  ~TestChannelFilter() {
-    on_channel_filter_destroyed->Call(instance_num_, filter_instance_num_, name_, direction_);
   }
 
   void onMessageForward(const wire::Message& msg) override {
@@ -57,9 +50,6 @@ public:
   TestChannelFilterFactory(uint32_t instance_num)
       : instance_num_(instance_num) {
     on_channel_filter_factory_created->Call(instance_num_);
-  }
-  ~TestChannelFilterFactory() {
-    on_channel_filter_factory_destroyed->Call(instance_num_);
   }
 
   Envoy::ProtobufTypes::MessagePtr createEmptyConfigProto() override {
@@ -146,16 +136,21 @@ public:
     });
   }
 
+  ~ChannelFilterManagerIntegrationTest() {
+    EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(on_channel_filter_created.ptr()));
+    EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(on_channel_filter_factory_created.ptr()));
+    EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(on_message_forward.ptr()));
+    on_channel_filter_created.reset();
+    on_channel_filter_factory_created.reset();
+    on_message_forward.reset();
+  }
+
   void SetUp() override {
     ASSERT_FALSE(on_channel_filter_created.has_value());
-    ASSERT_FALSE(on_channel_filter_destroyed.has_value());
     ASSERT_FALSE(on_channel_filter_factory_created.has_value());
-    ASSERT_FALSE(on_channel_filter_factory_destroyed.has_value());
     ASSERT_FALSE(on_message_forward.has_value());
     on_channel_filter_created.emplace(on_channel_filter_created_fn_);
-    on_channel_filter_destroyed.emplace(on_channel_filter_destroyed_fn_);
     on_channel_filter_factory_created.emplace(on_channel_filter_factory_created_fn_);
-    on_channel_filter_factory_destroyed.emplace(on_channel_filter_factory_destroyed_fn_);
     on_message_forward.emplace(on_message_forward_fn_);
     initialize();
   }
@@ -164,11 +159,6 @@ public:
     EXPECT_TRUE(driver1_->closed());
     EXPECT_TRUE(driver2_->closed());
     cleanup();
-    on_channel_filter_created.reset();
-    on_channel_filter_destroyed.reset();
-    on_channel_filter_factory_created.reset();
-    on_channel_filter_factory_destroyed.reset();
-    on_message_forward.reset();
   }
 
   void StartListeningForNewSshConnection() {
@@ -197,9 +187,7 @@ public:
     }));
   }
   on_channel_filter_created_fn_t on_channel_filter_created_fn_;
-  on_channel_filter_created_fn_t on_channel_filter_destroyed_fn_;
   on_channel_filter_factory_created_fn_t on_channel_filter_factory_created_fn_;
-  on_channel_filter_factory_destroyed_fn_t on_channel_filter_factory_destroyed_fn_;
   on_message_forward_fn_t on_message_forward_fn_;
 
   std::shared_ptr<SshConnectionDriver> driver1_;
@@ -310,17 +298,13 @@ TEST_F(ChannelFilterManagerIntegrationTest, TestChannelFilterManagerPerConnectio
     IN_SEQUENCE;
 
     EXPECT_CALL(on_message_forward_fn_, Call(0, 0, "driver1", Read, MSG(wire::ChannelCloseMsg, FIELD_EQ(recipient_channel, driver1Channel1.remote_id))));
-    EXPECT_CALL(on_channel_filter_destroyed_fn_, Call(0, 0, "driver1", Read));
     EXPECT_CALL(on_message_forward_fn_, Call(0, 0, "driver1", Write, MSG(wire::ChannelCloseMsg, FIELD_EQ(recipient_channel, driver1Channel1.local_id))));
-    EXPECT_CALL(on_channel_filter_destroyed_fn_, Call(0, 0, "driver1", Write));
     ASSERT_TRUE(driver1_->wait(
       driver1_->createTask<Tasks::SendChannelCloseAndWait>()
         .start(driver1Channel1)));
 
     EXPECT_CALL(on_message_forward_fn_, Call(0, 1, "driver1", Read, MSG(wire::ChannelCloseMsg, FIELD_EQ(recipient_channel, driver1Channel2.remote_id))));
-    EXPECT_CALL(on_channel_filter_destroyed_fn_, Call(0, 1, "driver1", Read));
     EXPECT_CALL(on_message_forward_fn_, Call(0, 1, "driver1", Write, MSG(wire::ChannelCloseMsg, FIELD_EQ(recipient_channel, driver1Channel2.local_id))));
-    EXPECT_CALL(on_channel_filter_destroyed_fn_, Call(0, 1, "driver1", Write));
     ASSERT_TRUE(driver1_->wait(
       driver1_->createTask<Tasks::SendChannelCloseAndWait>()
         .start(driver1Channel2)));
@@ -330,25 +314,19 @@ TEST_F(ChannelFilterManagerIntegrationTest, TestChannelFilterManagerPerConnectio
     IN_SEQUENCE;
 
     EXPECT_CALL(on_message_forward_fn_, Call(1, 0, "driver2", Read, MSG(wire::ChannelCloseMsg, FIELD_EQ(recipient_channel, driver2Channel1.remote_id))));
-    EXPECT_CALL(on_channel_filter_destroyed_fn_, Call(1, 0, "driver2", Read));
     EXPECT_CALL(on_message_forward_fn_, Call(1, 0, "driver2", Write, MSG(wire::ChannelCloseMsg, FIELD_EQ(recipient_channel, driver2Channel1.local_id))));
-    EXPECT_CALL(on_channel_filter_destroyed_fn_, Call(1, 0, "driver2", Write));
     ASSERT_TRUE(driver2_->wait(
       driver2_->createTask<Tasks::SendChannelCloseAndWait>()
         .start(driver2Channel1)));
 
     EXPECT_CALL(on_message_forward_fn_, Call(1, 1, "driver2", Read, MSG(wire::ChannelCloseMsg, FIELD_EQ(recipient_channel, driver2Channel2.remote_id))));
-    EXPECT_CALL(on_channel_filter_destroyed_fn_, Call(1, 1, "driver2", Read));
     EXPECT_CALL(on_message_forward_fn_, Call(1, 1, "driver2", Write, MSG(wire::ChannelCloseMsg, FIELD_EQ(recipient_channel, driver2Channel2.local_id))));
-    EXPECT_CALL(on_channel_filter_destroyed_fn_, Call(1, 1, "driver2", Write));
     ASSERT_TRUE(driver2_->wait(
       driver2_->createTask<Tasks::SendChannelCloseAndWait>()
         .start(driver2Channel2)));
   }
 
-  EXPECT_CALL(on_channel_filter_factory_destroyed_fn_, Call(0));
   ASSERT_TRUE(driver1_->disconnect());
-  EXPECT_CALL(on_channel_filter_factory_destroyed_fn_, Call(1));
   ASSERT_TRUE(driver2_->disconnect());
 }
 

--- a/test/extensions/filters/network/ssh/server_transport_test.cc
+++ b/test/extensions/filters/network/ssh/server_transport_test.cc
@@ -13,6 +13,7 @@
 #include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/proto_equal.h"
 #include "test/test_common/test_common.h"
+#include "test/test_common/registry.h"
 #include "source/extensions/filters/network/ssh/service_connection.h" // IWYU pragma: keep
 #include "source/extensions/filters/network/ssh/service_userauth.h"   // IWYU pragma: keep
 #include "gmock/gmock.h"
@@ -34,7 +35,7 @@ public:
       : server_config_(newConfig()),
         client_host_key_(*openssh::SSHKey::generate(KEY_ED25519, 256)),
         secrets_provider_(*server_config_),
-        channel_filter_manager_(std::make_shared<ChannelFilterManager>(server_factory_context_, std::vector<std::string>{})),
+        channel_filter_manager_(std::make_shared<ChannelFilterManager>(ExtensionConfigList{}, server_factory_context_)),
         transport_([this] {
           ON_CALL(server_factory_context_.drain_manager_, addOnDrainCloseCb)
             .WillByDefault([this](Network::DrainDirection, Network::DrainDecision::DrainCloseCb cb) {
@@ -325,6 +326,30 @@ public:
     serve_channel_callbacks_[stream_index]->onReceiveMessage(std::move(ptr));
   }
 
+  void SetupChannelFilterManager() {
+    ON_CALL(channel_filter_factory_config_, createEmptyConfigProto)
+      .WillByDefault([] {
+        return std::make_unique<Envoy::Protobuf::StringValue>();
+      });
+    ON_CALL(channel_filter_factory_config_, name)
+      .WillByDefault(Return("test_channel_filter"));
+
+    ExtensionConfigList enabledChannelFilters;
+    {
+      auto* factoryConfig = enabledChannelFilters.Add();
+      factoryConfig->set_name("test_channel_filter");
+      Envoy::Protobuf::StringValue v;
+      v.set_value("factory_config");
+      factoryConfig->mutable_typed_config()->PackFrom(v);
+    }
+
+    inject_ = std::make_unique<Registry::InjectFactory<ChannelFilterFactoryConfig>>(channel_filter_factory_config_);
+
+    auto* channelFilterMgr = channel_filter_manager_.get();
+    channelFilterMgr->~ChannelFilterManager();
+    new (channelFilterMgr) ChannelFilterManager(enabledChannelFilters, server_factory_context_);
+  }
+
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context_;
   std::shared_ptr<pomerium::extensions::ssh::CodecConfig> server_config_;
   Envoy::Common::CallbackManager<absl::Status, std::chrono::milliseconds> drain_close_callbacks_;
@@ -338,6 +363,8 @@ public:
   openssh::SSHKeyPtr client_host_key_;
   TestSecretsProvider secrets_provider_;
   ChannelFilterManagerSharedPtr channel_filter_manager_;
+  testing::NiceMock<MockChannelFilterFactoryConfig> channel_filter_factory_config_;
+  std::unique_ptr<Registry::InjectFactory<ChannelFilterFactoryConfig>> inject_;
   testing::StrictMock<MockServerCodecCallbacks> server_codec_callbacks_;
   testing::NiceMock<Envoy::Network::MockServerConnection> mock_connection_;
   Envoy::Grpc::AsyncStreamCallbacks<ServerMessage>* manage_stream_callbacks_{};
@@ -697,6 +724,130 @@ TEST_F(ServerTransportTest, ForwardGlobalRequests) {
 
   ASSERT_OK(WriteMsg(auto(tcpipForwardMsg)));
   ASSERT_OK(WriteMsg(auto(cancelTcpipForwardMsg)));
+}
+
+// NOLINTBEGIN(readability-identifier-naming)
+class ChannelFilterConfigTest : public ServerTransportTest {
+public:
+  void SetUp() override {
+    ServerTransportTest::SetUp();
+
+    ON_CALL(channel_filter_factory_config_, createChannelFilterFactory)
+      .WillByDefault([&](const google::protobuf::Message& config, const Envoy::Server::Configuration::ServerFactoryContext&) {
+        EXPECT_EQ("factory_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
+
+        auto factory = std::make_unique<testing::NiceMock<MockChannelFilterFactory>>();
+        ON_CALL(*factory, createEmptyConfigProto)
+          .WillByDefault([] {
+            return std::make_unique<Envoy::Protobuf::StringValue>();
+          });
+        return factory;
+      });
+    SetupChannelFilterManager();
+  }
+};
+// NOLINTEND(readability-identifier-naming)
+
+TEST_F(ChannelFilterConfigTest, ConfigureChannelFilters) {
+  ASSERT_OK(ReadExtInfo());
+
+  auto clientKey = *openssh::SSHKey::generate(KEY_ED25519, 256);
+
+  ASSERT_OK(RequestUserAuthService());
+  auto [authReq, clientMsg] = BuildUserAuthMessages(*clientKey);
+
+  EXPECT_CALL(manage_stream_stream_, sendMessageRaw_(ProtoBufferStrictEq(clientMsg), false))
+    .WillOnce([this](Buffer::InstancePtr&, bool) {
+      auto response = std::make_unique<ServerMessage>();
+      auto* allow = response->mutable_auth_response()->mutable_allow();
+      allow->set_username("test");
+      auto* upstream = allow->mutable_upstream();
+      upstream->set_hostname("example");
+      *upstream->add_allowed_methods()->mutable_method() = "publickey";
+
+      // configure channel filters
+      auto* filter = upstream->add_channel_filters();
+      filter->set_name("test_channel_filter");
+      Envoy::Protobuf::StringValue filterConfig;
+      filterConfig.set_value("filter_config");
+      filter->mutable_typed_config()->PackFrom(filterConfig);
+
+      manage_stream_callbacks_->onReceiveMessage(std::move(response));
+    });
+  ExpectDecodingSuccess();
+  ExpectUpstreamConnectEvent();
+
+  ASSERT_OK(WriteMsg(std::move(authReq)));
+
+  EXPECT_EQ(1, channel_filter_manager_->numConfiguredFilters());
+}
+
+TEST_F(ChannelFilterConfigTest, ConfigureChannelFilters_InvalidChannelFilterConfig) {
+  ASSERT_OK(ReadExtInfo());
+
+  auto clientKey = *openssh::SSHKey::generate(KEY_ED25519, 256);
+
+  ASSERT_OK(RequestUserAuthService());
+  auto [authReq, clientMsg] = BuildUserAuthMessages(*clientKey);
+
+  EXPECT_CALL(manage_stream_stream_, sendMessageRaw_(ProtoBufferStrictEq(clientMsg), false))
+    .WillOnce([this](Buffer::InstancePtr&, bool) {
+      auto response = std::make_unique<ServerMessage>();
+      auto* allow = response->mutable_auth_response()->mutable_allow();
+      allow->set_username("test");
+      auto* upstream = allow->mutable_upstream();
+      upstream->set_hostname("example");
+      *upstream->add_allowed_methods()->mutable_method() = "publickey";
+
+      auto* filter = upstream->add_channel_filters();
+      filter->set_name("test_channel_filter");
+      Envoy::Protobuf::Int64Value filterConfig;
+      filterConfig.set_value(1234);
+      filter->mutable_typed_config()->PackFrom(filterConfig);
+
+      manage_stream_callbacks_->onReceiveMessage(std::move(response));
+    });
+
+  EXPECT_CALL(server_codec_callbacks_, onDecodingFailure(HasSubstr("invalid channel filter config")));
+  ASSERT_OK(WriteMsg(std::move(authReq)));
+
+  EXPECT_EQ(0, channel_filter_manager_->numConfiguredFilters());
+}
+
+TEST_F(ChannelFilterConfigTest, ConfigureChannelFilters_ChannelFilterNotFound) {
+  ASSERT_OK(ReadExtInfo());
+
+  auto clientKey = *openssh::SSHKey::generate(KEY_ED25519, 256);
+
+  ASSERT_OK(RequestUserAuthService());
+  auto [authReq, clientMsg] = BuildUserAuthMessages(*clientKey);
+
+  EXPECT_CALL(manage_stream_stream_, sendMessageRaw_(ProtoBufferStrictEq(clientMsg), false))
+    .WillOnce([this](Buffer::InstancePtr&, bool) {
+      auto response = std::make_unique<ServerMessage>();
+      auto* allow = response->mutable_auth_response()->mutable_allow();
+      allow->set_username("test");
+      auto* upstream = allow->mutable_upstream();
+      upstream->set_hostname("example");
+      *upstream->add_allowed_methods()->mutable_method() = "publickey";
+
+      auto* filter = upstream->add_channel_filters();
+      filter->set_name("test_channel_filter");
+      Envoy::Protobuf::StringValue filterConfig;
+      filterConfig.set_value("filter_config");
+      filter->mutable_typed_config()->PackFrom(filterConfig);
+
+      // add another filter that doesn't exist
+      upstream->add_channel_filters()
+        ->set_name("nonexistent");
+
+      manage_stream_callbacks_->onReceiveMessage(std::move(response));
+    });
+
+  EXPECT_CALL(server_codec_callbacks_, onDecodingFailure(HasSubstr("channel filter not found: nonexistent")));
+  ASSERT_OK(WriteMsg(std::move(authReq)));
+
+  EXPECT_EQ(0, channel_filter_manager_->numConfiguredFilters());
 }
 
 // NOLINTBEGIN(readability-identifier-naming)
@@ -1676,6 +1827,76 @@ TEST_F(HandoffTest, HandoffMode_HandoffMsgMissingDownstreamChannelInfo) {
 
   EXPECT_CALL(server_codec_callbacks_, onDecodingFailure("received invalid handoff message: missing downstream channel info"));
   ReceiveOnServeChannelStream(ctrl);
+}
+
+TEST_F(HandoffTest, HandoffMode_ConfigureChannelFilters) {
+  EXPECT_CALL(channel_filter_factory_config_, createChannelFilterFactory)
+    .WillOnce([&](const google::protobuf::Message& config, const Envoy::Server::Configuration::ServerFactoryContext&) {
+      EXPECT_EQ("factory_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
+
+      auto factory = std::make_unique<testing::NiceMock<MockChannelFilterFactory>>();
+      EXPECT_CALL(*factory, createEmptyConfigProto)
+        .WillOnce([] {
+          return std::make_unique<Envoy::Protobuf::StringValue>();
+        });
+      return factory;
+    });
+  SetupChannelFilterManager();
+
+  ASSERT_OK(PrepareHandoff());
+  SendChannelOpenConfirmation();
+  ExpectUpstreamConnectEvent();
+  EXPECT_CALL(mock_connection_, readDisable(true));
+  ExpectDecodingSuccess();
+
+  auto msg = BuildHandOffChannelMessage();
+  SSHChannelControlAction action;
+  msg.mutable_channel_control()->mutable_control_action()->UnpackTo(&action);
+  auto* filter = action.mutable_hand_off()->mutable_upstream_auth()->mutable_upstream()->add_channel_filters();
+  filter->set_name("test_channel_filter");
+  Envoy::Protobuf::StringValue v;
+  v.set_value("filter_config");
+  filter->mutable_typed_config()->PackFrom(v);
+  msg.mutable_channel_control()->mutable_control_action()->PackFrom(action);
+
+  ReceiveOnServeChannelStream(msg);
+  serve_channel_callbacks_[0]->onRemoteClose(Envoy::Grpc::Status::Canceled, "handoff");
+
+  EXPECT_EQ(1, channel_filter_manager_->numConfiguredFilters());
+}
+
+TEST_F(HandoffTest, HandoffMode_ConfigureChannelFiltersError) {
+  EXPECT_CALL(channel_filter_factory_config_, createChannelFilterFactory)
+    .WillOnce([&](const google::protobuf::Message& config, const Envoy::Server::Configuration::ServerFactoryContext&) {
+      EXPECT_EQ("factory_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
+
+      auto factory = std::make_unique<testing::NiceMock<MockChannelFilterFactory>>();
+      EXPECT_CALL(*factory, createEmptyConfigProto)
+        .WillOnce([] {
+          return std::make_unique<Envoy::Protobuf::StringValue>();
+        });
+      return factory;
+    });
+  SetupChannelFilterManager();
+
+  ASSERT_OK(PrepareHandoff());
+  SendChannelOpenConfirmation();
+  // Upstream connect event, readDisable(true), and decoding success should not occur
+
+  auto msg = BuildHandOffChannelMessage();
+  SSHChannelControlAction action;
+  msg.mutable_channel_control()->mutable_control_action()->UnpackTo(&action);
+  auto* filter = action.mutable_hand_off()->mutable_upstream_auth()->mutable_upstream()->add_channel_filters();
+  filter->set_name("test_channel_filter");
+  Envoy::Protobuf::Int64Value v;
+  v.set_value(1234);
+  filter->mutable_typed_config()->PackFrom(v);
+  msg.mutable_channel_control()->mutable_control_action()->PackFrom(action);
+
+  EXPECT_CALL(server_codec_callbacks_, onDecodingFailure(HasSubstr("invalid channel filter config")));
+  ReceiveOnServeChannelStream(msg);
+
+  EXPECT_EQ(0, channel_filter_manager_->numConfiguredFilters());
 }
 
 TEST_F(ServerTransportTest, SuccessfulUserAuth_MirrorMode) {

--- a/test/extensions/filters/network/ssh/server_transport_test.cc
+++ b/test/extensions/filters/network/ssh/server_transport_test.cc
@@ -34,6 +34,7 @@ public:
       : server_config_(newConfig()),
         client_host_key_(*openssh::SSHKey::generate(KEY_ED25519, 256)),
         secrets_provider_(*server_config_),
+        channel_filter_manager_(std::make_shared<ChannelFilterManager>(server_factory_context_, std::vector<std::string>{})),
         transport_([this] {
           ON_CALL(server_factory_context_.drain_manager_, addOnDrainCloseCb)
             .WillByDefault([this](Network::DrainDirection, Network::DrainDecision::DrainCloseCb cb) {
@@ -70,6 +71,7 @@ public:
               return client;
             },
             StreamTracker::fromContext(server_factory_context_),
+            channel_filter_manager_,
             secrets_provider_);
         }()) {}
 
@@ -335,6 +337,7 @@ public:
   Envoy::Buffer::OwnedImpl output_buffer_;
   openssh::SSHKeyPtr client_host_key_;
   TestSecretsProvider secrets_provider_;
+  ChannelFilterManagerSharedPtr channel_filter_manager_;
   testing::StrictMock<MockServerCodecCallbacks> server_codec_callbacks_;
   testing::NiceMock<Envoy::Network::MockServerConnection> mock_connection_;
   Envoy::Grpc::AsyncStreamCallbacks<ServerMessage>* manage_stream_callbacks_{};

--- a/test/extensions/filters/network/ssh/server_transport_test.cc
+++ b/test/extensions/filters/network/ssh/server_transport_test.cc
@@ -35,7 +35,6 @@ public:
       : server_config_(newConfig()),
         client_host_key_(*openssh::SSHKey::generate(KEY_ED25519, 256)),
         secrets_provider_(*server_config_),
-        channel_filter_manager_(std::make_shared<ChannelFilterManager>(ExtensionConfigList{}, server_factory_context_)),
         transport_([this] {
           ON_CALL(server_factory_context_.drain_manager_, addOnDrainCloseCb)
             .WillByDefault([this](Network::DrainDirection, Network::DrainDecision::DrainCloseCb cb) {
@@ -72,7 +71,6 @@ public:
               return client;
             },
             StreamTracker::fromContext(server_factory_context_),
-            channel_filter_manager_,
             secrets_provider_);
         }()) {}
 
@@ -345,7 +343,7 @@ public:
 
     inject_ = std::make_unique<Registry::InjectFactory<ChannelFilterFactoryConfig>>(channel_filter_factory_config_);
 
-    auto* channelFilterMgr = channel_filter_manager_.get();
+    auto* channelFilterMgr = &transport_.channelFilterManager();
     channelFilterMgr->~ChannelFilterManager();
     new (channelFilterMgr) ChannelFilterManager(enabledChannelFilters, server_factory_context_);
   }
@@ -362,7 +360,6 @@ public:
   Envoy::Buffer::OwnedImpl output_buffer_;
   openssh::SSHKeyPtr client_host_key_;
   TestSecretsProvider secrets_provider_;
-  ChannelFilterManagerSharedPtr channel_filter_manager_;
   testing::NiceMock<MockChannelFilterFactoryConfig> channel_filter_factory_config_;
   std::unique_ptr<Registry::InjectFactory<ChannelFilterFactoryConfig>> inject_;
   testing::StrictMock<MockServerCodecCallbacks> server_codec_callbacks_;
@@ -779,7 +776,7 @@ TEST_F(ChannelFilterConfigTest, ConfigureChannelFilters) {
 
   ASSERT_OK(WriteMsg(std::move(authReq)));
 
-  EXPECT_EQ(1, channel_filter_manager_->numConfiguredFilters());
+  EXPECT_EQ(1, transport_.channelFilterManager().numConfiguredFilters());
 }
 
 TEST_F(ChannelFilterConfigTest, ConfigureChannelFilters_InvalidChannelFilterConfig) {
@@ -811,7 +808,7 @@ TEST_F(ChannelFilterConfigTest, ConfigureChannelFilters_InvalidChannelFilterConf
   EXPECT_CALL(server_codec_callbacks_, onDecodingFailure(HasSubstr("invalid channel filter config")));
   ASSERT_OK(WriteMsg(std::move(authReq)));
 
-  EXPECT_EQ(0, channel_filter_manager_->numConfiguredFilters());
+  EXPECT_EQ(0, transport_.channelFilterManager().numConfiguredFilters());
 }
 
 TEST_F(ChannelFilterConfigTest, ConfigureChannelFilters_ChannelFilterNotFound) {
@@ -847,7 +844,7 @@ TEST_F(ChannelFilterConfigTest, ConfigureChannelFilters_ChannelFilterNotFound) {
   EXPECT_CALL(server_codec_callbacks_, onDecodingFailure(HasSubstr("channel filter not found: nonexistent")));
   ASSERT_OK(WriteMsg(std::move(authReq)));
 
-  EXPECT_EQ(0, channel_filter_manager_->numConfiguredFilters());
+  EXPECT_EQ(0, transport_.channelFilterManager().numConfiguredFilters());
 }
 
 // NOLINTBEGIN(readability-identifier-naming)
@@ -1862,7 +1859,7 @@ TEST_F(HandoffTest, HandoffMode_ConfigureChannelFilters) {
   ReceiveOnServeChannelStream(msg);
   serve_channel_callbacks_[0]->onRemoteClose(Envoy::Grpc::Status::Canceled, "handoff");
 
-  EXPECT_EQ(1, channel_filter_manager_->numConfiguredFilters());
+  EXPECT_EQ(1, transport_.channelFilterManager().numConfiguredFilters());
 }
 
 TEST_F(HandoffTest, HandoffMode_ConfigureChannelFiltersError) {
@@ -1896,7 +1893,7 @@ TEST_F(HandoffTest, HandoffMode_ConfigureChannelFiltersError) {
   EXPECT_CALL(server_codec_callbacks_, onDecodingFailure(HasSubstr("invalid channel filter config")));
   ReceiveOnServeChannelStream(msg);
 
-  EXPECT_EQ(0, channel_filter_manager_->numConfiguredFilters());
+  EXPECT_EQ(0, transport_.channelFilterManager().numConfiguredFilters());
 }
 
 TEST_F(ServerTransportTest, SuccessfulUserAuth_MirrorMode) {

--- a/test/extensions/filters/network/ssh/service_connection_impl_test.cc
+++ b/test/extensions/filters/network/ssh/service_connection_impl_test.cc
@@ -397,6 +397,7 @@ TEST_F(UpstreamConnectionServiceTest, TestChannelWriteFilters) {
       EXPECT_EQ("filter_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
       EXPECT_EQ(static_cast<stream_id_t>(1), filter_callbacks.streamId());
       EXPECT_EQ(&std::as_const(fake_auth_info_), &filter_callbacks.authInfo());
+      EXPECT_EQ(&mock_dispatcher_, &filter_callbacks.connectionDispatcher());
       channelFilterCallbacks = &filter_callbacks;
       EXPECT_EQ(channelId, filter_callbacks.channelId());
       return std::move(filter);

--- a/test/extensions/filters/network/ssh/service_connection_impl_test.cc
+++ b/test/extensions/filters/network/ssh/service_connection_impl_test.cc
@@ -246,6 +246,7 @@ TEST_F(DownstreamConnectionServiceTest, TestChannelReadFilters) {
   EXPECT_CALL(*factory, createReadFilter)
     .WillOnce([&](const google::protobuf::Message& config, ChannelFilterCallbacks& filter_callbacks) {
       EXPECT_EQ("filter_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
+      EXPECT_EQ(static_cast<stream_id_t>(1), filter_callbacks.streamId());
       channelFilterCallbacks = &filter_callbacks;
       EXPECT_EQ(channelId, filter_callbacks.channelId());
       // no channel open message has been received yet, so channelType should return nullopt
@@ -389,6 +390,7 @@ TEST_F(UpstreamConnectionServiceTest, TestChannelWriteFilters) {
   EXPECT_CALL(*factory, createWriteFilter)
     .WillOnce([&](const google::protobuf::Message& config, ChannelFilterCallbacks& filter_callbacks) {
       EXPECT_EQ("filter_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
+      EXPECT_EQ(static_cast<stream_id_t>(1), filter_callbacks.streamId());
       channelFilterCallbacks = &filter_callbacks;
       EXPECT_EQ(channelId, filter_callbacks.channelId());
       return std::move(filter);

--- a/test/extensions/filters/network/ssh/service_connection_impl_test.cc
+++ b/test/extensions/filters/network/ssh/service_connection_impl_test.cc
@@ -450,13 +450,16 @@ TEST_F(UpstreamConnectionServiceTest, TestChannelWriteFilters) {
   });
   ASSERT_TRUE(channelFilterCallbacks->interruptChannel(absl::InternalError("test error")));
   EXPECT_TRUE(called);
+
+  // interruptChannel should return false if called a second time, since the channel is no longer
+  // preemptible.
+  // Order is important wrt receiving the ChannelClose message below. After receiving the close
+  // message the channel will be destroyed and channelFilterCallbacks will point to garbage.
+  ASSERT_FALSE(channelFilterCallbacks->interruptChannel(absl::InternalError("test error")));
+
   ASSERT_OK(service_->handleMessage(wire::ChannelCloseMsg{
     .recipient_channel = channelId,
   }));
-
-  // interruptChannel should return false if called a second time, since the channel is no longer
-  // preemptible
-  ASSERT_FALSE(channelFilterCallbacks->interruptChannel(absl::InternalError("test error")));
 }
 
 } // namespace test

--- a/test/extensions/filters/network/ssh/service_connection_impl_test.cc
+++ b/test/extensions/filters/network/ssh/service_connection_impl_test.cc
@@ -4,6 +4,7 @@
 #include <cstdlib>
 
 #include "source/extensions/filters/network/ssh/channel.h"
+#include "source/extensions/filters/network/ssh/channel_filter_config.h"
 #include "source/extensions/filters/network/ssh/id_manager.h"
 #include "source/extensions/filters/network/ssh/service_connection.h"
 #include "source/extensions/filters/network/ssh/stream_tracker.h"
@@ -12,6 +13,7 @@
 #include "test/extensions/filters/network/ssh/wire/test_field_reflect.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/test_common.h"
+#include "test/test_common/registry.h"
 
 // Note: these tests are separate from the regular ConnectionService tests, due to the dependency
 // on MockServerFactoryContext which triples compile time
@@ -30,11 +32,34 @@ public:
   UpstreamConnectionServiceTest() {
     transport_ = std::make_unique<testing::StrictMock<MockUpstreamTransportCallbacks>>();
     service_ = std::make_unique<UpstreamConnectionService>(ConnectionServiceOptions{}, *transport_);
+    channel_filter_manager_ = std::make_unique<ChannelFilterManager>(context_, std::vector<std::string>{});
     service_->registerMessageHandlers(msg_dispatcher_);
+    EXPECT_CALL(*transport_, streamId)
+      .WillRepeatedly(Return(1));
+    EXPECT_CALL(*transport_, channelIdManager)
+      .WillRepeatedly(ReturnRef(channel_id_manager_));
+    EXPECT_CALL(*transport_, secretsProvider)
+      .WillRepeatedly(ReturnRef(secrets_provider_));
+    EXPECT_CALL(*transport_, statsScope)
+      .Times(AnyNumber());
+    EXPECT_CALL(*transport_, connectionDispatcher)
+      .WillRepeatedly([this] -> Envoy::OptRef<Envoy::Event::Dispatcher> {
+        return mock_dispatcher_;
+      });
+    EXPECT_CALL(*transport_, channelFilterManager)
+      .Times(AnyNumber())
+      .WillRepeatedly([this] -> ChannelFilterManager& {
+        return *channel_filter_manager_;
+      });
   }
 
 protected:
+  NiceMock<Envoy::Event::MockDispatcher> mock_dispatcher_; // field order is important
+  ChannelIDManager channel_id_manager_{100, 100};
+  TestSecretsProvider secrets_provider_;
   TestSshMessageDispatcher msg_dispatcher_;
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context_;
+  std::unique_ptr<ChannelFilterManager> channel_filter_manager_;
   std::unique_ptr<testing::StrictMock<MockUpstreamTransportCallbacks>> transport_;
   std::unique_ptr<UpstreamConnectionService> service_;
 };
@@ -64,8 +89,8 @@ public:
   DownstreamConnectionServiceTest() {
     transport_ = std::make_unique<testing::StrictMock<MockDownstreamTransportCallbacks>>();
     service_ = std::make_unique<DownstreamConnectionService>(ConnectionServiceOptions{}, *transport_, std::make_shared<StreamTracker>(context_));
+    channel_filter_manager_ = std::make_unique<ChannelFilterManager>(context_, std::vector<std::string>{});
     service_->registerMessageHandlers(msg_dispatcher_);
-
     EXPECT_CALL(*transport_, streamId)
       .WillRepeatedly(Return(1));
     EXPECT_CALL(*transport_, channelIdManager)
@@ -78,6 +103,11 @@ public:
       .WillRepeatedly([this] -> Envoy::OptRef<Envoy::Event::Dispatcher> {
         return mock_dispatcher_;
       });
+    EXPECT_CALL(*transport_, channelFilterManager)
+      .Times(AnyNumber())
+      .WillRepeatedly([this] -> ChannelFilterManager& {
+        return *channel_filter_manager_;
+      });
   }
 
 protected:
@@ -86,6 +116,7 @@ protected:
   TestSecretsProvider secrets_provider_;
   TestSshMessageDispatcher msg_dispatcher_;
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context_;
+  std::unique_ptr<ChannelFilterManager> channel_filter_manager_;
   std::unique_ptr<testing::StrictMock<MockDownstreamTransportCallbacks>> transport_;
   std::unique_ptr<DownstreamConnectionService> service_;
 };
@@ -185,6 +216,247 @@ TEST_F(DownstreamConnectionServiceTest, TestStatsTimer) {
   EXPECT_EQ(101, stats2.channel_id());
   EXPECT_EQ(2, stats2.rx_bytes_total());
   EXPECT_EQ(2, stats2.tx_bytes_total());
+}
+
+TEST_F(DownstreamConnectionServiceTest, TestChannelReadFilters) {
+  testing::NiceMock<MockChannelFilterFactoryConfig> cfg;
+  ON_CALL(cfg, createEmptyConfigProto).WillByDefault([] {
+    return std::make_unique<Envoy::Protobuf::StringValue>();
+  });
+  ON_CALL(cfg, name).WillByDefault(Return("test_channel_filter"));
+
+  IN_SEQUENCE;
+
+  auto factory = std::make_unique<testing::StrictMock<MockChannelFilterFactory>>();
+  auto filter = std::make_unique<testing::StrictMock<MockChannelFilter>>();
+  EXPECT_CALL(cfg, createChannelFilterFactory)
+    .WillOnce([&] {
+      return std::move(factory);
+    });
+
+  auto ch1 = std::make_unique<testing::StrictMock<MockChannel>>();
+  ChannelFilterCallbacks* channelFilterCallbacks{};
+  ChannelCallbacks* ch1Callbacks{};
+  auto channelId = *channel_id_manager_.allocateNewChannel(Peer::Downstream);
+
+  EXPECT_CALL(*factory, createReadFilter)
+    .WillOnce([&](ChannelFilterCallbacks& filter_callbacks) {
+      channelFilterCallbacks = &filter_callbacks;
+      EXPECT_EQ(channelId, filter_callbacks.channelId());
+      // no channel open message has been received yet, so channelType should return nullopt
+      EXPECT_EQ(std::nullopt, filter_callbacks.channelType());
+      return std::move(filter);
+    });
+  EXPECT_CALL(*ch1, setChannelCallbacks)
+    .WillOnce([ch1 = ch1.get(), &ch1Callbacks](ChannelCallbacks& cb) {
+      ch1->Channel::setChannelCallbacks(cb);
+      ch1Callbacks = &cb;
+    });
+
+  Registry::InjectFactory<ChannelFilterFactoryConfig> inject(cfg);
+  channel_filter_manager_.reset(new ChannelFilterManager(context_, {"test_channel_filter"}));
+
+  // 1) receive channel open
+  EXPECT_CALL(*ch1, readChannelOpen)
+    .WillOnce([&ch1Callbacks](wire::ChannelOpenMsg&& msg) {
+      EXPECT_EQ(1u, *msg.sender_channel);
+      EXPECT_EQ("session", msg.channel_type());
+      return ch1Callbacks->sendMessageRemote(std::move(msg));
+    });
+  EXPECT_CALL(*filter, onMessageForward(MSG(wire::ChannelOpenMsg,
+                                            FIELD_EQ(sender_channel, channelId),
+                                            FIELD(request, SUB_MSG(wire::SessionChannelOpenMsg, _)))))
+    .WillOnce(InvokeWithoutArgs([&ch1Callbacks] {
+      EXPECT_EQ("session", ch1Callbacks->channelType());
+    }));
+  EXPECT_CALL(*transport_, forward(MSG(wire::ChannelOpenMsg,
+                                       FIELD_EQ(sender_channel, channelId),
+                                       FIELD(request, SUB_MSG(wire::SessionChannelOpenMsg, _))),
+                                   _));
+
+  // 2) receive channel data
+  EXPECT_CALL(*ch1, readMessage(MSG(wire::ChannelDataMsg,
+                                    FIELD_EQ(recipient_channel, channelId),
+                                    FIELD(data, "hello world"_bytes))))
+    .WillOnce([&ch1Callbacks](wire::Message&& msg) {
+      return ch1Callbacks->sendMessageRemote(std::move(msg));
+    });
+  EXPECT_CALL(*filter, onMessageForward(MSG(wire::ChannelDataMsg,
+                                            FIELD_EQ(recipient_channel, 2u),
+                                            FIELD(data, "hello world"_bytes))));
+  EXPECT_CALL(*transport_, forward(MSG(wire::ChannelDataMsg,
+                                       FIELD_EQ(recipient_channel, 2u),
+                                       FIELD(data, "hello world"_bytes)),
+                                   _));
+
+  // 3) interrupt
+  EXPECT_CALL(*transport_, sendMessageToConnection(MSG(wire::ChannelCloseMsg,
+                                                       FIELD_EQ(recipient_channel, 1u))))
+    .WillOnce(Return(0uz));
+
+  EXPECT_CALL(*ch1, readMessage(MSG(wire::ChannelCloseMsg,
+                                    FIELD_EQ(recipient_channel, channelId))))
+    .WillOnce([&ch1Callbacks](wire::Message&& msg) {
+      return ch1Callbacks->sendMessageRemote(std::move(msg));
+    });
+  EXPECT_CALL(*filter, onMessageForward(MSG(wire::ChannelCloseMsg,
+                                            FIELD_EQ(recipient_channel, 2u))));
+  EXPECT_CALL(*transport_, forward(MSG(wire::ChannelCloseMsg,
+                                       FIELD_EQ(recipient_channel, 2u)),
+                                   _));
+  EXPECT_CALL(*ch1, Die);
+
+  //
+
+  ASSERT_OK(service_->startChannel(std::move(ch1),
+                                   {
+                                     .allocated_channel_id = channelId,
+                                     .channel_open = wire::ChannelOpenMsg{
+                                       .sender_channel = 1,
+                                       .request = wire::SessionChannelOpenMsg{},
+                                     },
+                                   }));
+  ASSERT_OK(channel_id_manager_.bindChannelID(channelId, PeerLocalID{
+                                                           .channel_id = 2,
+                                                           .local_peer = Upstream,
+                                                         }));
+
+  ASSERT_OK(service_->handleMessage(wire::ChannelDataMsg{
+    .recipient_channel = channelId,
+    .data = "hello world"_bytes,
+  }));
+
+  bool called{};
+  auto cbHandle = ch1Callbacks->addInterruptCallback([&called](absl::Status err, TransportCallbacks&) {
+    EXPECT_EQ(absl::InternalError("test error"), err);
+    called = true;
+  });
+  channelFilterCallbacks->interruptChannel(absl::InternalError("test error"));
+  EXPECT_TRUE(called);
+  ASSERT_OK(service_->handleMessage(wire::ChannelCloseMsg{
+    .recipient_channel = channelId,
+  }));
+}
+
+TEST_F(UpstreamConnectionServiceTest, TestChannelWriteFilters) {
+  testing::NiceMock<MockChannelFilterFactoryConfig> cfg;
+  ON_CALL(cfg, createEmptyConfigProto).WillByDefault([] {
+    return std::make_unique<Envoy::Protobuf::StringValue>();
+  });
+  ON_CALL(cfg, name).WillByDefault(Return("test_channel_filter"));
+
+  IN_SEQUENCE;
+
+  auto factory = std::make_unique<testing::StrictMock<MockChannelFilterFactory>>();
+  auto filter = std::make_unique<testing::StrictMock<MockChannelFilter>>();
+  EXPECT_CALL(cfg, createChannelFilterFactory)
+    .WillOnce([&] {
+      return std::move(factory);
+    });
+
+  auto ch1 = std::make_unique<testing::StrictMock<MockChannel>>();
+  ChannelFilterCallbacks* channelFilterCallbacks{};
+  ChannelCallbacks* ch1Callbacks{};
+  auto channelId = *channel_id_manager_.allocateNewChannel(Peer::Downstream);
+
+  EXPECT_CALL(*factory, createWriteFilter)
+    .WillOnce([&](ChannelFilterCallbacks& filter_callbacks) {
+      channelFilterCallbacks = &filter_callbacks;
+      EXPECT_EQ(channelId, filter_callbacks.channelId());
+      return std::move(filter);
+    });
+  EXPECT_CALL(*ch1, setChannelCallbacks)
+    .WillOnce([ch1 = ch1.get(), &ch1Callbacks](ChannelCallbacks& cb) {
+      ch1->Channel::setChannelCallbacks(cb);
+      ch1Callbacks = &cb;
+    });
+
+  Registry::InjectFactory<ChannelFilterFactoryConfig> inject(cfg);
+
+  channel_filter_manager_.reset(new ChannelFilterManager(context_, {"test_channel_filter"}));
+
+  ASSERT_OK(channel_id_manager_.bindChannelID(channelId, PeerLocalID{
+                                                           .channel_id = 1,
+                                                           .local_peer = Downstream,
+                                                         }));
+
+  // 1) receive channel open confirmation
+  EXPECT_CALL(*ch1, readMessage(MSG(wire::ChannelOpenConfirmationMsg,
+                                    FIELD_EQ(recipient_channel, channelId),
+                                    FIELD_EQ(sender_channel, channelId))))
+    .WillOnce([&ch1Callbacks](wire::Message&& msg) {
+      return ch1Callbacks->sendMessageRemote(std::move(msg));
+    });
+  EXPECT_CALL(*filter, onMessageForward(MSG(wire::ChannelOpenConfirmationMsg,
+                                            FIELD_EQ(sender_channel, channelId),
+                                            FIELD_EQ(recipient_channel, 1u))))
+    .WillOnce(InvokeWithoutArgs([&ch1Callbacks] {
+      // the write filter won't have the channel type
+      EXPECT_EQ(std::nullopt, ch1Callbacks->channelType());
+    }));
+  EXPECT_CALL(*transport_, forward(MSG(wire::ChannelOpenConfirmationMsg,
+                                       FIELD_EQ(sender_channel, channelId),
+                                       FIELD_EQ(recipient_channel, 1u)),
+                                   _));
+
+  // 2) receive channel data
+  EXPECT_CALL(*ch1, readMessage(MSG(wire::ChannelDataMsg,
+                                    FIELD_EQ(recipient_channel, channelId),
+                                    FIELD_EQ(data, "hello world"_bytes))))
+    .WillOnce([&ch1Callbacks](wire::Message&& msg) {
+      return ch1Callbacks->sendMessageRemote(std::move(msg));
+    });
+  EXPECT_CALL(*filter, onMessageForward(MSG(wire::ChannelDataMsg,
+                                            FIELD_EQ(recipient_channel, 1u),
+                                            FIELD(data, "hello world"_bytes))));
+  EXPECT_CALL(*transport_, forward(MSG(wire::ChannelDataMsg,
+                                       FIELD_EQ(recipient_channel, 1u),
+                                       FIELD_EQ(data, "hello world"_bytes)),
+                                   _));
+
+  // 3) interrupt
+  EXPECT_CALL(*transport_, sendMessageToConnection(MSG(wire::ChannelCloseMsg,
+                                                       FIELD_EQ(recipient_channel, 2u))))
+    .WillOnce(Return(0uz));
+
+  EXPECT_CALL(*ch1, readMessage(MSG(wire::ChannelCloseMsg,
+                                    FIELD_EQ(recipient_channel, channelId))))
+    .WillOnce([&ch1Callbacks](wire::Message&& msg) {
+      return ch1Callbacks->sendMessageRemote(std::move(msg));
+    });
+  EXPECT_CALL(*filter, onMessageForward(MSG(wire::ChannelCloseMsg,
+                                            FIELD_EQ(recipient_channel, 1u))));
+  EXPECT_CALL(*transport_, forward(MSG(wire::ChannelCloseMsg,
+                                       FIELD_EQ(recipient_channel, 1u)),
+                                   _));
+  EXPECT_CALL(*ch1, Die);
+
+  //
+
+  ASSERT_OK(service_->startChannel(std::move(ch1), {.allocated_channel_id = channelId}));
+  ASSERT_OK(service_->handleMessage(wire::ChannelOpenConfirmationMsg{
+    .recipient_channel = channelId,
+    .sender_channel = 2,
+  }));
+  ASSERT_OK(service_->handleMessage(wire::ChannelDataMsg{
+    .recipient_channel = channelId,
+    .data = "hello world"_bytes,
+  }));
+
+  bool called{};
+  auto cbHandle = ch1Callbacks->addInterruptCallback([&called](absl::Status err, TransportCallbacks&) {
+    EXPECT_EQ(absl::InternalError("test error"), err);
+    called = true;
+  });
+  ASSERT_TRUE(channelFilterCallbacks->interruptChannel(absl::InternalError("test error")));
+  EXPECT_TRUE(called);
+  ASSERT_OK(service_->handleMessage(wire::ChannelCloseMsg{
+    .recipient_channel = channelId,
+  }));
+
+  // interruptChannel should return false if called a second time, since the channel is no longer
+  // preemptible
+  ASSERT_FALSE(channelFilterCallbacks->interruptChannel(absl::InternalError("test error")));
 }
 
 } // namespace test

--- a/test/extensions/filters/network/ssh/service_connection_impl_test.cc
+++ b/test/extensions/filters/network/ssh/service_connection_impl_test.cc
@@ -32,7 +32,7 @@ public:
   UpstreamConnectionServiceTest() {
     transport_ = std::make_unique<testing::StrictMock<MockUpstreamTransportCallbacks>>();
     service_ = std::make_unique<UpstreamConnectionService>(ConnectionServiceOptions{}, *transport_);
-    channel_filter_manager_ = std::make_unique<ChannelFilterManager>(context_, std::vector<std::string>{});
+    channel_filter_manager_ = std::make_unique<ChannelFilterManager>(ExtensionConfigList{}, context_);
     service_->registerMessageHandlers(msg_dispatcher_);
     EXPECT_CALL(*transport_, streamId)
       .WillRepeatedly(Return(1));
@@ -89,7 +89,7 @@ public:
   DownstreamConnectionServiceTest() {
     transport_ = std::make_unique<testing::StrictMock<MockDownstreamTransportCallbacks>>();
     service_ = std::make_unique<DownstreamConnectionService>(ConnectionServiceOptions{}, *transport_, std::make_shared<StreamTracker>(context_));
-    channel_filter_manager_ = std::make_unique<ChannelFilterManager>(context_, std::vector<std::string>{});
+    channel_filter_manager_ = std::make_unique<ChannelFilterManager>(ExtensionConfigList{}, context_);
     service_->registerMessageHandlers(msg_dispatcher_);
     EXPECT_CALL(*transport_, streamId)
       .WillRepeatedly(Return(1));
@@ -239,8 +239,13 @@ TEST_F(DownstreamConnectionServiceTest, TestChannelReadFilters) {
   ChannelCallbacks* ch1Callbacks{};
   auto channelId = *channel_id_manager_.allocateNewChannel(Peer::Downstream);
 
+  EXPECT_CALL(*factory, createEmptyConfigProto)
+    .WillOnce([] {
+      return std::make_unique<Envoy::Protobuf::StringValue>();
+    });
   EXPECT_CALL(*factory, createReadFilter)
-    .WillOnce([&](ChannelFilterCallbacks& filter_callbacks) {
+    .WillOnce([&](const google::protobuf::Message& config, ChannelFilterCallbacks& filter_callbacks) {
+      EXPECT_EQ("filter_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
       channelFilterCallbacks = &filter_callbacks;
       EXPECT_EQ(channelId, filter_callbacks.channelId());
       // no channel open message has been received yet, so channelType should return nullopt
@@ -254,7 +259,25 @@ TEST_F(DownstreamConnectionServiceTest, TestChannelReadFilters) {
     });
 
   Registry::InjectFactory<ChannelFilterFactoryConfig> inject(cfg);
-  channel_filter_manager_.reset(new ChannelFilterManager(context_, {"test_channel_filter"}));
+  ExtensionConfigList enabledChannelFilters;
+  {
+    auto* cfg = enabledChannelFilters.Add();
+    cfg->set_name("test_channel_filter");
+    Envoy::Protobuf::StringValue v;
+    v.set_value("factory_config");
+    cfg->mutable_typed_config()->PackFrom(v);
+  }
+  ExtensionConfigList filterConfigs;
+  {
+    auto* cfg = filterConfigs.Add();
+    cfg->set_name("test_channel_filter");
+    Envoy::Protobuf::StringValue v;
+    v.set_value("filter_config");
+    cfg->mutable_typed_config()->PackFrom(v);
+  }
+
+  channel_filter_manager_.reset(new ChannelFilterManager(enabledChannelFilters, context_));
+  ASSERT_OK(channel_filter_manager_->configureFilters(filterConfigs));
 
   // 1) receive channel open
   EXPECT_CALL(*ch1, readChannelOpen)
@@ -359,8 +382,13 @@ TEST_F(UpstreamConnectionServiceTest, TestChannelWriteFilters) {
   ChannelCallbacks* ch1Callbacks{};
   auto channelId = *channel_id_manager_.allocateNewChannel(Peer::Downstream);
 
+  EXPECT_CALL(*factory, createEmptyConfigProto)
+    .WillOnce([] {
+      return std::make_unique<Envoy::Protobuf::StringValue>();
+    });
   EXPECT_CALL(*factory, createWriteFilter)
-    .WillOnce([&](ChannelFilterCallbacks& filter_callbacks) {
+    .WillOnce([&](const google::protobuf::Message& config, ChannelFilterCallbacks& filter_callbacks) {
+      EXPECT_EQ("filter_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
       channelFilterCallbacks = &filter_callbacks;
       EXPECT_EQ(channelId, filter_callbacks.channelId());
       return std::move(filter);
@@ -373,7 +401,25 @@ TEST_F(UpstreamConnectionServiceTest, TestChannelWriteFilters) {
 
   Registry::InjectFactory<ChannelFilterFactoryConfig> inject(cfg);
 
-  channel_filter_manager_.reset(new ChannelFilterManager(context_, {"test_channel_filter"}));
+  ExtensionConfigList enabledChannelFilters;
+  {
+    auto* cfg = enabledChannelFilters.Add();
+    cfg->set_name("test_channel_filter");
+    Envoy::Protobuf::StringValue v;
+    v.set_value("factory_config");
+    cfg->mutable_typed_config()->PackFrom(v);
+  }
+  ExtensionConfigList filterConfigs;
+  {
+    auto* cfg = filterConfigs.Add();
+    cfg->set_name("test_channel_filter");
+    Envoy::Protobuf::StringValue v;
+    v.set_value("filter_config");
+    cfg->mutable_typed_config()->PackFrom(v);
+  }
+
+  channel_filter_manager_.reset(new ChannelFilterManager(enabledChannelFilters, context_));
+  ASSERT_OK(channel_filter_manager_->configureFilters(filterConfigs));
 
   ASSERT_OK(channel_id_manager_.bindChannelID(channelId, PeerLocalID{
                                                            .channel_id = 1,

--- a/test/extensions/filters/network/ssh/service_connection_impl_test.cc
+++ b/test/extensions/filters/network/ssh/service_connection_impl_test.cc
@@ -51,6 +51,10 @@ public:
       .WillRepeatedly([this] -> ChannelFilterManager& {
         return *channel_filter_manager_;
       });
+    fake_auth_info_.stream_id = 1;
+    EXPECT_CALL(*transport_, authInfo)
+      .Times(AnyNumber())
+      .WillRepeatedly(ReturnRef(fake_auth_info_));
   }
 
 protected:
@@ -58,6 +62,7 @@ protected:
   ChannelIDManager channel_id_manager_{100, 100};
   TestSecretsProvider secrets_provider_;
   TestSshMessageDispatcher msg_dispatcher_;
+  AuthInfo fake_auth_info_;
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context_;
   std::unique_ptr<ChannelFilterManager> channel_filter_manager_;
   std::unique_ptr<testing::StrictMock<MockUpstreamTransportCallbacks>> transport_;
@@ -391,6 +396,7 @@ TEST_F(UpstreamConnectionServiceTest, TestChannelWriteFilters) {
     .WillOnce([&](const google::protobuf::Message& config, ChannelFilterCallbacks& filter_callbacks) {
       EXPECT_EQ("filter_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
       EXPECT_EQ(static_cast<stream_id_t>(1), filter_callbacks.streamId());
+      EXPECT_EQ(&std::as_const(fake_auth_info_), &filter_callbacks.authInfo());
       channelFilterCallbacks = &filter_callbacks;
       EXPECT_EQ(channelId, filter_callbacks.channelId());
       return std::move(filter);

--- a/test/extensions/filters/network/ssh/service_connection_impl_test.cc
+++ b/test/extensions/filters/network/ssh/service_connection_impl_test.cc
@@ -223,298 +223,406 @@ TEST_F(DownstreamConnectionServiceTest, TestStatsTimer) {
   EXPECT_EQ(2, stats2.tx_bytes_total());
 }
 
-TEST_F(DownstreamConnectionServiceTest, TestChannelReadFilters) {
-  testing::NiceMock<MockChannelFilterFactoryConfig> cfg;
-  ON_CALL(cfg, createEmptyConfigProto).WillByDefault([] {
-    return std::make_unique<Envoy::Protobuf::StringValue>();
-  });
-  ON_CALL(cfg, name).WillByDefault(Return("test_channel_filter"));
-
-  IN_SEQUENCE;
-
-  auto factory = std::make_unique<testing::StrictMock<MockChannelFilterFactory>>();
-  auto filter = std::make_unique<testing::StrictMock<MockChannelFilter>>();
-  EXPECT_CALL(cfg, createChannelFilterFactory)
-    .WillOnce([&] {
-      return std::move(factory);
-    });
-
-  auto ch1 = std::make_unique<testing::StrictMock<MockChannel>>();
-  ChannelFilterCallbacks* channelFilterCallbacks{};
-  ChannelCallbacks* ch1Callbacks{};
-  auto channelId = *channel_id_manager_.allocateNewChannel(Peer::Downstream);
-
-  EXPECT_CALL(*factory, createEmptyConfigProto)
-    .WillOnce([] {
+// NOLINTBEGIN(readability-identifier-naming)
+template <typename BaseTest>
+class ChannelFiltersTest : public BaseTest {
+public:
+  void SetupChannelFilterManager() {
+    ON_CALL(cfg_, createEmptyConfigProto).WillByDefault([] {
       return std::make_unique<Envoy::Protobuf::StringValue>();
     });
-  EXPECT_CALL(*factory, createReadFilter)
-    .WillOnce([&](const google::protobuf::Message& config, ChannelFilterCallbacks& filter_callbacks) {
-      EXPECT_EQ("filter_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
-      EXPECT_EQ(static_cast<stream_id_t>(1), filter_callbacks.streamId());
-      channelFilterCallbacks = &filter_callbacks;
-      EXPECT_EQ(channelId, filter_callbacks.channelId());
-      // no channel open message has been received yet, so channelType should return nullopt
-      EXPECT_EQ(std::nullopt, filter_callbacks.channelType());
-      return std::move(filter);
-    });
-  EXPECT_CALL(*ch1, setChannelCallbacks)
-    .WillOnce([ch1 = ch1.get(), &ch1Callbacks](ChannelCallbacks& cb) {
-      ch1->Channel::setChannelCallbacks(cb);
-      ch1Callbacks = &cb;
-    });
+    ON_CALL(cfg_, name).WillByDefault(Return("test_channel_filter"));
 
-  Registry::InjectFactory<ChannelFilterFactoryConfig> inject(cfg);
-  ExtensionConfigList enabledChannelFilters;
-  {
-    auto* cfg = enabledChannelFilters.Add();
-    cfg->set_name("test_channel_filter");
-    Envoy::Protobuf::StringValue v;
-    v.set_value("factory_config");
-    cfg->mutable_typed_config()->PackFrom(v);
+    factory_ = std::make_unique<testing::StrictMock<MockChannelFilterFactory>>();
+    filter_ = std::make_unique<testing::StrictMock<MockChannelFilter>>();
+    EXPECT_CALL(cfg_, createChannelFilterFactory)
+      .WillOnce([&] {
+        return std::move(factory_);
+      });
+
+    channel_ = std::make_unique<testing::StrictMock<MockChannel>>();
+    channel_id_ = *this->channel_id_manager_.allocateNewChannel(Peer::Downstream);
+
+    EXPECT_CALL(*factory_, createEmptyConfigProto)
+      .WillOnce([] {
+        return std::make_unique<Envoy::Protobuf::StringValue>();
+      });
+    if constexpr (std::is_same_v<BaseTest, DownstreamConnectionServiceTest>) {
+      EXPECT_CALL(*factory_, createReadFilter)
+        .WillOnce([this](const google::protobuf::Message& config, ChannelFilterCallbacks& filter_callbacks) {
+          EXPECT_EQ("filter_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
+          EXPECT_EQ(static_cast<stream_id_t>(1), filter_callbacks.streamId());
+          channel_filter_callbacks_ = &filter_callbacks;
+          EXPECT_EQ(channel_id_, filter_callbacks.channelId());
+          // no channel open message has been received yet, so channelType should return nullopt
+          EXPECT_EQ(std::nullopt, filter_callbacks.channelType());
+          return std::move(filter_);
+        });
+    } else if constexpr (std::is_same_v<BaseTest, UpstreamConnectionServiceTest>) {
+      EXPECT_CALL(*factory_, createWriteFilter)
+        .WillOnce([&](const google::protobuf::Message& config, ChannelFilterCallbacks& filter_callbacks) {
+          EXPECT_EQ("filter_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
+          EXPECT_EQ(static_cast<stream_id_t>(1), filter_callbacks.streamId());
+          EXPECT_EQ(&std::as_const(this->fake_auth_info_), &filter_callbacks.authInfo());
+          EXPECT_EQ(&this->mock_dispatcher_, &filter_callbacks.connectionDispatcher());
+          channel_filter_callbacks_ = &filter_callbacks;
+          EXPECT_EQ(channel_id_, filter_callbacks.channelId());
+          return std::move(filter_);
+        });
+    }
+    EXPECT_CALL(*channel_, setChannelCallbacks)
+      .WillOnce([ch1 = channel_.get(), this](ChannelCallbacks& cb) {
+        ch1->Channel::setChannelCallbacks(cb);
+        channel_callbacks_ = &cb;
+      });
+
+    inject_ = std::make_unique<Registry::InjectFactory<ChannelFilterFactoryConfig>>(cfg_);
+
+    ExtensionConfigList enabledChannelFilters;
+    {
+      auto* cfg = enabledChannelFilters.Add();
+      cfg->set_name("test_channel_filter");
+      Envoy::Protobuf::StringValue v;
+      v.set_value("factory_config");
+      cfg->mutable_typed_config()->PackFrom(v);
+    }
+    ExtensionConfigList filterConfigs;
+    {
+      auto* cfg = filterConfigs.Add();
+      cfg->set_name("test_channel_filter");
+      Envoy::Protobuf::StringValue v;
+      v.set_value("filter_config");
+      cfg->mutable_typed_config()->PackFrom(v);
+    }
+
+    this->channel_filter_manager_.reset(new ChannelFilterManager(enabledChannelFilters, this->context_));
+    ASSERT_OK(this->channel_filter_manager_->configureFilters(filterConfigs));
   }
-  ExtensionConfigList filterConfigs;
-  {
-    auto* cfg = filterConfigs.Add();
-    cfg->set_name("test_channel_filter");
-    Envoy::Protobuf::StringValue v;
-    v.set_value("filter_config");
-    cfg->mutable_typed_config()->PackFrom(v);
+
+  testing::NiceMock<MockChannelFilterFactoryConfig> cfg_;
+  std::unique_ptr<testing::StrictMock<MockChannelFilterFactory>> factory_;
+  std::unique_ptr<testing::StrictMock<MockChannelFilter>> filter_;
+
+protected:
+  std::unique_ptr<testing::StrictMock<MockChannel>> channel_;
+
+public:
+  ChannelFilterCallbacks* channel_filter_callbacks_{};
+  ChannelCallbacks* channel_callbacks_{};
+  uint32_t channel_id_{};
+  std::unique_ptr<Registry::InjectFactory<ChannelFilterFactoryConfig>> inject_;
+};
+
+class ChannelReadFiltersTest : public ChannelFiltersTest<DownstreamConnectionServiceTest> {
+public:
+  void ExpectForwardChannelOpen() {
+    EXPECT_CALL(*channel_, readChannelOpen)
+      .WillOnce([this](wire::ChannelOpenMsg&& msg) {
+        EXPECT_EQ(1u, *msg.sender_channel);
+        EXPECT_EQ("session", msg.channel_type());
+        return channel_callbacks_->sendMessageRemote(std::move(msg));
+      });
+    EXPECT_CALL(*filter_, onMessageForward(MSG(wire::ChannelOpenMsg,
+                                               FIELD_EQ(sender_channel, channel_id_),
+                                               FIELD(request, SUB_MSG(wire::SessionChannelOpenMsg, _)))))
+      .WillOnce(InvokeWithoutArgs([this] {
+        EXPECT_EQ("session", channel_callbacks_->channelType());
+      }));
+    EXPECT_CALL(*transport_, forward(MSG(wire::ChannelOpenMsg,
+                                         FIELD_EQ(sender_channel, channel_id_),
+                                         FIELD(request, SUB_MSG(wire::SessionChannelOpenMsg, _))),
+                                     _));
   }
 
-  channel_filter_manager_.reset(new ChannelFilterManager(enabledChannelFilters, context_));
-  ASSERT_OK(channel_filter_manager_->configureFilters(filterConfigs));
+  void ExpectForwardChannelData() {
+    EXPECT_CALL(*channel_, readMessage(MSG(wire::ChannelDataMsg,
+                                           FIELD_EQ(recipient_channel, channel_id_),
+                                           FIELD(data, "hello world"_bytes))))
+      .WillOnce([this](wire::Message&& msg) {
+        return channel_callbacks_->sendMessageRemote(std::move(msg));
+      });
+    EXPECT_CALL(*filter_, onMessageForward(MSG(wire::ChannelDataMsg,
+                                               FIELD_EQ(recipient_channel, 2u),
+                                               FIELD(data, "hello world"_bytes))));
+    EXPECT_CALL(*transport_, forward(MSG(wire::ChannelDataMsg,
+                                         FIELD_EQ(recipient_channel, 2u),
+                                         FIELD(data, "hello world"_bytes)),
+                                     _));
+  }
 
-  // 1) receive channel open
-  EXPECT_CALL(*ch1, readChannelOpen)
-    .WillOnce([&ch1Callbacks](wire::ChannelOpenMsg&& msg) {
-      EXPECT_EQ(1u, *msg.sender_channel);
-      EXPECT_EQ("session", msg.channel_type());
-      return ch1Callbacks->sendMessageRemote(std::move(msg));
-    });
-  EXPECT_CALL(*filter, onMessageForward(MSG(wire::ChannelOpenMsg,
-                                            FIELD_EQ(sender_channel, channelId),
-                                            FIELD(request, SUB_MSG(wire::SessionChannelOpenMsg, _)))))
-    .WillOnce(InvokeWithoutArgs([&ch1Callbacks] {
-      EXPECT_EQ("session", ch1Callbacks->channelType());
+  void ExpectInterrupt() {
+    EXPECT_CALL(*transport_, sendMessageToConnection(MSG(wire::ChannelCloseMsg,
+                                                         FIELD_EQ(recipient_channel, 1u))))
+      .WillOnce(Return(0uz));
+
+    EXPECT_CALL(*channel_, readMessage(MSG(wire::ChannelCloseMsg,
+                                           FIELD_EQ(recipient_channel, channel_id_))))
+      .WillOnce([this](wire::Message&& msg) {
+        return channel_callbacks_->sendMessageRemote(std::move(msg));
+      });
+    EXPECT_CALL(*filter_, onMessageForward(MSG(wire::ChannelCloseMsg,
+                                               FIELD_EQ(recipient_channel, 2u))));
+    EXPECT_CALL(*transport_, forward(MSG(wire::ChannelCloseMsg,
+                                         FIELD_EQ(recipient_channel, 2u)),
+                                     _));
+    EXPECT_CALL(*channel_, Die);
+  }
+
+  void ReceiveChannelOpen() {
+    ASSERT_OK(service_->startChannel(std::move(channel_),
+                                     {
+                                       .allocated_channel_id = channel_id_,
+                                       .channel_open = wire::ChannelOpenMsg{
+                                         .sender_channel = 1,
+                                         .request = wire::SessionChannelOpenMsg{},
+                                       },
+                                     }));
+    ASSERT_OK(channel_id_manager_.bindChannelID(channel_id_, PeerLocalID{
+                                                               .channel_id = 2,
+                                                               .local_peer = Upstream,
+                                                             }));
+  }
+
+  void ReceiveChannelData() {
+    ASSERT_OK(service_->handleMessage(wire::ChannelDataMsg{
+      .recipient_channel = channel_id_,
+      .data = "hello world"_bytes,
     }));
-  EXPECT_CALL(*transport_, forward(MSG(wire::ChannelOpenMsg,
-                                       FIELD_EQ(sender_channel, channelId),
-                                       FIELD(request, SUB_MSG(wire::SessionChannelOpenMsg, _))),
-                                   _));
+  }
 
-  // 2) receive channel data
-  EXPECT_CALL(*ch1, readMessage(MSG(wire::ChannelDataMsg,
-                                    FIELD_EQ(recipient_channel, channelId),
-                                    FIELD(data, "hello world"_bytes))))
-    .WillOnce([&ch1Callbacks](wire::Message&& msg) {
-      return ch1Callbacks->sendMessageRemote(std::move(msg));
+  void Interrupt() {
+    bool called{};
+    auto cbHandle = channel_callbacks_->addInterruptCallback([&called](absl::Status err, TransportCallbacks&) {
+      EXPECT_EQ(absl::InternalError("test error"), err);
+      called = true;
     });
-  EXPECT_CALL(*filter, onMessageForward(MSG(wire::ChannelDataMsg,
-                                            FIELD_EQ(recipient_channel, 2u),
-                                            FIELD(data, "hello world"_bytes))));
-  EXPECT_CALL(*transport_, forward(MSG(wire::ChannelDataMsg,
-                                       FIELD_EQ(recipient_channel, 2u),
-                                       FIELD(data, "hello world"_bytes)),
-                                   _));
+    ASSERT_TRUE(channel_filter_callbacks_->interruptChannel(absl::InternalError("test error")));
+    EXPECT_TRUE(called);
+  }
 
-  // 3) interrupt
-  EXPECT_CALL(*transport_, sendMessageToConnection(MSG(wire::ChannelCloseMsg,
-                                                       FIELD_EQ(recipient_channel, 1u))))
-    .WillOnce(Return(0uz));
+  void ReceiveChannelClose() {
+    ASSERT_OK(service_->handleMessage(wire::ChannelCloseMsg{
+      .recipient_channel = channel_id_,
+    }));
+  }
+};
+// NOLINTEND(readability-identifier-naming)
 
-  EXPECT_CALL(*ch1, readMessage(MSG(wire::ChannelCloseMsg,
-                                    FIELD_EQ(recipient_channel, channelId))))
-    .WillOnce([&ch1Callbacks](wire::Message&& msg) {
-      return ch1Callbacks->sendMessageRemote(std::move(msg));
-    });
-  EXPECT_CALL(*filter, onMessageForward(MSG(wire::ChannelCloseMsg,
-                                            FIELD_EQ(recipient_channel, 2u))));
-  EXPECT_CALL(*transport_, forward(MSG(wire::ChannelCloseMsg,
-                                       FIELD_EQ(recipient_channel, 2u)),
-                                   _));
-  EXPECT_CALL(*ch1, Die);
+TEST_F(ChannelReadFiltersTest, TestChannelReadFilters) {
+  IN_SEQUENCE;
 
-  //
+  SetupChannelFilterManager();
+  ExpectForwardChannelOpen();
+  ExpectForwardChannelData();
+  ExpectInterrupt();
 
-  ASSERT_OK(service_->startChannel(std::move(ch1),
-                                   {
-                                     .allocated_channel_id = channelId,
-                                     .channel_open = wire::ChannelOpenMsg{
-                                       .sender_channel = 1,
-                                       .request = wire::SessionChannelOpenMsg{},
-                                     },
-                                   }));
-  ASSERT_OK(channel_id_manager_.bindChannelID(channelId, PeerLocalID{
-                                                           .channel_id = 2,
-                                                           .local_peer = Upstream,
-                                                         }));
-
-  ASSERT_OK(service_->handleMessage(wire::ChannelDataMsg{
-    .recipient_channel = channelId,
-    .data = "hello world"_bytes,
-  }));
-
-  bool called{};
-  auto cbHandle = ch1Callbacks->addInterruptCallback([&called](absl::Status err, TransportCallbacks&) {
-    EXPECT_EQ(absl::InternalError("test error"), err);
-    called = true;
-  });
-  channelFilterCallbacks->interruptChannel(absl::InternalError("test error"));
-  EXPECT_TRUE(called);
-  ASSERT_OK(service_->handleMessage(wire::ChannelCloseMsg{
-    .recipient_channel = channelId,
-  }));
+  ReceiveChannelOpen();
+  ReceiveChannelData();
+  Interrupt();
+  ReceiveChannelClose();
 }
 
-TEST_F(UpstreamConnectionServiceTest, TestChannelWriteFilters) {
-  testing::NiceMock<MockChannelFilterFactoryConfig> cfg;
-  ON_CALL(cfg, createEmptyConfigProto).WillByDefault([] {
-    return std::make_unique<Envoy::Protobuf::StringValue>();
-  });
-  ON_CALL(cfg, name).WillByDefault(Return("test_channel_filter"));
-
+TEST_F(ChannelReadFiltersTest, TestChannelReadFilters_InterruptTwice) {
   IN_SEQUENCE;
 
-  auto factory = std::make_unique<testing::StrictMock<MockChannelFilterFactory>>();
-  auto filter = std::make_unique<testing::StrictMock<MockChannelFilter>>();
-  EXPECT_CALL(cfg, createChannelFilterFactory)
-    .WillOnce([&] {
-      return std::move(factory);
-    });
+  SetupChannelFilterManager();
+  ExpectForwardChannelOpen();
+  ExpectForwardChannelData();
+  ExpectInterrupt();
 
-  auto ch1 = std::make_unique<testing::StrictMock<MockChannel>>();
-  ChannelFilterCallbacks* channelFilterCallbacks{};
-  ChannelCallbacks* ch1Callbacks{};
-  auto channelId = *channel_id_manager_.allocateNewChannel(Peer::Downstream);
-
-  EXPECT_CALL(*factory, createEmptyConfigProto)
-    .WillOnce([] {
-      return std::make_unique<Envoy::Protobuf::StringValue>();
-    });
-  EXPECT_CALL(*factory, createWriteFilter)
-    .WillOnce([&](const google::protobuf::Message& config, ChannelFilterCallbacks& filter_callbacks) {
-      EXPECT_EQ("filter_config", dynamic_cast<const Envoy::Protobuf::StringValue&>(config).value());
-      EXPECT_EQ(static_cast<stream_id_t>(1), filter_callbacks.streamId());
-      EXPECT_EQ(&std::as_const(fake_auth_info_), &filter_callbacks.authInfo());
-      EXPECT_EQ(&mock_dispatcher_, &filter_callbacks.connectionDispatcher());
-      channelFilterCallbacks = &filter_callbacks;
-      EXPECT_EQ(channelId, filter_callbacks.channelId());
-      return std::move(filter);
-    });
-  EXPECT_CALL(*ch1, setChannelCallbacks)
-    .WillOnce([ch1 = ch1.get(), &ch1Callbacks](ChannelCallbacks& cb) {
-      ch1->Channel::setChannelCallbacks(cb);
-      ch1Callbacks = &cb;
-    });
-
-  Registry::InjectFactory<ChannelFilterFactoryConfig> inject(cfg);
-
-  ExtensionConfigList enabledChannelFilters;
-  {
-    auto* cfg = enabledChannelFilters.Add();
-    cfg->set_name("test_channel_filter");
-    Envoy::Protobuf::StringValue v;
-    v.set_value("factory_config");
-    cfg->mutable_typed_config()->PackFrom(v);
-  }
-  ExtensionConfigList filterConfigs;
-  {
-    auto* cfg = filterConfigs.Add();
-    cfg->set_name("test_channel_filter");
-    Envoy::Protobuf::StringValue v;
-    v.set_value("filter_config");
-    cfg->mutable_typed_config()->PackFrom(v);
-  }
-
-  channel_filter_manager_.reset(new ChannelFilterManager(enabledChannelFilters, context_));
-  ASSERT_OK(channel_filter_manager_->configureFilters(filterConfigs));
-
-  ASSERT_OK(channel_id_manager_.bindChannelID(channelId, PeerLocalID{
-                                                           .channel_id = 1,
-                                                           .local_peer = Downstream,
-                                                         }));
-
-  // 1) receive channel open confirmation
-  EXPECT_CALL(*ch1, readMessage(MSG(wire::ChannelOpenConfirmationMsg,
-                                    FIELD_EQ(recipient_channel, channelId),
-                                    FIELD_EQ(sender_channel, channelId))))
-    .WillOnce([&ch1Callbacks](wire::Message&& msg) {
-      return ch1Callbacks->sendMessageRemote(std::move(msg));
-    });
-  EXPECT_CALL(*filter, onMessageForward(MSG(wire::ChannelOpenConfirmationMsg,
-                                            FIELD_EQ(sender_channel, channelId),
-                                            FIELD_EQ(recipient_channel, 1u))))
-    .WillOnce(InvokeWithoutArgs([&ch1Callbacks] {
-      // the write filter won't have the channel type
-      EXPECT_EQ(std::nullopt, ch1Callbacks->channelType());
-    }));
-  EXPECT_CALL(*transport_, forward(MSG(wire::ChannelOpenConfirmationMsg,
-                                       FIELD_EQ(sender_channel, channelId),
-                                       FIELD_EQ(recipient_channel, 1u)),
-                                   _));
-
-  // 2) receive channel data
-  EXPECT_CALL(*ch1, readMessage(MSG(wire::ChannelDataMsg,
-                                    FIELD_EQ(recipient_channel, channelId),
-                                    FIELD_EQ(data, "hello world"_bytes))))
-    .WillOnce([&ch1Callbacks](wire::Message&& msg) {
-      return ch1Callbacks->sendMessageRemote(std::move(msg));
-    });
-  EXPECT_CALL(*filter, onMessageForward(MSG(wire::ChannelDataMsg,
-                                            FIELD_EQ(recipient_channel, 1u),
-                                            FIELD(data, "hello world"_bytes))));
-  EXPECT_CALL(*transport_, forward(MSG(wire::ChannelDataMsg,
-                                       FIELD_EQ(recipient_channel, 1u),
-                                       FIELD_EQ(data, "hello world"_bytes)),
-                                   _));
-
-  // 3) interrupt
-  EXPECT_CALL(*transport_, sendMessageToConnection(MSG(wire::ChannelCloseMsg,
-                                                       FIELD_EQ(recipient_channel, 2u))))
-    .WillOnce(Return(0uz));
-
-  EXPECT_CALL(*ch1, readMessage(MSG(wire::ChannelCloseMsg,
-                                    FIELD_EQ(recipient_channel, channelId))))
-    .WillOnce([&ch1Callbacks](wire::Message&& msg) {
-      return ch1Callbacks->sendMessageRemote(std::move(msg));
-    });
-  EXPECT_CALL(*filter, onMessageForward(MSG(wire::ChannelCloseMsg,
-                                            FIELD_EQ(recipient_channel, 1u))));
-  EXPECT_CALL(*transport_, forward(MSG(wire::ChannelCloseMsg,
-                                       FIELD_EQ(recipient_channel, 1u)),
-                                   _));
-  EXPECT_CALL(*ch1, Die);
-
-  //
-
-  ASSERT_OK(service_->startChannel(std::move(ch1), {.allocated_channel_id = channelId}));
-  ASSERT_OK(service_->handleMessage(wire::ChannelOpenConfirmationMsg{
-    .recipient_channel = channelId,
-    .sender_channel = 2,
-  }));
-  ASSERT_OK(service_->handleMessage(wire::ChannelDataMsg{
-    .recipient_channel = channelId,
-    .data = "hello world"_bytes,
-  }));
-
-  bool called{};
-  auto cbHandle = ch1Callbacks->addInterruptCallback([&called](absl::Status err, TransportCallbacks&) {
-    EXPECT_EQ(absl::InternalError("test error"), err);
-    called = true;
-  });
-  ASSERT_TRUE(channelFilterCallbacks->interruptChannel(absl::InternalError("test error")));
-  EXPECT_TRUE(called);
+  ReceiveChannelOpen();
+  ReceiveChannelData();
+  Interrupt();
 
   // interruptChannel should return false if called a second time, since the channel is no longer
   // preemptible.
   // Order is important wrt receiving the ChannelClose message below. After receiving the close
   // message the channel will be destroyed and channelFilterCallbacks will point to garbage.
-  ASSERT_FALSE(channelFilterCallbacks->interruptChannel(absl::InternalError("test error")));
+  ASSERT_FALSE(channel_filter_callbacks_->interruptChannel(absl::InternalError("test error")));
 
-  ASSERT_OK(service_->handleMessage(wire::ChannelCloseMsg{
-    .recipient_channel = channelId,
-  }));
+  ReceiveChannelClose();
+}
+
+TEST_F(ChannelReadFiltersTest, TestChannelReadFilters_ConnectionReadDisable) {
+  {
+    IN_SEQUENCE;
+    SetupChannelFilterManager();
+    ExpectForwardChannelOpen();
+    ExpectInterrupt();
+  }
+
+  ReceiveChannelOpen();
+
+  testing::MockFunction<void()> checkpoint;
+  {
+    IN_SEQUENCE;
+    EXPECT_CALL(*transport_, connectionReadDisable(true));
+    EXPECT_CALL(checkpoint, Call);
+    EXPECT_CALL(*transport_, connectionReadDisable(false));
+  }
+  auto handle = channel_filter_callbacks_->connectionReadDisable();
+  checkpoint.Call();
+  handle = nullptr;
+
+  Interrupt();
+  ReceiveChannelClose();
+}
+
+// NOLINTBEGIN(readability-identifier-naming)
+class ChannelWriteFiltersTest : public ChannelFiltersTest<UpstreamConnectionServiceTest> {
+public:
+  void ExpectForwardChannelOpenConfirmation() {
+    EXPECT_CALL(*channel_, readMessage(MSG(wire::ChannelOpenConfirmationMsg,
+                                           FIELD_EQ(recipient_channel, channel_id_),
+                                           FIELD_EQ(sender_channel, channel_id_))))
+      .WillOnce([this](wire::Message&& msg) {
+        return channel_callbacks_->sendMessageRemote(std::move(msg));
+      });
+    EXPECT_CALL(*filter_, onMessageForward(MSG(wire::ChannelOpenConfirmationMsg,
+                                               FIELD_EQ(sender_channel, channel_id_),
+                                               FIELD_EQ(recipient_channel, 1u))))
+      .WillOnce(InvokeWithoutArgs([this] {
+        // the write filter won't have the channel type
+        EXPECT_EQ(std::nullopt, channel_callbacks_->channelType());
+      }));
+    EXPECT_CALL(*transport_, forward(MSG(wire::ChannelOpenConfirmationMsg,
+                                         FIELD_EQ(sender_channel, channel_id_),
+                                         FIELD_EQ(recipient_channel, 1u)),
+                                     _));
+  }
+
+  void ExpectForwardChannelData() {
+    EXPECT_CALL(*channel_, readMessage(MSG(wire::ChannelDataMsg,
+                                           FIELD_EQ(recipient_channel, channel_id_),
+                                           FIELD_EQ(data, "hello world"_bytes))))
+      .WillOnce([this](wire::Message&& msg) {
+        return channel_callbacks_->sendMessageRemote(std::move(msg));
+      });
+    EXPECT_CALL(*filter_, onMessageForward(MSG(wire::ChannelDataMsg,
+                                               FIELD_EQ(recipient_channel, 1u),
+                                               FIELD(data, "hello world"_bytes))));
+    EXPECT_CALL(*transport_, forward(MSG(wire::ChannelDataMsg,
+                                         FIELD_EQ(recipient_channel, 1u),
+                                         FIELD_EQ(data, "hello world"_bytes)),
+                                     _));
+  }
+
+  void ExpectInterrupt() {
+    EXPECT_CALL(*transport_, sendMessageToConnection(MSG(wire::ChannelCloseMsg,
+                                                         FIELD_EQ(recipient_channel, 2u))))
+      .WillOnce(Return(0uz));
+
+    EXPECT_CALL(*channel_, readMessage(MSG(wire::ChannelCloseMsg,
+                                           FIELD_EQ(recipient_channel, channel_id_))))
+      .WillOnce([this](wire::Message&& msg) {
+        return channel_callbacks_->sendMessageRemote(std::move(msg));
+      });
+    EXPECT_CALL(*filter_, onMessageForward(MSG(wire::ChannelCloseMsg,
+                                               FIELD_EQ(recipient_channel, 1u))));
+    EXPECT_CALL(*transport_, forward(MSG(wire::ChannelCloseMsg,
+                                         FIELD_EQ(recipient_channel, 1u)),
+                                     _));
+    EXPECT_CALL(*channel_, Die);
+  }
+
+  void StartChannelFromDownstream() {
+
+    ASSERT_OK(channel_id_manager_.bindChannelID(channel_id_, PeerLocalID{
+                                                               .channel_id = 1,
+                                                               .local_peer = Downstream,
+                                                             }));
+    ASSERT_OK(service_->startChannel(std::move(channel_), {.allocated_channel_id = channel_id_}));
+  }
+
+  void ReceiveChannelOpenConfirmation() {
+    ASSERT_OK(service_->handleMessage(wire::ChannelOpenConfirmationMsg{
+      .recipient_channel = channel_id_,
+      .sender_channel = 2,
+    }));
+  }
+
+  void ReceiveChannelData() {
+    ASSERT_OK(service_->handleMessage(wire::ChannelDataMsg{
+      .recipient_channel = channel_id_,
+      .data = "hello world"_bytes,
+    }));
+  }
+
+  void Interrupt() {
+    bool called{};
+    auto cbHandle = channel_callbacks_->addInterruptCallback([&called](absl::Status err, TransportCallbacks&) {
+      EXPECT_EQ(absl::InternalError("test error"), err);
+      called = true;
+    });
+    ASSERT_TRUE(channel_filter_callbacks_->interruptChannel(absl::InternalError("test error")));
+    EXPECT_TRUE(called);
+  }
+
+  void ReceiveChannelClose() {
+    ASSERT_OK(service_->handleMessage(wire::ChannelCloseMsg{
+      .recipient_channel = channel_id_,
+    }));
+  }
+};
+// NOLINTEND(readability-identifier-naming)
+
+TEST_F(ChannelWriteFiltersTest, TestChannelWriteFilters) {
+  IN_SEQUENCE;
+
+  SetupChannelFilterManager();
+  ExpectForwardChannelOpenConfirmation();
+  ExpectForwardChannelData();
+  ExpectInterrupt();
+
+  StartChannelFromDownstream();
+  ReceiveChannelOpenConfirmation();
+  ReceiveChannelData();
+  Interrupt();
+  ReceiveChannelClose();
+}
+
+TEST_F(ChannelWriteFiltersTest, TestChannelWriteFilters_InterruptTwice) {
+  IN_SEQUENCE;
+
+  SetupChannelFilterManager();
+  ExpectForwardChannelOpenConfirmation();
+  ExpectForwardChannelData();
+  ExpectInterrupt();
+
+  StartChannelFromDownstream();
+  ReceiveChannelOpenConfirmation();
+  ReceiveChannelData();
+  Interrupt();
+
+  ASSERT_FALSE(channel_filter_callbacks_->interruptChannel(absl::InternalError("test error")));
+
+  ReceiveChannelClose();
+}
+
+TEST_F(ChannelWriteFiltersTest, TestChannelWriteFilters_ConnectionReadDisable) {
+  {
+    IN_SEQUENCE;
+    SetupChannelFilterManager();
+    ExpectForwardChannelOpenConfirmation();
+    ExpectInterrupt();
+  }
+
+  StartChannelFromDownstream();
+  ReceiveChannelOpenConfirmation();
+
+  testing::MockFunction<void()> checkpoint;
+  {
+    IN_SEQUENCE;
+    EXPECT_CALL(*transport_, connectionReadDisable(true));
+    EXPECT_CALL(checkpoint, Call);
+    EXPECT_CALL(*transport_, connectionReadDisable(false));
+  }
+  auto handle = channel_filter_callbacks_->connectionReadDisable();
+  checkpoint.Call();
+  handle = nullptr;
+
+  Interrupt();
+  ReceiveChannelClose();
 }
 
 } // namespace test

--- a/test/extensions/filters/network/ssh/service_connection_test.cc
+++ b/test/extensions/filters/network/ssh/service_connection_test.cc
@@ -6,6 +6,7 @@
 #include "envoy/common/exception.h"
 #include "source/common/types.h"
 #include "source/extensions/filters/network/ssh/channel.h"
+#include "source/extensions/filters/network/ssh/channel_filter_config.h"
 #include "source/extensions/filters/network/ssh/frame.h"
 #include "source/extensions/filters/network/ssh/id_manager.h"
 #include "source/extensions/filters/network/ssh/service_connection.h"
@@ -65,6 +66,8 @@ public:
       .WillRepeatedly([this] -> Envoy::OptRef<Envoy::Event::Dispatcher> {
         return mock_dispatcher_;
       });
+    EXPECT_CALL(transport_, channelFilterManager)
+      .WillRepeatedly(ReturnRef(channel_filter_manager_));
   }
 
   Peer LocalPeer() const {
@@ -77,6 +80,7 @@ public:
   NiceMock<Envoy::Event::MockDispatcher> mock_dispatcher_; // field order is important
   ChannelIDManager channel_id_manager_{100, 100};
   TestSecretsProvider secrets_provider_;
+  ChannelFilterManager channel_filter_manager_{ChannelFilterManager::unused_in_this_test{}};
   testing::StrictMock<MockTransportCallbacks> transport_;
   TestConnectionService service_;
 };

--- a/test/extensions/filters/network/ssh/ssh_connection_driver.cc
+++ b/test/extensions/filters/network/ssh/ssh_connection_driver.cc
@@ -496,5 +496,9 @@ void SshConnectionDriver::CodecCallbacks::writeToConnection(Buffer::Instance& bu
   client_connection_.write(buffer, false);
 }
 
+Envoy::OptRef<Envoy::Network::Connection> SshConnectionDriver::CodecCallbacks::connection() {
+  return client_connection_;
+}
+
 } // namespace test
 } // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/test/extensions/filters/network/ssh/ssh_connection_driver.h
+++ b/test/extensions/filters/network/ssh/ssh_connection_driver.h
@@ -175,6 +175,10 @@ protected:
     PANIC("unused");
   }
 
+  ChannelFilterManager& channelFilterManager() override {
+    return channel_filter_manager_;
+  }
+
   stream_id_t streamId() const override {
     return 42; // unused, except in logs
   }
@@ -242,6 +246,7 @@ protected:
 
   Envoy::Network::ReadFilterCallbacks* read_filter_callbacks_{nullptr};
   Network::ClientConnectionPtr client_connection_;
+  ChannelFilterManager channel_filter_manager_{ChannelFilterManager::unused_in_this_test{}};
 
   absl::Notification on_kex_completed_;
   std::shared_ptr<KexResult> kex_result_;

--- a/test/extensions/filters/network/ssh/ssh_connection_driver.h
+++ b/test/extensions/filters/network/ssh/ssh_connection_driver.h
@@ -20,6 +20,7 @@ public:
   virtual ~SshConnectionDriverCodecCallbacks() = default;
   virtual void onDecodingFailure(absl::string_view reason = {}) PURE;
   virtual void writeToConnection(Buffer::Instance& buffer) PURE;
+  virtual Envoy::OptRef<Envoy::Network::Connection> connection() PURE;
 };
 
 class SshConnectionDriverCodec {
@@ -239,6 +240,7 @@ protected:
         : client_connection_(client_connection) {}
     void onDecodingFailure(absl::string_view reason = {}) override;
     void writeToConnection(Buffer::Instance& buffer) override;
+    Envoy::OptRef<Envoy::Network::Connection> connection() override;
 
     bool expect_decoding_failure_{};
     Network::ClientConnection& client_connection_;

--- a/test/extensions/filters/network/ssh/ssh_integration_test.cc
+++ b/test/extensions/filters/network/ssh/ssh_integration_test.cc
@@ -71,18 +71,16 @@ void SshIntegrationTest::cleanup() {
 void FakeUpstreamShimImpl::cleanup() {
   absl::MutexLock lock(listeners_mu_);
   for (auto& listener : listeners_) {
-    listener->mu.lock();
-    if (listener->handler != nullptr) {
-      absl::Notification done;
-      fake_upstream_->dispatcher()->post([handler = std::move(listener->handler), &done] mutable {
-        handler.reset();
-        done.Notify();
-      });
+    absl::Notification done;
+    fake_upstream_->dispatcher()->post([listener = listener.get(), &done] mutable {
+      listener->mu.lock();
+      listener->timer->disableTimer();
+      listener->handler.reset();
       listener->mu.unlock();
-      done.WaitForNotification();
-    } else {
-      listener->mu.unlock();
-    }
+
+      done.Notify();
+    });
+    done.WaitForNotification();
   }
   fake_upstream_->cleanUp();
 }
@@ -190,7 +188,7 @@ AssertionResult FakeUpstreamShimImpl::listenForSshConnection(std::shared_ptr<Ssh
         listener->timer->enableTimer(std::chrono::milliseconds(10));
         return;
       }
-      listener->timer = nullptr;
+      listener->timer->disableTimer();
       auto& sc = fake_upstream_->consumeConnection();
       lock2.Release();
       listener->handler->onNewConnection(sc.connection());

--- a/test/extensions/filters/network/ssh/ssh_upstream.cc
+++ b/test/extensions/filters/network/ssh/ssh_upstream.cc
@@ -20,6 +20,10 @@ void SshFakeUpstreamHandler::CodecCallbacks::writeToConnection(Buffer::Instance&
   connection_.write(buffer, false);
 }
 
+Envoy::OptRef<Envoy::Network::Connection> SshFakeUpstreamHandler::CodecCallbacks::connection() {
+  return connection_;
+}
+
 Network::FilterStatus SshFakeUpstreamHandler::ReadFilter::onData(Buffer::Instance& data, bool end_stream) {
   parent_.decode(data, end_stream);
   return Network::FilterStatus::StopIteration; // this is the only read filter

--- a/test/extensions/filters/network/ssh/ssh_upstream.h
+++ b/test/extensions/filters/network/ssh/ssh_upstream.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "source/extensions/filters/network/ssh/channel_filter_config.h"
 #include "source/extensions/filters/network/ssh/service_connection.h"
 #include "source/extensions/filters/network/ssh/service_userauth.h"
 #include "source/extensions/filters/network/ssh/transport_base.h"
@@ -140,6 +141,10 @@ protected:
     return channel_id_manager_;
   }
 
+  ChannelFilterManager& channelFilterManager() override {
+    return channel_filter_manager_;
+  }
+
   stream_id_t streamId() const override {
     return 42; // unused, except in logs
   }
@@ -151,6 +156,7 @@ private:
   // order is important here
   std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config_;
   ChannelIDManager channel_id_manager_{100};
+  ChannelFilterManager channel_filter_manager_{ChannelFilterManager::unused_in_this_test{}};
   MessageDispatcher<wire::Message>* msg_dispatcher_{};
   std::shared_ptr<SshFakeUpstreamHandlerOpts> opts_;
   std::unique_ptr<CodecCallbacks> codec_callbacks_;

--- a/test/extensions/filters/network/ssh/ssh_upstream.h
+++ b/test/extensions/filters/network/ssh/ssh_upstream.h
@@ -19,6 +19,7 @@ public:
   virtual ~SshFakeUpstreamHandlerCodecCallbacks() = default;
   virtual void onDecodingFailure(absl::string_view reason = {}) PURE;
   virtual void writeToConnection(Buffer::Instance& buffer) PURE;
+  virtual Envoy::OptRef<Envoy::Network::Connection> connection() PURE;
 };
 
 class SshFakeUpstreamHandlerCodec {
@@ -75,6 +76,7 @@ public:
     explicit CodecCallbacks(Network::Connection& connection);
     void onDecodingFailure(absl::string_view reason = {}) override;
     void writeToConnection(Buffer::Instance& buffer) override;
+    Envoy::OptRef<Envoy::Network::Connection> connection() override;
 
     Network::Connection& connection_;
   };

--- a/test/extensions/filters/network/ssh/test_mocks.cc
+++ b/test/extensions/filters/network/ssh/test_mocks.cc
@@ -50,5 +50,17 @@ MockChannel::~MockChannel() {
 MockChannelStatsProvider::MockChannelStatsProvider() {}
 MockChannelStatsProvider::~MockChannelStatsProvider() {}
 
+MockChannelFilterCallbacks::MockChannelFilterCallbacks() {}
+MockChannelFilterCallbacks::~MockChannelFilterCallbacks() {}
+
+MockChannelFilter::MockChannelFilter() {}
+MockChannelFilter::~MockChannelFilter() {}
+
+MockChannelFilterFactory::MockChannelFilterFactory() {}
+MockChannelFilterFactory::~MockChannelFilterFactory() {}
+
+MockChannelFilterFactoryConfig::MockChannelFilterFactoryConfig() {}
+MockChannelFilterFactoryConfig::~MockChannelFilterFactoryConfig() {}
+
 } // namespace test
 } // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec

--- a/test/extensions/filters/network/ssh/test_mocks.h
+++ b/test/extensions/filters/network/ssh/test_mocks.h
@@ -161,7 +161,7 @@ public:
   virtual ~MockHijackedChannelCallbacks();
 
   MOCK_METHOD(void, initHandoff, (pomerium::extensions::ssh::SSHChannelControlAction_HandOffUpstream*));
-  MOCK_METHOD(void, hijackedChannelFailed, (absl::Status));
+  MOCK_METHOD(pomerium::extensions::ssh::InternalCLIModeHint, modeHint, (), (const));
 };
 
 class MockKexCallbacks : public KexCallbacks {

--- a/test/extensions/filters/network/ssh/test_mocks.h
+++ b/test/extensions/filters/network/ssh/test_mocks.h
@@ -134,8 +134,10 @@ class MockChannelFilterFactory : public ChannelFilterFactory {
 public:
   MockChannelFilterFactory();
   virtual ~MockChannelFilterFactory();
-  MOCK_METHOD(ChannelFilterPtr, createReadFilter, (ChannelFilterCallbacks&));
-  MOCK_METHOD(ChannelFilterPtr, createWriteFilter, (ChannelFilterCallbacks&));
+
+  MOCK_METHOD(ProtobufTypes::MessagePtr, createEmptyConfigProto, ());
+  MOCK_METHOD(ChannelFilterPtr, createReadFilter, (const google::protobuf::Message&, ChannelFilterCallbacks&));
+  MOCK_METHOD(ChannelFilterPtr, createWriteFilter, (const google::protobuf::Message&, ChannelFilterCallbacks&));
 };
 
 class MockChannelFilterFactoryConfig : public ChannelFilterFactoryConfig {
@@ -144,7 +146,7 @@ public:
   virtual ~MockChannelFilterFactoryConfig();
 
   MOCK_METHOD(ProtobufTypes::MessagePtr, createEmptyConfigProto, ()); // returns empty StringValue by default
-  MOCK_METHOD(ChannelFilterFactoryPtr, createChannelFilterFactory, (Envoy::Server::Configuration::ServerFactoryContext&));
+  MOCK_METHOD(ChannelFilterFactoryPtr, createChannelFilterFactory, (const google::protobuf::Message&, Envoy::Server::Configuration::ServerFactoryContext&));
   MOCK_METHOD(std::string, name, (), (const));
 };
 

--- a/test/extensions/filters/network/ssh/test_mocks.h
+++ b/test/extensions/filters/network/ssh/test_mocks.h
@@ -121,6 +121,7 @@ public:
   MOCK_METHOD(std::optional<std::string_view>, channelType, (), (const));
   MOCK_METHOD(Stats::Scope&, scope, (), (const));
   MOCK_METHOD(stream_id_t, streamId, (), (const));
+  MOCK_METHOD(const AuthInfo&, authInfo, (), (const));
   MOCK_METHOD(bool, interruptChannel, (absl::Status));
 };
 

--- a/test/extensions/filters/network/ssh/test_mocks.h
+++ b/test/extensions/filters/network/ssh/test_mocks.h
@@ -60,6 +60,7 @@ public:
   MOCK_METHOD(void, terminate, (absl::Status), (override));
   MOCK_METHOD(Envoy::OptRef<Envoy::Event::Dispatcher>, connectionDispatcher, (), (const override));
   MOCK_METHOD(ChannelIDManager&, channelIdManager, (), (override));
+  MOCK_METHOD(ChannelFilterManager&, channelFilterManager, (), (override));
   MOCK_METHOD(const SecretsProvider&, secretsProvider, (), (const override));
   MOCK_METHOD(Stats::Scope&, statsScope, (), (const));
 
@@ -110,6 +111,41 @@ public:
   MockChannelStatsProvider();
   virtual ~MockChannelStatsProvider();
   MOCK_METHOD(void, populateChannelStats, (pomerium::extensions::ssh::ChannelStats&), (const));
+};
+
+class MockChannelFilterCallbacks : public ChannelFilterCallbacks {
+public:
+  MockChannelFilterCallbacks();
+  virtual ~MockChannelFilterCallbacks();
+  MOCK_METHOD(uint32_t, channelId, (), (const));
+  MOCK_METHOD(std::optional<std::string_view>, channelType, (), (const));
+  MOCK_METHOD(Stats::Scope&, scope, (), (const));
+  MOCK_METHOD(bool, interruptChannel, (absl::Status));
+};
+
+class MockChannelFilter : public ChannelFilter {
+public:
+  MockChannelFilter();
+  virtual ~MockChannelFilter();
+  MOCK_METHOD(void, onMessageForward, (const wire::Message&));
+};
+
+class MockChannelFilterFactory : public ChannelFilterFactory {
+public:
+  MockChannelFilterFactory();
+  virtual ~MockChannelFilterFactory();
+  MOCK_METHOD(ChannelFilterPtr, createReadFilter, (ChannelFilterCallbacks&));
+  MOCK_METHOD(ChannelFilterPtr, createWriteFilter, (ChannelFilterCallbacks&));
+};
+
+class MockChannelFilterFactoryConfig : public ChannelFilterFactoryConfig {
+public:
+  MockChannelFilterFactoryConfig();
+  virtual ~MockChannelFilterFactoryConfig();
+
+  MOCK_METHOD(ProtobufTypes::MessagePtr, createEmptyConfigProto, ()); // returns empty StringValue by default
+  MOCK_METHOD(ChannelFilterFactoryPtr, createChannelFilterFactory, (Envoy::Server::Configuration::ServerFactoryContext&));
+  MOCK_METHOD(std::string, name, (), (const));
 };
 
 class MockHijackedChannelCallbacks : public HijackedChannelCallbacks {

--- a/test/extensions/filters/network/ssh/test_mocks.h
+++ b/test/extensions/filters/network/ssh/test_mocks.h
@@ -120,6 +120,7 @@ public:
   MOCK_METHOD(uint32_t, channelId, (), (const));
   MOCK_METHOD(std::optional<std::string_view>, channelType, (), (const));
   MOCK_METHOD(Stats::Scope&, scope, (), (const));
+  MOCK_METHOD(stream_id_t, streamId, (), (const));
   MOCK_METHOD(bool, interruptChannel, (absl::Status));
 };
 

--- a/test/extensions/filters/network/ssh/test_mocks.h
+++ b/test/extensions/filters/network/ssh/test_mocks.h
@@ -59,6 +59,7 @@ public:
   MOCK_METHOD(std::optional<wire::ExtInfoMsg>, peerExtInfo, (), (const));
   MOCK_METHOD(void, terminate, (absl::Status), (override));
   MOCK_METHOD(Envoy::OptRef<Envoy::Event::Dispatcher>, connectionDispatcher, (), (const override));
+  MOCK_METHOD(void, connectionReadDisable, (bool), (override));
   MOCK_METHOD(ChannelIDManager&, channelIdManager, (), (override));
   MOCK_METHOD(ChannelFilterManager&, channelFilterManager, (), (override));
   MOCK_METHOD(const SecretsProvider&, secretsProvider, (), (const override));
@@ -123,6 +124,8 @@ public:
   MOCK_METHOD(stream_id_t, streamId, (), (const));
   MOCK_METHOD(const AuthInfo&, authInfo, (), (const));
   MOCK_METHOD(bool, interruptChannel, (absl::Status));
+  MOCK_METHOD(Envoy::Event::Dispatcher&, connectionDispatcher, (), (const));
+  MOCK_METHOD(ReadDisableHandlePtr, connectionReadDisable, ());
 };
 
 class MockChannelFilter : public ChannelFilter {

--- a/test/extensions/filters/network/ssh/transport_base_test.cc
+++ b/test/extensions/filters/network/ssh/transport_base_test.cc
@@ -22,7 +22,8 @@ public:
                     std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config,
                     const SecretsProvider& secrets_provider)
       : TransportBase<T>(context, config, secrets_provider),
-        dispatcher_(context.api().allocateDispatcher(std::string(codec_traits<T>::name))) {
+        dispatcher_(context.api().allocateDispatcher(std::string(codec_traits<T>::name))),
+        channel_filter_manager_(context, {}) {
     SetVersion(fmt::format("SSH-2.0-{}", codec_traits<T>::name));
   }
 
@@ -66,6 +67,8 @@ public:
       });
     ON_CALL(*this, channelIdManager())
       .WillByDefault(ReturnRef(channel_id_manager_));
+    ON_CALL(*this, channelFilterManager())
+      .WillByDefault(ReturnRef(channel_filter_manager_));
     ON_CALL(*this, updatePeerExtInfo(_))
       .WillByDefault([this](std::optional<wire::ExtInfoMsg> msg) {
         return this->TransportBase<T>::updatePeerExtInfo(std::move(msg));
@@ -113,6 +116,7 @@ public:
   MOCK_METHOD(void, registerMessageHandlers, (SshMessageDispatcher&));                              // mocked
   MOCK_METHOD(Envoy::OptRef<Envoy::Event::Dispatcher>, connectionDispatcher, (), (const override)); // mocked
   MOCK_METHOD(ChannelIDManager&, channelIdManager, (), (override));                                 // mocked
+  MOCK_METHOD(ChannelFilterManager&, channelFilterManager, (), (override));                         // mocked, not tested here
 
   MOCK_METHOD(void, forward, (wire::Message&&, FrameTags));                   // pure virtual, not tested here
   MOCK_METHOD(absl::StatusOr<bytes>, signWithHostKey, (bytes_view), (const)); // pure virtual, not tested here
@@ -205,6 +209,7 @@ private:
   std::atomic_bool closed_{false};
   ::Envoy::Event::DispatcherPtr dispatcher_;
   ChannelIDManager channel_id_manager_;
+  ChannelFilterManager channel_filter_manager_;
 };
 
 inline absl::Duration defaultTimeout() {

--- a/test/extensions/filters/network/ssh/transport_base_test.cc
+++ b/test/extensions/filters/network/ssh/transport_base_test.cc
@@ -23,7 +23,7 @@ public:
                     const SecretsProvider& secrets_provider)
       : TransportBase<T>(context, config, secrets_provider),
         dispatcher_(context.api().allocateDispatcher(std::string(codec_traits<T>::name))),
-        channel_filter_manager_(context, {}) {
+        channel_filter_manager_({}, context) {
     SetVersion(fmt::format("SSH-2.0-{}", codec_traits<T>::name));
   }
 

--- a/test/extensions/filters/network/ssh/transport_base_test.cc
+++ b/test/extensions/filters/network/ssh/transport_base_test.cc
@@ -12,6 +12,18 @@
 #include "absl/synchronization/blocking_counter.h"
 #include "test/mocks/server/server_factory_context.h"
 
+namespace Envoy::Network {
+// Mock connection with no defaults configured. The regular mock connection interferes with the
+// time system, and some tests here only need to check if certain methods are called.
+class NoopMockConnection : public Connection {
+public:
+  NoopMockConnection() = default;
+  ~NoopMockConnection() = default;
+
+  DEFINE_MOCK_CONNECTION_MOCK_METHODS;
+};
+} // namespace Envoy::Network
+
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 namespace test {
 // NOLINTBEGIN(readability-identifier-naming)
@@ -61,6 +73,10 @@ public:
       .WillByDefault([this](absl::Status status) {
         return this->TransportBase<T>::terminate(std::move(status));
       });
+    ON_CALL(*this, connectionReadDisable(_))
+      .WillByDefault([this](bool disable) {
+        return this->TransportBase<T>::connectionReadDisable(disable);
+      });
     ON_CALL(*this, connectionDispatcher())
       .WillByDefault([this] -> Envoy::OptRef<Envoy::Event::Dispatcher> {
         return *dispatcher_;
@@ -108,6 +124,7 @@ public:
   MOCK_METHOD(absl::StatusOr<size_t>, sendMessageToConnection, (wire::Message&&), (override));           // delegates to the base class
   MOCK_METHOD(absl::StatusOr<size_t>, sendMessageDirect, (wire::Message&&), (override));                 // delegates to the base class
   MOCK_METHOD(void, terminate, (absl::Status), (override));                                              // delegates to the base class
+  MOCK_METHOD(void, connectionReadDisable, (bool), (override));                                          // delegates to the base class
 
   MOCK_METHOD(EncodingResult, encode, (const StreamFrame&, EncodingContext&));                         // pure virtual, not tested here
   MOCK_METHOD(ResponseHeaderFramePtr, respond, (Status, std::string_view, const RequestHeaderFrame&)); // pure virtual, not tested here
@@ -1528,6 +1545,60 @@ TYPED_TEST_P(TransportBaseTest, TestUnimplementedMsg) {
   this->Join();
 }
 
+TYPED_TEST_P(TransportBaseTest, TestConnectionReadDisable) {
+  if (!this->StartAndWaitForInitialKeyExchange()) {
+    return;
+  }
+
+  testing::StrictMock<Envoy::Network::NoopMockConnection> mockServerConn;
+  testing::MockFunction<void()> mockServerCheckpoint;
+  testing::StrictMock<Envoy::Network::NoopMockConnection> mockClientConn;
+  testing::MockFunction<void()> mockClientCheckpoint;
+
+  {
+    IN_SEQUENCE;
+    EXPECT_CALL(mockServerConn, readDisable(true));
+    EXPECT_CALL(mockServerCheckpoint, Call);
+    EXPECT_CALL(mockServerConn, readDisable(false));
+  }
+  {
+    IN_SEQUENCE;
+    EXPECT_CALL(mockClientConn, readDisable(true));
+    EXPECT_CALL(mockClientCheckpoint, Call);
+    EXPECT_CALL(mockClientConn, readDisable(false));
+  }
+
+  ON_CALL(this->ServerCallbacks(), connection())
+    .WillByDefault([&] {
+      return makeOptRef(dynamic_cast<Envoy::Network::Connection&>(mockServerConn));
+    });
+  EXPECT_CALL(this->ServerCallbacks(), connection())
+    .Times(2);
+
+  ON_CALL(this->ClientCallbacks(), connection())
+    .WillByDefault([&] {
+      return makeOptRef(dynamic_cast<Envoy::Network::Connection&>(mockClientConn));
+    });
+  EXPECT_CALL(this->ClientCallbacks(), connection())
+    .Times(2);
+
+  this->Server().Post([&](auto& server) {
+    server.connectionReadDisable(true);
+    mockServerCheckpoint.Call();
+    server.connectionReadDisable(false);
+    this->Server().Exit();
+  });
+
+  this->Client().Post([&](auto& client) {
+    client.connectionReadDisable(true);
+    mockClientCheckpoint.Call();
+    client.connectionReadDisable(false);
+    this->Client().Exit();
+  });
+
+  this->Join();
+}
+
 REGISTER_TYPED_TEST_SUITE_P(TransportBaseTest,
                             TestHandshake,
                             TestHandshakeWithExtInfo,
@@ -1551,7 +1622,8 @@ REGISTER_TYPED_TEST_SUITE_P(TransportBaseTest,
                             TestErrorSendingQueuedMessagesAfterRekey,
                             TestRekeyTriggeredDuringQueueReplay,
                             TestErrorEncodingPacket,
-                            TestUnimplementedMsg);
+                            TestUnimplementedMsg,
+                            TestConnectionReadDisable);
 
 struct ClientInitiatesOptions {
   static constexpr bool client_initiates = true;


### PR DESCRIPTION
This adds a new channel filter extension type which can be used in a similar manner as generic proxy stream filters, but scoped to individual ssh channels instead of the entire connection. Channel filters implement a method `onMessageForward` which is called before a channel is about to forward a message to the peer. Channel filters are also able to query a channel's internal id, type, and stats, and are able to interrupt channels using the same preempt mechanism used for graceful shutdown.