### PR TITLE
ensure macos binaries link dynamically to libc++/libc++abi

### DIFF
--- a/bazel/cxx_libs/cxx_cross_libs.bzl
+++ b/bazel/cxx_libs/cxx_cross_libs.bzl
@@ -1,3 +1,4 @@
+load("@aspect_bazel_lib//lib:repo_utils.bzl", "repo_utils")
 load("//bazel:toolchains.bzl", "TOOLCHAIN_INFO", "TOOLCHAIN_INTEGRITY")
 
 def _cxx_cross_libs_impl(rctx):
@@ -25,7 +26,42 @@ def _cxx_cross_libs_impl(rctx):
     rctx.execute(["mkdir", "lib"])
     rctx.execute(["mkdir", "include"])
     rctx.execute(["find", "%s/include" % prefix, "-type", "f", "-exec", "mv", "{}", "include/", ";"])
-    rctx.execute(["find", "%s/lib" % prefix, "-type", "f", "-exec", "mv", "{}", "lib/", ";"])
+    rctx.execute(["find", "%s/lib" % prefix, "-type", "f,l", "-exec", "mv", "{}", "lib/", ";"])
+
+    if rctx.attr.os == "macos":
+        host_install_name_tool = Label("@llvm_macos_utils_%s//:bin/llvm-install-name-tool" % repo_utils.platform(rctx))
+
+        # Patch the libc++ and libc++abi dylibs such that binaries linking against these will
+        # look in /usr/lib/ for the system libraries, instead of @rpath/
+        res = rctx.execute([
+            str(rctx.path(host_install_name_tool)),
+            "-id",
+            "/usr/lib/libc++.1.dylib",
+            "lib/libc++.1.dylib",
+        ])
+        if res.return_code != 0:
+            fail("install_name_tool failed: %s" % res.stderr)
+
+        # By default the ID for libc++abi is @rpath/libc++abi.1.dylib. /usr/lib/libc++abi.1.dylib
+        # may not exist however, so use /usr/lib/libc++abi.dylib instead
+        res = rctx.execute([
+            str(rctx.path(host_install_name_tool)),
+            "-id",
+            "/usr/lib/libc++abi.dylib",
+            "lib/libc++abi.1.0.dylib",
+        ])
+        if res.return_code != 0:
+            fail("install_name_tool failed: %s" % res.stderr)
+
+        res = rctx.execute([
+            "sed",
+            "-i",
+            "s/#define _LIBCPP_HAS_VENDOR_AVAILABILITY_ANNOTATIONS 0/#define _LIBCPP_HAS_VENDOR_AVAILABILITY_ANNOTATIONS 1/",
+            "include/__config_site",
+        ])
+        if res.return_code != 0:
+            fail("sed failed: %s" % res.stderr)
+
     rctx.delete(prefix)
 
     rctx.file("BUILD", """

--- a/bazel/cxx_libs/load_cxx_cross_libs.bzl
+++ b/bazel/cxx_libs/load_cxx_cross_libs.bzl
@@ -1,6 +1,9 @@
 load("//bazel/cxx_libs:cxx_cross_libs.bzl", "cxx_cross_libs")
+load("//bazel/llvm_macos_utils:load_llvm_macos_utils.bzl", "load_llvm_macos_utils")
 
 def load_cxx_cross_libs():
+    load_llvm_macos_utils()
+
     cxx_cross_libs(
         name = "cxx_cross_libs_linux_arm64",
         os = "linux",

--- a/bazel/llvm_macos_utils/llvm_macos_utils.bzl
+++ b/bazel/llvm_macos_utils/llvm_macos_utils.bzl
@@ -1,0 +1,45 @@
+load("//bazel:toolchains.bzl", "TOOLCHAIN_INFO", "TOOLCHAIN_INTEGRITY")
+
+def _llvm_macos_utils_impl(rctx):
+    _os_mapping = {
+        "linux": "linux",
+        "macos": "darwin",
+    }
+    _arch_mapping = {
+        "amd64": "x86_64",
+        "arm64": "aarch64",
+    }
+    rctx.download_and_extract(
+        sha256 = TOOLCHAIN_INTEGRITY.macos_utils["%s-%s" % (_os_mapping[rctx.attr.os], _arch_mapping[rctx.attr.arch])],
+        stripPrefix = "llvm-macos-utils-{llvm_version}-{attr_os}-{attr_arch}".format(
+            attr_os = rctx.attr.os,
+            attr_arch = rctx.attr.arch,
+            **TOOLCHAIN_INFO
+        ),
+        url = ["{repository}/releases/download/{llvm_version}-{release_revision}/llvm-macos-utils-{llvm_version}-{attr_os}-{attr_arch}.tar.zst".format(
+            attr_os = rctx.attr.os,
+            attr_arch = rctx.attr.arch,
+            **TOOLCHAIN_INFO
+        )],
+    )
+    rctx.file("BUILD", """
+filegroup(
+    name = "llvm_macos_utils",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+""")
+
+llvm_macos_utils = repository_rule(
+    implementation = _llvm_macos_utils_impl,
+    attrs = {
+        "os": attr.string(
+            mandatory = True,
+            values = ["linux", "macos"],
+        ),
+        "arch": attr.string(
+            mandatory = True,
+            values = ["amd64", "arm64"],
+        ),
+    },
+)

--- a/bazel/llvm_macos_utils/load_llvm_macos_utils.bzl
+++ b/bazel/llvm_macos_utils/load_llvm_macos_utils.bzl
@@ -1,0 +1,18 @@
+load("//bazel/llvm_macos_utils:llvm_macos_utils.bzl", "llvm_macos_utils")
+
+def load_llvm_macos_utils():
+    llvm_macos_utils(
+        name = "llvm_macos_utils_linux_amd64",
+        os = "linux",
+        arch = "amd64",
+    )
+    llvm_macos_utils(
+        name = "llvm_macos_utils_linux_arm64",
+        os = "linux",
+        arch = "arm64",
+    )
+    llvm_macos_utils(
+        name = "llvm_macos_utils_darwin_arm64",
+        os = "macos",
+        arch = "arm64",
+    )

--- a/bazel/toolchains.bzl
+++ b/bazel/toolchains.bzl
@@ -25,6 +25,11 @@ TOOLCHAIN_INTEGRITY = struct(
         "linux-x86_64": "f2c7d1d00e1e2dd128bbd943152dab331d60a5dfd066eeaa59d9b87958e6492f",
         "linux-aarch64": "13e1622bafc902508e56b7ac2252b61046e27f04a378cf43aa63bbd42351950e",
     },
+    macos_utils = {
+        "linux-x86_64": "c9e32a2308ac1f0f00772c7f4f54217ae22da10a42daa2a46c239420ceb6c4ea",
+        "linux-aarch64": "6820317c1bb5a1d6f881ecde69c4857597146f1276dee9c266a889af0e151427",
+        "darwin-aarch64": "9e315b52d3b8c74baee7bd957ccabae50793e74514e9fd920f98ada46fc21908",
+    },
     sysroot = {
         "linux-x86_64": "60d503a72a3728a0e3fee8c8bda0f9dab23251f0225c7f0c6aafd8993d4122cb",
         "linux-aarch64": "b9b7e53597c6b7b3289960ad16d6dd01763b9d6ab6122e7c74b72c6823a355b3",

--- a/patches/toolchains_llvm/0002-darwin.patch
+++ b/patches/toolchains_llvm/0002-darwin.patch
@@ -1,5 +1,5 @@
 diff --git a/toolchain/cc_toolchain_config.bzl b/toolchain/cc_toolchain_config.bzl
-index 6e80a11..6f22842 100644
+index 6e80a11..093596c 100644
 --- a/toolchain/cc_toolchain_config.bzl
 +++ b/toolchain/cc_toolchain_config.bzl
 @@ -224,6 +224,8 @@ def cc_toolchain_config(
@@ -25,20 +25,24 @@ index 6e80a11..6f22842 100644
          else:
              # For single-platform builds, we can statically link the bundled
              # libraries.
-@@ -294,9 +303,10 @@ def cc_toolchain_config(
+@@ -294,10 +303,12 @@ def cc_toolchain_config(
              "-stdlib=libc++",
          ]
  
-+        compiler_rt_link_flags = ["-rtlib=compiler-rt"]
-         link_libs.extend([
+-        link_libs.extend([
 -            "-l:libc++.a",
 -            "-l:libc++abi.a",
-+            "-l:libc++.a" if target_os != "darwin" else "-lc++",
-+            "-l:libc++abi.a" if target_os != "darwin" else "-lc++abi",
-         ])
+-        ])
++        compiler_rt_link_flags = ["-rtlib=compiler-rt"]
++        if target_os != "darwin":
++            link_libs.extend([
++                "-l:libc++.a",
++                "-l:libc++abi.a",
++            ])
      elif stdlib == "dynamic-stdc++":
          cxx_flags = [
-@@ -320,12 +330,14 @@ def cc_toolchain_config(
+             "-std=" + cxx_standard,
+@@ -320,12 +331,14 @@ def cc_toolchain_config(
          cxx_flags = [
              "-std=" + cxx_standard,
          ]

--- a/source/common/BUILD
+++ b/source/common/BUILD
@@ -11,6 +11,7 @@ envoy_cc_library(
     name = "common_lib",
     srcs = [],
     hdrs = [
+        "apple.h",
         "concepts.h",
         "factory.h",
         "fixed_string.h",

--- a/source/common/apple.h
+++ b/source/common/apple.h
@@ -1,0 +1,7 @@
+#include <version>
+
+#if defined(__APPLE__)
+#if !_LIBCPP_HAS_VENDOR_AVAILABILITY_ANNOTATIONS
+#error "vendor availability annotations are not enabled"
+#endif
+#endif

--- a/source/extensions/filters/network/ssh/config.h
+++ b/source/extensions/filters/network/ssh/config.h
@@ -3,6 +3,8 @@
 #include <cerrno>
 #include <unistd.h>
 
+#include "source/common/apple.h"
+
 #pragma clang unsafe_buffer_usage begin
 #include "api/extensions/filters/network/ssh/ssh.pb.h"
 #include "api/extensions/filters/network/ssh/ssh.pb.validate.h"


### PR DESCRIPTION
Fixes https://linear.app/pomerium/issue/ENG-3971. Note this only fixes the cross-compile builds, building natively on mac is likely still broken.