### PR TITLE
add libevent patch to remove kqueue check for macos

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,7 +47,7 @@ http_archive(
     patches = [
         "//patches/envoy:0001-revert-deps-drop-BoringSSL-linkstatic-patch-38621.patch",
         "//patches/envoy:0002-envoy-copts.patch",
-        "//patches/envoy:0003-protoc-gen-validate.patch",
+        "//patches/envoy:0003-add-external-patches.patch",
         "//patches/envoy:0004-suppress-duplicate-wip-warnings.patch",
         "//patches/envoy:0005-user-space-io-handle.patch",
         "//patches/envoy:0006-fake-upstream.patch",

--- a/patches/envoy/0003-add-external-patches.patch
+++ b/patches/envoy/0003-add-external-patches.patch
@@ -11,3 +11,16 @@ index c93daba62e..55f77d7b7d 100644
          repo_mapping = {"@com_google_absl": "@abseil-cpp"},
      )
      external_http_archive(
+diff --git a/bazel/repositories.bzl b/bazel/repositories.bzl
+index ad51ee705e..19b6a3eebd 100644
+--- a/bazel/repositories.bzl
++++ b/bazel/repositories.bzl
+@@ -478,6 +478,8 @@ def _libevent():
+     external_http_archive(
+         name = "libevent",
+         build_file_content = LIBEVENT_BUILD_CONTENT,
++        patches = ["@pomerium_envoy//patches/libevent:0001-macos-skip-kqueue-check.patch"],
++        patch_args = ["-p1"],
+     )
+ 
+ def _colm():

--- a/patches/libevent/0001-macos-skip-kqueue-check.patch
+++ b/patches/libevent/0001-macos-skip-kqueue-check.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 89f0ca32..2241ffba 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -665,13 +665,7 @@ CHECK_TYPE_SIZE("time_t" EVENT__SIZEOF_TIME_T)
+ 
+ # Verify kqueue works with pipes.
+ if (EVENT__HAVE_KQUEUE)
+-    if ((CMAKE_CROSSCOMPILING OR APPLE) AND NOT EVENT__FORCE_KQUEUE_CHECK)
+-        message(WARNING "Cannot check if kqueue works with pipes when crosscompiling, use EVENT__FORCE_KQUEUE_CHECK to be sure (this requires manually running a test program on the cross compilation target)")
+-        set(EVENT__HAVE_WORKING_KQUEUE 1)
+-    else()
+-        message(STATUS "Checking if kqueue works with pipes...")
+-        include(CheckWorkingKqueue)
+-    endif()
++    set(EVENT__HAVE_WORKING_KQUEUE 1)
+ endif()
+ 
+ if(EVENT__HAVE_NETDB_H)


### PR DESCRIPTION
When building for BSD platforms and kqueue is available, libevent runs a test program to check if it works (see [here](https://github.com/libevent/libevent/blob/48296514d8fd9c0b3812b11d45ad80b0c002c14e/CMakeLists.txt#L725-L738)). This check will be skipped if either the `CMAKE_CROSSCOMPILING` or `APPLE` internal variables are set (so it's not applicable for macos anyway). We cannot easily control these variables (see https://github.com/bazel-contrib/rules_foreign_cc/issues/397) and the platforms which would use this check are not supported by us, so the check can be omitted entirely.

Fixes https://github.com/pomerium/pomerium/issues/6301