### PR TITLE
dynamic extensions: add exit hook

### DIFF
--- a/source/common/dynamic_extensions/extension.h
+++ b/source/common/dynamic_extensions/extension.h
@@ -15,3 +15,4 @@
 
 constexpr const char* dynamic_extension_init_sym = "_Z20dynamicExtensionInitRKN6google8protobuf3AnyERN5Envoy6Server8InstanceE";
 constexpr const char* dynamic_extension_init_no_config_sym = "_Z20dynamicExtensionInitRN5Envoy6Server8InstanceE";
+constexpr const char* dynamic_extension_exit_sym = "_Z20dynamicExtensionExitv";

--- a/source/extensions/bootstrap/dynamic_extension_loader/handle.cc
+++ b/source/extensions/bootstrap/dynamic_extension_loader/handle.cc
@@ -11,6 +11,10 @@ DynamicExtensionHandle::DynamicExtensionHandle(void* raw_handle, ExtensionInfo i
 }
 
 DynamicExtensionHandle::~DynamicExtensionHandle() {
+  if (abi_dynamic_extension_exit_ != nullptr) {
+    ENVOY_LOG_MISC(debug, "calling dynamicExtensionExit for extension {}", info_.metadata.id);
+    abi_dynamic_extension_exit_();
+  }
   // best-effort only, this is not guaranteed to always work.
   dlclose(raw_handle_);
 }
@@ -50,6 +54,9 @@ void DynamicExtensionHandle::loadAbiSymbols() {
   }
   if (auto* sp = dlsym(raw_handle_, dynamic_extension_init_no_config_sym); sp != nullptr) {
     abi_dynamic_extension_init_no_config_ = reinterpret_cast<DynamicExtensionInitNoConfigFunc>(sp);
+  }
+  if (auto* sp = dlsym(raw_handle_, dynamic_extension_exit_sym); sp != nullptr) {
+    abi_dynamic_extension_exit_ = reinterpret_cast<DynamicExtensionExitFunc>(sp);
   }
 }
 

--- a/source/extensions/bootstrap/dynamic_extension_loader/handle.h
+++ b/source/extensions/bootstrap/dynamic_extension_loader/handle.h
@@ -7,6 +7,7 @@ namespace Envoy::Extensions::Bootstrap::DynamicExtensionLoader {
 
 using DynamicExtensionInitFunc = void (*)(const google::protobuf::Any&, Envoy::Server::Instance&);
 using DynamicExtensionInitNoConfigFunc = void (*)(Envoy::Server::Instance&);
+using DynamicExtensionExitFunc = void (*)();
 
 class DynamicExtensionHandle {
 public:
@@ -25,6 +26,7 @@ private:
 
   DynamicExtensionInitFunc abi_dynamic_extension_init_{};
   DynamicExtensionInitNoConfigFunc abi_dynamic_extension_init_no_config_{};
+  DynamicExtensionExitFunc abi_dynamic_extension_exit_{};
 };
 
 using DynamicExtensionHandlePtr = std::unique_ptr<DynamicExtensionHandle>;

--- a/test/common/dynamic_extensions/test/test_tls.cc
+++ b/test/common/dynamic_extensions/test/test_tls.cc
@@ -51,8 +51,9 @@ DYNAMIC_EXTENSION_EXPORT void dynamicExtensionInit(Envoy::Server::Instance& serv
     Envoy::Server::ServerLifecycleNotifier::Stage::ShutdownExit,
     []() {
       test_thread_local_slot_.reset();
-      // also delete the handle itself, as it too would outlive the server instance
-      // (deleting the handle inside the callback is allowed)
-      test_shutdown_callback_handle_.reset();
     });
+}
+
+DYNAMIC_EXTENSION_EXPORT void dynamicExtensionExit() {
+  test_shutdown_callback_handle_.reset();
 }


### PR DESCRIPTION
This adds a new ABI function `dynamicExtensionExit()` which is called when the extension loader instance is destroyed. This gives extensions a chance to perform any cleanup that would be complicated or unsafe if using lifecycle callbacks. In particular, destroying a lifecycle callback handle (which appears to be unsafe from within the callback itself, at least in some cases, despite comments in the envoy source suggesting otherwise)