### PR TITLE
dynamic extensions: improve build rules for internal api deps, disable fission

### DIFF
--- a/bazel/dynamic_extension.bzl
+++ b/bazel/dynamic_extension.bzl
@@ -1,4 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 
 # dependencies required for all extensions
 builtin_host_deps = [
@@ -6,12 +8,98 @@ builtin_host_deps = [
     "@envoy//source/common/common:logger_lib",
 ]
 
+def _filter_static_libs_impl(ctx):
+    linker_inputs = []
+    for src in ctx.attr.srcs:
+        if DefaultInfo in src:
+            files = src[DefaultInfo].files.to_list()
+            generated_libs = [
+                cc_common.create_library_to_link(pic_static_library = f, actions = ctx.actions)
+                for f in files
+                if f.extension == "a"
+            ]
+            linker_inputs.append(cc_common.create_linker_input(
+                owner = src.label,
+                libraries = depset(direct = generated_libs),
+            ))
+
+    return [
+        CcInfo(
+            linking_context = cc_common.create_linking_context(
+                linker_inputs = depset(direct = linker_inputs),
+            ),
+        ),
+    ]
+
+def _filter_generated_hdrs_impl(ctx):
+    generated_hdrs = []
+    for src in ctx.attr.srcs:
+        if DefaultInfo in src:
+            files = src[DefaultInfo].files.to_list()
+            generated_hdrs += [f for f in files if f.extension == "h"]
+    return [
+        DefaultInfo(
+            files = depset(direct = generated_hdrs),
+        ),
+    ]
+
+_filter_static_libs = rule(
+    implementation = _filter_static_libs_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            mandatory = True,
+        ),
+    },
+)
+
+_filter_generated_hdrs = rule(
+    implementation = _filter_generated_hdrs_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            mandatory = True,
+        ),
+    },
+)
+
+_disable_fission_transition = transition(
+    implementation = lambda _, __: {"//command_line_option:fission": "no"},
+    inputs = [],
+    outputs = ["//command_line_option:fission"],
+)
+
+def _extension_cc_binary_impl(ctx):
+    output = ctx.actions.declare_file(ctx.label.name + ".so")
+    ctx.actions.symlink(
+        target_file = ctx.attr.target[0][DefaultInfo].files.to_list()[0],
+        output = output,
+    )
+    return [
+        DefaultInfo(
+            files = depset(direct = [output]),
+        ),
+    ]
+
+extension_cc_binary = rule(
+    implementation = _extension_cc_binary_impl,
+    attrs = {
+        "target": attr.label(
+            allow_single_file = True,
+            cfg = _disable_fission_transition,
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)
+
 def _internal_api_deps_targets(targets):
     out = []
     for target in targets:
+        # TODO: handle grpc services
         out += [
             target + ":pkg_cc_proto_cc_proto",
             target + ":pkg_cc_proto_validate",
+            target + ":pkg_cc_proto_descriptor",
         ]
     return out
 
@@ -26,11 +114,21 @@ def cc_dynamic_extension(
         testonly = 0,
         visibility = ["//visibility:public"]):
     _name = "_" + name
+    _filter_static_libs(
+        name = _name + "_proto_generated_libs",
+        srcs = _internal_api_deps_targets(internal_api_deps),
+        testonly = testonly,
+    )
+    _filter_generated_hdrs(
+        name = _name + "_proto_generated_hdrs",
+        srcs = _internal_api_deps_targets(internal_api_deps),
+        testonly = testonly,
+    )
     cc_library(
-        name = _name,
+        name = _name + "_lib",
         visibility = visibility,
-        srcs = srcs + _internal_api_deps_targets(internal_api_deps),
-        hdrs = hdrs,
+        srcs = srcs,
+        hdrs = hdrs + [_name + "_proto_generated_hdrs"],
         copts = copts + [
             "-fvisibility=hidden",
             "-fPIC",
@@ -44,14 +142,33 @@ def cc_dynamic_extension(
         alwayslink = True,
     )
     cc_binary(
-        name = name,
-        srcs = [_name],
+        name = _name,
+        srcs = [_name + "_lib"],
         linkopts = [
             "-fvisibility=hidden",
             "-fPIC",
         ],
         testonly = testonly,
-        deps = ["@pomerium_envoy//source/common/dynamic_extensions:version_ref_lib"],
+        deps = [
+            "@pomerium_envoy//source/common/dynamic_extensions:version_ref_lib",
+
+            # We use the envoy macros to build protobuf packages, which expand to several other
+            # rules. The combined output is the generated headers plus several libraries (both .a
+            # and .so versions for each), and the generated sources used to build those libraries.
+            # If the symbols for the generated code aren't in the host binary, they all need to be
+            # in the extension binary. Since the extension is a shared library, directly depending
+            # on the *_cc_proto target will link with shared library built from the generated code
+            # instead of the static one. This forces it to link only the static libraries instead.
+            # Note that this has to be added here and not part of the srcs of the cc_library above,
+            # which is where the extension sources normally go. Adding the proto targets there will
+            # cause an internal error in bazel.
+            _name + "_proto_generated_libs",
+        ],
         linkshared = True,
         linkstatic = False,
+    )
+    extension_cc_binary(
+        name = name,
+        target = _name,
+        testonly = testonly,
     )

--- a/test/common/dynamic_extensions/dynamic_extensions_test.cc
+++ b/test/common/dynamic_extensions/dynamic_extensions_test.cc
@@ -186,7 +186,7 @@ public:
     test_no_config_dynamic_extension_init_called = 0;
 
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
-      "test/common/dynamic_extensions/test/libtest_no_config.so", "pomerium_envoy");
+      "test/common/dynamic_extensions/test/test_no_config.so", "pomerium_envoy");
 
 #ifndef SANITIZER_ENABLED
     auto result = RunReadExtension({"--check", SelfPath(), extension_path_});
@@ -234,7 +234,7 @@ public:
     test_optional_config_dynamic_extension_init_called = 0;
 
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
-      "test/common/dynamic_extensions/test/libtest_optional_config.so", "pomerium_envoy");
+      "test/common/dynamic_extensions/test/test_optional_config.so", "pomerium_envoy");
 
 #ifndef SANITIZER_ENABLED
     auto result = RunReadExtension({"--check", SelfPath(), extension_path_});
@@ -282,7 +282,7 @@ public:
     test_required_config_dynamic_extension_init_called = 0;
 
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
-      "test/common/dynamic_extensions/test/libtest_required_config.so", "pomerium_envoy");
+      "test/common/dynamic_extensions/test/test_required_config.so", "pomerium_envoy");
 
 #ifndef SANITIZER_ENABLED
     auto result = RunReadExtension({"--check", SelfPath(), extension_path_});
@@ -326,7 +326,7 @@ public:
 
   void SetUp() override {
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
-      "test/common/dynamic_extensions/test/libtest_no_init.so", "pomerium_envoy");
+      "test/common/dynamic_extensions/test/test_no_init.so", "pomerium_envoy");
 
 #ifndef SANITIZER_ENABLED
     auto result = RunReadExtension({"--check", SelfPath(), extension_path_});
@@ -366,7 +366,7 @@ public:
 
   void SetUp() override {
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
-      "test/common/dynamic_extensions/test/libtest_missing_symbol.so", "pomerium_envoy");
+      "test/common/dynamic_extensions/test/test_missing_symbol.so", "pomerium_envoy");
 
 #ifndef SANITIZER_ENABLED
     auto result = RunReadExtension({"--check", SelfPath(), "--demangle", extension_path_});
@@ -390,7 +390,7 @@ TEST_F(MissingWeakDependencyTest, TestMissingWeakDependency) {
 
 TEST_F(DynamicExtensionsIntegrationTest, TestVersionMismatch) {
   auto extension_path = Envoy::TestEnvironment::runfilesPath(
-    "test/common/dynamic_extensions/test/libtest_version_mismatch.so", "pomerium_envoy");
+    "test/common/dynamic_extensions/test/test_version_mismatch.so", "pomerium_envoy");
 
   ConfigureExtensionLoader({extension_path});
 
@@ -403,7 +403,7 @@ TEST_F(DynamicExtensionsIntegrationTest, TestVersionMismatch) {
 
 TEST_F(DynamicExtensionsIntegrationTest, TestMetadataUnknownKeys) {
   auto extension_path = Envoy::TestEnvironment::runfilesPath(
-    "test/common/dynamic_extensions/test/libtest_md_unknown_keys.so", "pomerium_envoy");
+    "test/common/dynamic_extensions/test/test_md_unknown_keys.so", "pomerium_envoy");
 
   ConfigureExtensionLoader({extension_path});
 
@@ -430,7 +430,7 @@ public:
 
   void SetUp() override {
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
-      "test/common/dynamic_extensions/test/libtest_tls.so", "pomerium_envoy");
+      "test/common/dynamic_extensions/test/test_tls.so", "pomerium_envoy");
 
 #ifndef SANITIZER_ENABLED
     auto result = RunReadExtension({"--check", SelfPath(), extension_path_});
@@ -485,7 +485,7 @@ public:
   }
   void SetUp() override {
     extension_path_ = Envoy::TestEnvironment::runfilesPath(
-      "test/common/dynamic_extensions/test/libtest_http_factory.so", "pomerium_envoy");
+      "test/common/dynamic_extensions/test/test_http_factory.so", "pomerium_envoy");
   }
   std::string extension_path_;
 };
@@ -519,7 +519,7 @@ TEST_F(DynamicExtensionsIntegrationTest, TestAdminApiMethodNotAllowed) {
 
 TEST_F(DynamicExtensionsIntegrationTest, TestLoadDuplicatePaths) {
   auto extension_path = Envoy::TestEnvironment::runfilesPath(
-    "test/common/dynamic_extensions/test/libtest_no_config.so", "pomerium_envoy");
+    "test/common/dynamic_extensions/test/test_no_config.so", "pomerium_envoy");
   ConfigureExtensionLoader({extension_path, extension_path, extension_path});
 
   initialize();
@@ -532,9 +532,9 @@ TEST_F(DynamicExtensionsIntegrationTest, TestLoadDuplicatePaths) {
 
 TEST_F(DynamicExtensionsIntegrationTest, TestLoadDuplicateIds) {
   auto path1 = Envoy::TestEnvironment::runfilesPath(
-    "test/common/dynamic_extensions/test/libtest_no_config.so", "pomerium_envoy");
+    "test/common/dynamic_extensions/test/test_no_config.so", "pomerium_envoy");
   auto path2 = Envoy::TestEnvironment::runfilesPath(
-    "test/common/dynamic_extensions/test/libtest_no_config_2.so", "pomerium_envoy");
+    "test/common/dynamic_extensions/test/test_no_config_2.so", "pomerium_envoy");
 
   ConfigureExtensionLoader({path1, path2});
 
@@ -550,7 +550,7 @@ TEST_F(DynamicExtensionsIntegrationTest, TestLoadDuplicateIds) {
 
 TEST_F(DynamicExtensionsIntegrationTest, TestNoMetadata) {
   auto extension_path = Envoy::TestEnvironment::runfilesPath(
-    "test/common/dynamic_extensions/test/libtest_no_metadata.so", "pomerium_envoy");
+    "test/common/dynamic_extensions/test/test_no_metadata.so", "pomerium_envoy");
 
   ConfigureExtensionLoader({extension_path});
 
@@ -564,7 +564,7 @@ TEST_F(DynamicExtensionsIntegrationTest, TestNoMetadata) {
 
 TEST_F(DynamicExtensionsIntegrationTest, TestNoID) {
   auto extension_path = Envoy::TestEnvironment::runfilesPath(
-    "test/common/dynamic_extensions/test/libtest_no_id.so", "pomerium_envoy");
+    "test/common/dynamic_extensions/test/test_no_id.so", "pomerium_envoy");
 
   ConfigureExtensionLoader({extension_path});
 
@@ -578,7 +578,7 @@ TEST_F(DynamicExtensionsIntegrationTest, TestNoID) {
 
 TEST_F(DynamicExtensionsIntegrationTest, TestInvalidID) {
   auto extension_path = Envoy::TestEnvironment::runfilesPath(
-    "test/common/dynamic_extensions/test/libtest_invalid_id.so", "pomerium_envoy");
+    "test/common/dynamic_extensions/test/test_invalid_id.so", "pomerium_envoy");
 
   ConfigureExtensionLoader({extension_path});
 


### PR DESCRIPTION
This fixes extensions which need to include protobuf packages built via the envoy api build system that are not present in the host binary. Additionally, fission is now disabled for extensions, since it is not possible to build dwp packages for them due to some bazel limitations wrt propagating debug context in CcInfo (and debug context being an internal api for some reason). Extensions are small enough anyway where the extra few MB of debug info is inconsequential.