### PR TITLE
macos: fix idle CPU usage by forcing kqueue in libevent

### DIFF
--- a/envoy.bazelrc
+++ b/envoy.bazelrc
@@ -100,6 +100,10 @@ build:macos --define tcmalloc=disabled
 build:macos --cxxopt=-Wno-nullability-completeness
 build:macos --@toolchains_llvm//toolchain/config:compiler-rt=false
 build:macos --@toolchains_llvm//toolchain/config:libunwind=false
+build:macos --copt=-DEVENT__HAVE_KQUEUE=1
+build:macos --copt=-DEVENT__HAVE_WORKING_KQUEUE=1
+build:macos --copt=-DHAVE_KQUEUE=1
+build:macos --copt=-DHAVE_WORKING_KQUEUE=1
 
 
 #############################################################################


### PR DESCRIPTION
When cross-compiling for macOS on Linux runners (via OCI migration), CMake fails to detect 'kqueue' support in libevent and falls back to an inefficient and level-triggered 'poll' event loop.

This causes a major performance regression (benchmarked at ~200% idle CPU) on high-core-count macOS systems because every worker thread enters a high-frequency busy-wait state on writable/idle sockets.

This PR explicitly forces the kqueue flags in envoy.bazelrc to ensure libevent uses the optimized edge-triggered backend even in cross-builds.

Linked issue: https://github.com/pomerium/pomerium/issues/6301