### PR TITLE
relax minimum macOS version to 14

### DIFF
--- a/pomerium.bazelrc
+++ b/pomerium.bazelrc
@@ -27,7 +27,7 @@ common:coverage --action_env=LDFLAGS="-stdlib=libc++ -fuse-ld=lld -rtlib=compile
 # which causes fPIC mismatch errors.
 build --@io_bazel_rules_go//go/config:pure=True
 
-build --macos_minimum_os=15.5
+build --macos_minimum_os=14.5
 build:linux --features=-libtool
 
 common:buildbarn --remote_executor=grpc://frontend.buildbarn.svc.cluster.local:8980


### PR DESCRIPTION
Match the macos_minimum_os value set by upstream envoy: https://github.com/envoyproxy/envoy/blob/3c9f5fca3f1769b0dd5c60bd82dbce4135cfc5b0/mobile/.bazelrc#L25

Related issue:
https://linear.app/pomerium/issue/ENG-3955/envoy-support-macos-14-or-later