### PR TITLE
integration tests: support parallel downstream connections with fake ssh upstream

### DIFF
--- a/source/extensions/filters/network/ssh/transport_base.h
+++ b/source/extensions/filters/network/ssh/transport_base.h
@@ -140,7 +140,8 @@ public:
         terminate(statusf("failed to decode packet: {}", packet_len.status()));
         return;
       }
-      ENVOY_LOG(trace, "received message: size: {}, type: {}", *packet_len, msg.msg_type());
+      ENVOY_LOG(trace, "ssh [{}]: stream {}: received message: size: {}, type: {}",
+                codec_traits<Codec>::name, streamId(), *packet_len, msg.msg_type());
       if (auto err = onMessageDecoded(std::move(msg)); !err.ok()) {
         terminate(err);
         return;

--- a/test/extensions/filters/network/ssh/BUILD
+++ b/test/extensions/filters/network/ssh/BUILD
@@ -18,6 +18,7 @@ envoy_cc_mock(
     repository = "@envoy",
     deps = [
         "//source/extensions/filters/network/ssh:pomerium_ssh",
+        "//test/extensions/filters/network/ssh/wire:wire_test_util",
         "@envoy//test/mocks/stats:stats_mocks",
         "@openssh_portable//:libssh",
     ],
@@ -37,6 +38,16 @@ envoy_cc_test_library(
     ],
 )
 
+envoy_cc_test_library(
+    name = "ssh_test_common_lib",
+    repository = "@envoy",
+    deps = [
+        "//source/extensions/filters/network/ssh:pomerium_ssh",
+        "//test/extensions/filters/network/ssh/wire:wire_test_util",
+        "//test/test_common:test_common_lib",
+    ],
+)
+
 envoy_cc_test(
     name = "extension_ping_test",
     srcs = [
@@ -44,9 +55,8 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
+        ":ssh_test_common_lib",
         ":test_mocks",
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/test_common:test_common_lib",
     ],
 )
 
@@ -61,9 +71,8 @@ envoy_cc_test(
     repository = "@envoy",
     shard_count = 8,
     deps = [
+        ":ssh_test_common_lib",
         ":test_env_util_lib",
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/extensions/filters/network/ssh/wire:wire_test_util",
     ],
 )
 
@@ -74,9 +83,8 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
+        ":ssh_test_common_lib",
         ":test_mocks",
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/extensions/filters/network/ssh/wire:wire_test_util",
     ],
 )
 
@@ -90,8 +98,7 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/extensions/filters/network/ssh/wire:wire_test_util",
+        ":ssh_test_common_lib",
         "@envoy//test/test_common:environment_lib",
         "@openssh_portable//:libssh",
     ],
@@ -104,9 +111,8 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
+        ":ssh_test_common_lib",
         ":test_mocks",
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/test_common:test_common_lib",
     ],
 )
 
@@ -117,10 +123,8 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
+        ":ssh_test_common_lib",
         ":test_mocks",
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/extensions/filters/network/ssh/wire:wire_test_util",
-        "//test/test_common:test_common_lib",
         "@envoy//test/mocks/grpc:grpc_mocks",
     ],
 )
@@ -132,9 +136,7 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/extensions/filters/network/ssh/wire:wire_test_util",
-        "//test/test_common:test_common_lib",
+        ":ssh_test_common_lib",
     ],
 )
 
@@ -158,8 +160,7 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/extensions/filters/network/ssh/wire:wire_test_util",
+        ":ssh_test_common_lib",
         "@envoy//test/test_common:environment_lib",
         "@openssh_portable//:libssh",
     ],
@@ -172,8 +173,7 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/extensions/filters/network/ssh/wire:wire_test_util",
+        ":ssh_test_common_lib",
         "@envoy//test/test_common:environment_lib",
         "@openssh_portable//:libssh",
     ],
@@ -186,9 +186,7 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/extensions/filters/network/ssh/wire:wire_test_util",
-        "//test/test_common:test_common_lib",
+        ":ssh_test_common_lib",
     ],
 )
 
@@ -199,11 +197,8 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
+        ":ssh_test_common_lib",
         ":test_mocks",
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//source/extensions/filters/network/ssh/wire:wire_lib",
-        "//test/extensions/filters/network/ssh/wire:wire_test_util",
-        "//test/test_common:test_common_lib",
         "@envoy//test/mocks/event:event_mocks",
         "@envoy//test/mocks/grpc:grpc_mocks",
         "@envoy//test/test_common:utility_lib",
@@ -217,11 +212,8 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
+        ":ssh_test_common_lib",
         ":test_mocks",
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//source/extensions/filters/network/ssh/wire:wire_lib",
-        "//test/extensions/filters/network/ssh/wire:wire_test_util",
-        "//test/test_common:test_common_lib",
         "@envoy//test/mocks/event:event_mocks",
         "@envoy//test/mocks/grpc:grpc_mocks",
         "@envoy//test/mocks/server:factory_context_mocks",
@@ -236,11 +228,9 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
+        ":ssh_test_common_lib",
         ":test_env_util_lib",
         ":test_mocks",
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/extensions/filters/network/ssh/wire:wire_test_util",
-        "//test/test_common:test_common_lib",
         "@envoy//test/mocks/api:api_mocks",
         "@envoy//test/test_common:utility_lib",
     ],
@@ -253,10 +243,8 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
+        ":ssh_test_common_lib",
         ":test_mocks",
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/extensions/filters/network/ssh/wire:wire_test_util",
-        "//test/test_common:test_common_lib",
     ],
 )
 
@@ -268,10 +256,8 @@ envoy_cc_test(
     repository = "@envoy",
     shard_count = 16,
     deps = [
+        ":ssh_test_common_lib",
         ":test_mocks",
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/extensions/filters/network/ssh/wire:wire_test_util",
-        "//test/test_common:test_common_lib",
         "@envoy//test/mocks/buffer:buffer_mocks",
     ],
 )
@@ -284,9 +270,8 @@ envoy_cc_test(
     repository = "@envoy",
     shard_count = 16,
     deps = [
+        ":ssh_test_common_lib",
         ":test_mocks",
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/extensions/filters/network/ssh/wire:wire_test_util",
         "@envoy//test/extensions/filters/network/generic_proxy/mocks:codec_mocks",
     ],
 )
@@ -298,11 +283,9 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
+        ":ssh_test_common_lib",
         ":test_env_util_lib",
         ":test_mocks",
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/extensions/filters/network/ssh/wire:wire_test_util",
-        "//test/test_common:test_common_lib",
         "@envoy//test/extensions/filters/network/generic_proxy/mocks:codec_mocks",
         "@envoy//test/mocks/buffer:buffer_mocks",
         "@envoy//test/mocks/server:factory_context_mocks",
@@ -317,11 +300,9 @@ envoy_cc_test(
     repository = "@envoy",
     shard_count = 8,
     deps = [
+        ":ssh_test_common_lib",
         ":test_env_util_lib",
         ":test_mocks",
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/extensions/filters/network/ssh/wire:wire_test_util",
-        "//test/test_common:test_common_lib",
         "@envoy//test/extensions/filters/network/generic_proxy/mocks:codec_mocks",
         "@envoy//test/mocks/buffer:buffer_mocks",
         "@envoy//test/mocks/grpc:grpc_mocks",
@@ -338,11 +319,9 @@ envoy_cc_test(
     repository = "@envoy",
     shard_count = 2,
     deps = [
+        ":ssh_test_common_lib",
         ":test_env_util_lib",
         ":test_mocks",
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/extensions/filters/network/ssh/wire:wire_test_util",
-        "//test/test_common:test_common_lib",
         "@envoy//test/extensions/filters/network/generic_proxy/mocks:codec_mocks",
         "@envoy//test/mocks/buffer:buffer_mocks",
         "@envoy//test/mocks/network:connection_mocks",
@@ -357,10 +336,9 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
+        ":ssh_test_common_lib",
         ":test_env_util_lib",
         ":test_mocks",
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/test_common:test_common_lib",
         "@envoy//test/extensions/filters/network/generic_proxy/mocks:codec_mocks",
         "@envoy//test/mocks/server:factory_context_mocks",
     ],
@@ -373,9 +351,8 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
+        ":ssh_test_common_lib",
         ":test_mocks",
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/test_common:test_common_lib",
         "@envoy//test/mocks/server:factory_context_mocks",
         "@envoy//test/test_common:real_threads_test_helper_lib",
     ],
@@ -388,9 +365,8 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
+        ":ssh_test_common_lib",
         ":test_mocks",
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/test_common:test_common_lib",
         "@envoy//test/mocks/event:event_mocks",
     ],
 )
@@ -402,8 +378,7 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/test_common:test_common_lib",
+        ":ssh_test_common_lib",
     ],
 )
 
@@ -414,8 +389,7 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/test_common:test_common_lib",
+        ":ssh_test_common_lib",
     ],
 )
 
@@ -426,8 +400,7 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/test_common:test_common_lib",
+        ":ssh_test_common_lib",
         "@envoy//test/mocks/event:event_mocks",
     ],
 )
@@ -448,9 +421,7 @@ envoy_cc_test_library(
     ],
     repository = "@envoy",
     deps = [
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/extensions/filters/network/ssh/wire:wire_test_util",
-        "//test/test_common:test_common_lib",
+        ":ssh_test_common_lib",
         "@envoy//source/extensions/filters/http/set_filter_state:config",
         "@envoy//source/extensions/filters/network/generic_proxy:config",
         "@envoy//source/extensions/filters/network/generic_proxy/router:config",
@@ -491,8 +462,7 @@ envoy_cc_benchmark_binary(
     srcs = ["packet_cipher_bench_test.cc"],
     repository = "@envoy",
     deps = [
-        "//source/extensions/filters/network/ssh:pomerium_ssh",
-        "//test/test_common:test_common_lib",
+        ":ssh_test_common_lib",
         "@benchmark",
     ],
 )

--- a/test/extensions/filters/network/ssh/graceful_shutdown_test.cc
+++ b/test/extensions/filters/network/ssh/graceful_shutdown_test.cc
@@ -21,7 +21,7 @@ public:
     initialize();
 
     EXPECT_CALL(channel_recv_, Call(MSG(wire::ChannelDataMsg, _)));
-    ASSERT_TRUE(configureSshUpstream(SshFakeUpstreamHandlerOpts{
+    ASSERT_TRUE(listenForSshConnection(SshFakeUpstreamHandlerOpts{
       .on_channel_open_request = [this](wire::ChannelOpenMsg&) -> ChannelMsgHandlerFunc {
         return [&](wire::ChannelMessage&& msg, ChannelCallbacks& callbacks) -> absl::Status {
           channel_recv_.Call(auto(msg));
@@ -144,7 +144,7 @@ TEST_P(GracefulShutdownIntegrationTest, ServerDrainThenShutdown) {
   ASSERT_FALSE(drainComplete.WaitForNotificationWithTimeout(absl::FromChrono(TestUtility::DefaultTimeout)));
 }
 
-class WaitForChannelCloseAndDoNotReply : public Task<Tasks::Channel, Tasks::Channel> {
+class WaitForChannelCloseAndDoNotReply : public Task<WaitForChannelCloseAndDoNotReply, Tasks::Channel, Tasks::Channel> {
 public:
   void start(Tasks::Channel channel) override {
     channel_ = channel;

--- a/test/extensions/filters/network/ssh/reverse_tunnel_test.cc
+++ b/test/extensions/filters/network/ssh/reverse_tunnel_test.cc
@@ -391,7 +391,7 @@ static constexpr auto stat_downstream_disconnect_before_init =
 static constexpr auto stat_upstream_init_canceled_by_downstream_disconnect =
   "cluster.tcp_cluster.ssh_reverse_tunnel.upstream_init_canceled_by_downstream_disconnect_total";
 
-class SendDataUntilRemoteWindowExhausted : public Task<Tasks::Channel, Tasks::Channel> {
+class SendDataUntilRemoteWindowExhausted : public Task<SendDataUntilRemoteWindowExhausted, Tasks::Channel, Tasks::Channel> {
 public:
   SendDataUntilRemoteWindowExhausted(Stats::Counter& local_window_exhausted_counter, size_t* total_bytes_written = nullptr)
       : local_window_exhausted_counter_(local_window_exhausted_counter),
@@ -402,7 +402,7 @@ public:
     remote_window_ = channel.initial_window_size;
     max_packet_size_ = channel.max_packet_size;
 
-    callbacks_->setTimeout(default_timeout_, "SendDataUntilRemoteWindowExhausted");
+    callbacks_->setTimeout(default_timeout_);
     callbacks_->loop(std::chrono::milliseconds(0), [this] {
       if (remote_window_ == 0) {
         if (local_window_exhausted_counter_.value() == 1) {
@@ -444,7 +444,7 @@ public:
   size_t* total_bytes_written_out_{};
 };
 
-class ReceiveDataUntilLocalWindowExhausted : public Task<Tasks::Channel, Tasks::Channel> {
+class ReceiveDataUntilLocalWindowExhausted : public Task<ReceiveDataUntilLocalWindowExhausted, Tasks::Channel, Tasks::Channel> {
 public:
   void start(Tasks::Channel channel) override {
     channel_ = channel;
@@ -731,10 +731,10 @@ TEST_P(StaticPortForwardTest, DownstreamDisconnectsDuringWriteBacklog) {
   ASSERT_TRUE(driver->wait(driver->createTask<Tasks::WaitForChannelCloseByPeer>().start(channel)));
 }
 
-class ReceiveReversePortForwardChannelOpen : public Task<void, wire::ChannelOpenMsg> {
+class ReceiveReversePortForwardChannelOpen : public Task<ReceiveReversePortForwardChannelOpen, void, wire::ChannelOpenMsg> {
 public:
   void start() override {
-    callbacks_->setTimeout(default_timeout_, "ReceiveReversePortForwardChannelOpen");
+    callbacks_->setTimeout(default_timeout_);
   }
 
   MiddlewareResult onMessageReceived(wire::Message& msg) override {
@@ -809,7 +809,7 @@ TEST_P(StaticPortForwardTest, UpstreamSendsLargeMessageThenDownstreamDisconnects
   ASSERT_TRUE(driver->wait(driver->createTask<Tasks::WaitForChannelCloseByPeer>().start(channel)));
 }
 
-class SendTooLargePacket : public Task<Tasks::Channel, Tasks::Channel> {
+class SendTooLargePacket : public Task<SendTooLargePacket, Tasks::Channel, Tasks::Channel> {
 public:
   void start(Tasks::Channel channel) override {
     callbacks_->sendMessage(wire::ChannelDataMsg{
@@ -1019,7 +1019,7 @@ TEST_P(StaticPortForwardTest, DownstreamClosesAbruptly2) {
   ASSERT_TRUE(driver->wait(driver->createTask<Tasks::WaitForChannelCloseByPeer>().start(channel)));
 }
 
-class RejectChannelOpenRequests : public Task<> {
+class RejectChannelOpenRequests : public Task<RejectChannelOpenRequests> {
 public:
   void start() override {}
 
@@ -1070,10 +1070,10 @@ TEST_P(StaticPortForwardTest, HostDrainClosesDownstreamConnections) {
   downstream->waitForDisconnect();
 }
 
-class ReceiveReversePortForwardButDoNotConfirm : public Task<void, Tasks::Channel> {
+class ReceiveReversePortForwardButDoNotConfirm : public Task<ReceiveReversePortForwardButDoNotConfirm, void, Tasks::Channel> {
 public:
   void start() override {
-    callbacks_->setTimeout(default_timeout_, fmt::format("ReceiveReversePortForwardButDoNotConfirm"));
+    callbacks_->setTimeout(default_timeout_);
   }
   MiddlewareResult onMessageReceived(wire::Message& msg) override {
     return msg.visit(
@@ -1258,7 +1258,7 @@ public:
   std::shared_ptr<SshConnectionDriver> driver;
 };
 
-class DoSocks5ServerHandshake : public Task<Tasks::Channel, Tasks::Channel> {
+class DoSocks5ServerHandshake : public Task<DoSocks5ServerHandshake, Tasks::Channel, Tasks::Channel> {
 public:
   DoSocks5ServerHandshake(Network::Address::IpVersion version) {
     if (version == Network::Address::IpVersion::v4) {
@@ -1276,7 +1276,7 @@ public:
   void start(Tasks::Channel channel) override {
     channel_ = channel;
     setChannelFilter(channel);
-    callbacks_->setTimeout(default_timeout_, "DoSocks5ServerHandshake");
+    callbacks_->setTimeout(default_timeout_);
     callbacks_->sendMessage(wire::ChannelDataMsg{
       .recipient_channel = channel.remote_id,
       .data = bytes{0x05, 0x00},
@@ -1371,12 +1371,12 @@ TEST_P(DynamicPortForwardTest, DownstreamCloseAfterOpen) {
   ASSERT_TRUE(driver->wait(th2));
 }
 
-class DoIncompleteSocks5ServerHandshake : public Task<Tasks::Channel, Tasks::Channel> {
+class DoIncompleteSocks5ServerHandshake : public Task<DoIncompleteSocks5ServerHandshake, Tasks::Channel, Tasks::Channel> {
 public:
   void start(Tasks::Channel channel) override {
     channel_ = channel;
     setChannelFilter(channel);
-    callbacks_->setTimeout(default_timeout_, "DoIncompleteSocks5ServerHandshake");
+    callbacks_->setTimeout(default_timeout_);
   }
 
   MiddlewareResult onMessageReceived(wire::Message& msg) override {
@@ -1627,7 +1627,7 @@ public:
   void start(Tasks::Channel channel) override {
     channel_ = channel;
     setChannelFilter(channel);
-    callbacks_->setTimeout(default_timeout_, "DoSocks5ServerHandshakeWithExtraData");
+    callbacks_->setTimeout(default_timeout_);
     callbacks_->sendMessage(wire::ChannelDataMsg{
       .recipient_channel = channel.remote_id,
       .data = bytes{0x05, 0x00},

--- a/test/extensions/filters/network/ssh/ssh_connection_driver.cc
+++ b/test/extensions/filters/network/ssh/ssh_connection_driver.cc
@@ -176,7 +176,8 @@ void SshConnectionDriver::sendManagementResponse(const Protobuf::Message& resp) 
   mgmt_stream_->sendGrpcMessage(resp);
 }
 
-AssertionResult SshConnectionDriver::waitForUserAuth(std::string username, std::string hostname) {
+AssertionResult SshConnectionDriver::waitForUserAuth(std::string username, std::string hostname,
+                                                     std::function<void(pomerium::extensions::ssh::AllowResponse&)> modify_allow_response) {
   if (auto res = wait(createTask<Tasks::RequestUserAuthService>().start()); !res) {
     return res;
   }
@@ -221,12 +222,14 @@ AssertionResult SshConnectionDriver::waitForUserAuth(std::string username, std::
     // Only the stream id is set here, not channel id.
     // TODO: maybe refactor this api to be less confusing
     ServerMessage serverMsg;
-    (*serverMsg.mutable_auth_response()
-        ->mutable_allow()
-        ->mutable_internal()
+    auto* allow = serverMsg.mutable_auth_response()->mutable_allow();
+    (*allow->mutable_internal()
         ->mutable_set_metadata()
         ->mutable_typed_filter_metadata())["com.pomerium.ssh"]
       .PackFrom(filterMetadata);
+    if (modify_allow_response != nullptr) {
+      modify_allow_response(*allow);
+    }
     sendManagementResponse(serverMsg);
   } else {
     ServerMessage serverMsg;
@@ -248,6 +251,9 @@ AssertionResult SshConnectionDriver::waitForUserAuth(std::string username, std::
       absl::ToUnixNanos(absl::Now() + absl::Hours(1)));
     *publicKeyMethodData.mutable_permissions() = std::move(permissions);
     publicKeyMethod->mutable_method_data()->PackFrom(publicKeyMethodData);
+    if (modify_allow_response != nullptr) {
+      modify_allow_response(*allow);
+    }
     sendManagementResponse(serverMsg);
   }
 
@@ -426,11 +432,11 @@ openssh::SSHKey& SshConnectionDriver::clientKey() {
   return *host_key_;
 }
 
-void SshConnectionDriver::TaskCallbacksImpl::setTimeout(std::chrono::milliseconds timeout, const std::string& name) {
+void SshConnectionDriver::TaskCallbacksImpl::setTimeout(std::chrono::milliseconds timeout, std::optional<std::string> name) {
   if (timeout_timer_ != nullptr) {
     timeout_timer_->disableTimer();
   }
-  timeout_timer_ = parent_.connectionDispatcher()->createTimer([this, name] {
+  timeout_timer_ = parent_.connectionDispatcher()->createTimer([this, name = name.value_or(task_->name())] {
     taskFailure(absl::DeadlineExceededError(fmt::format("task timed out: {} ()", name, task_->errorDetails())));
   });
   timeout_timer_->enableTimer(timeout);

--- a/test/extensions/filters/network/ssh/ssh_connection_driver.h
+++ b/test/extensions/filters/network/ssh/ssh_connection_driver.h
@@ -77,8 +77,8 @@ public:
                                                          std::chrono::milliseconds timeout) PURE;
 
   [[nodiscard]]
-  virtual testing::AssertionResult configureSshUpstream(std::shared_ptr<SshFakeUpstreamHandlerOpts> opts,
-                                                        Server::Configuration::ServerFactoryContext& ctx) PURE;
+  virtual testing::AssertionResult listenForSshConnection(std::shared_ptr<SshFakeUpstreamHandlerOpts> opts,
+                                                          Server::Configuration::ServerFactoryContext& ctx) PURE;
 
   virtual void cleanup() PURE;
 };
@@ -103,6 +103,9 @@ public:
 
   AssertionResult disconnect();
   void close();
+  bool closed() const {
+    return closed_;
+  }
 
   void sendMessage(wire::Message&& msg);
 
@@ -110,7 +113,8 @@ public:
   AssertionResult waitForDiagnostic(const std::string& message);
   void waitForManagementRequest(Protobuf::Message& req);
   void sendManagementResponse(const Protobuf::Message& resp);
-  AssertionResult waitForUserAuth(std::string username = "user", std::string hostname = ""); // empty hostname = internal
+  AssertionResult waitForUserAuth(std::string username = "user", std::string hostname = "",
+                                  std::function<void(pomerium::extensions::ssh::AllowResponse&)> modify_allow_response = nullptr); // empty hostname = internal
   AssertionResult requestReversePortForward(const std::string& address, uint32_t port, uint32_t server_port);
   AssertionResult waitForStatsEvent(pomerium::extensions::ssh::ChannelStatsList* out);
   AssertionResult waitForStatsOnChannelClose(pomerium::extensions::ssh::ChannelStats* out);
@@ -190,7 +194,7 @@ protected:
     // TaskCallbacks
     void taskSuccess(std::any output, std::function<void(const std::any&, void*)> apply_fn) override;
     void taskFailure(absl::Status stat) override;
-    void setTimeout(std::chrono::milliseconds timeout, const std::string& name) override;
+    void setTimeout(std::chrono::milliseconds timeout, std::optional<std::string> name = {}) override;
     void setTimeout(std::chrono::milliseconds timeout, std::function<void()> cb) override;
 
     void sendMessage(wire::Message&& msg) override;

--- a/test/extensions/filters/network/ssh/ssh_integration_test.cc
+++ b/test/extensions/filters/network/ssh/ssh_integration_test.cc
@@ -14,7 +14,13 @@ SshIntegrationTest::SshIntegrationTest(std::vector<std::string> ssh_routes, Netw
   config_helper_.addConfigModifier([this, localhost = localhost(), ssh_routes](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     RELEASE_ASSERT(bootstrap.mutable_static_resources()->clusters_size() == 0, "");
     auto fakeMgmtCluster = ConfigHelper::buildStaticCluster("fake_mgmt", 0, localhost);
-    ConfigHelper::setHttp2(fakeMgmtCluster);
+    // NB: the management server must have a max stream count of 1 so that each stream gets its own
+    // unique connection. When waiting for a management server connection, waitForHttpConnection
+    // is called, followed by waitForNewStream. If streams are multiplexed and we need to wait for
+    // more than one management server connection, the first call to waitForHttpConnection will
+    // succeed but the second one will block forever (since the second stream is really multiplexed
+    // onto the first connection and there is no new connection to wait for).
+    ConfigHelper::setHttp2WithMaxConcurrentStreams(fakeMgmtCluster, 1);
     bootstrap.mutable_static_resources()->add_clusters()->CopyFrom(fakeMgmtCluster);
 
     // Upstream bug: BaseIntegrationTest::createEnvoy() does not assign ports in the correct order
@@ -45,31 +51,38 @@ SshIntegrationTest::SshIntegrationTest(std::vector<std::string> ssh_routes, Netw
     configureUpstreamTunnelCluster(tcpCluster);
     bootstrap.mutable_static_resources()->add_clusters()->CopyFrom(tcpCluster);
   });
-  mgmt_upstream_ = FakeUpstreamShimImpl{&addFakeUpstream(Http::CodecType::HTTP2, "mgmt_upstream")};
+  mgmt_upstream_ = std::make_unique<FakeUpstreamShimImpl>(&addFakeUpstream(Http::CodecType::HTTP2, "mgmt_upstream"));
   for (size_t i = 0; i < ssh_routes.size(); i++) {
-    ssh_upstreams_.emplace_back(&addFakeUpstream(Http::CodecType::HTTP1, "ssh_upstream_" + ssh_routes[i])); // codec type is unused here
+    ssh_upstreams_.push_back(std::make_unique<FakeUpstreamShimImpl>(&addFakeUpstream(Http::CodecType::HTTP1, "ssh_upstream_" + ssh_routes[i]))); // codec type is unused here
   }
-  http_upstream_1_ = FakeUpstreamShimImpl{&addFakeUpstream(Http::CodecType::HTTP1, "http_upstream_1")};
-  http_upstream_2_ = FakeUpstreamShimImpl{&addFakeUpstream(Http::CodecType::HTTP1, "http_upstream_2")};
-  tcp_upstream_ = FakeUpstreamShimImpl{&addFakeUpstream(Http::CodecType::HTTP1, "tcp_upstream")}; // codec type is unused here
+  http_upstream_1_ = std::make_unique<FakeUpstreamShimImpl>(&addFakeUpstream(Http::CodecType::HTTP1, "http_upstream_1"));
+  http_upstream_2_ = std::make_unique<FakeUpstreamShimImpl>(&addFakeUpstream(Http::CodecType::HTTP1, "http_upstream_2"));
+  tcp_upstream_ = std::make_unique<FakeUpstreamShimImpl>(&addFakeUpstream(Http::CodecType::HTTP1, "tcp_upstream")); // codec type is unused here
 }
 
 SshIntegrationTest::~SshIntegrationTest() = default;
 
 void SshIntegrationTest::cleanup() {
   for (auto& upstream : ssh_upstreams_) {
-    upstream.cleanup();
+    upstream->cleanup();
   }
 };
 
 void FakeUpstreamShimImpl::cleanup() {
-  if (handler_ != nullptr) {
-    absl::Notification done;
-    fake_upstream_->dispatcher()->post([handler = std::move(handler_), &done] mutable {
-      handler.reset();
-      done.Notify();
-    });
-    done.WaitForNotification();
+  absl::MutexLock lock(listeners_mu_);
+  for (auto& listener : listeners_) {
+    listener->mu.lock();
+    if (listener->handler != nullptr) {
+      absl::Notification done;
+      fake_upstream_->dispatcher()->post([handler = std::move(listener->handler), &done] mutable {
+        handler.reset();
+        done.Notify();
+      });
+      listener->mu.unlock();
+      done.WaitForNotification();
+    } else {
+      listener->mu.unlock();
+    }
   }
   fake_upstream_->cleanUp();
 }
@@ -83,12 +96,12 @@ std::shared_ptr<SshConnectionDriver> SshIntegrationTest::makeSshConnectionDriver
     makeClientConnection(lookupPort("ssh")),
     server_factory_context_,
     std::make_shared<pomerium::extensions::ssh::CodecConfig>(),
-    mgmt_upstream_);
+    *mgmt_upstream_);
 }
 
-AssertionResult SshIntegrationTest::configureSshUpstream(SshFakeUpstreamHandlerOpts&& opts, size_t upstream_index) {
+AssertionResult SshIntegrationTest::listenForSshConnection(SshFakeUpstreamHandlerOpts&& opts, size_t upstream_index) {
   ASSERT(upstream_index < ssh_upstreams_.size());
-  return ssh_upstreams_[upstream_index].configureSshUpstream(
+  return ssh_upstreams_[upstream_index]->listenForSshConnection(
     std::make_shared<SshFakeUpstreamHandlerOpts>(std::move(opts)), server_factory_context_);
 }
 
@@ -147,8 +160,8 @@ AssertionResult FakeUpstreamShimImpl::waitForHttpConnection(Envoy::Event::Dispat
   return ret;
 }
 
-AssertionResult FakeUpstreamShimImpl::configureSshUpstream(std::shared_ptr<SshFakeUpstreamHandlerOpts> opts,
-                                                           Server::Configuration::ServerFactoryContext& server_factory_context) {
+AssertionResult FakeUpstreamShimImpl::listenForSshConnection(std::shared_ptr<SshFakeUpstreamHandlerOpts> opts,
+                                                             Server::Configuration::ServerFactoryContext& server_factory_context) {
   // FakeUpstream isn't really built to do what we need here, which is to have it pre-configured
   // with callbacks that all run on its own thread. We don't want to drive it from the test thread,
   // because we are already driving the downstream connection from the test thread. The tests need
@@ -156,30 +169,41 @@ AssertionResult FakeUpstreamShimImpl::configureSshUpstream(std::shared_ptr<SshFa
   // sequence involves connecting to the upstream, which would otherwise need to be a separate
   // blocking operation on the test thread.
   return fake_upstream_->runOnDispatcherThreadAndWait([this, opts, ctx = &server_factory_context] {
-    ASSERT(timer_ == nullptr);
-    // XXX: this only handles one connection. If we need to support multiple upstream connections at
-    // the same time, this will need to be adjusted.
-    ASSERT(handler_ == nullptr);
     auto config = std::make_shared<pomerium::extensions::ssh::CodecConfig>();
     config->mutable_connection_service_options()
       ->mutable_channel_close_response_grace_period()
       ->set_seconds(1);
-    handler_ = std::make_unique<SshFakeUpstreamHandler>(
+    auto listener = std::make_unique<FakeUpstreamConnectionListenCtx>();
+    listener->mu.lock();
+    listener->handler = std::make_unique<SshFakeUpstreamHandler>(
       *ctx,
       config,
       opts);
-    timer_ = fake_upstream_->dispatcher()->createTimer([this] {
-      absl::ReleasableMutexLock lock(fake_upstream_->lock());
-      if (!fake_upstream_->hasNewConnections()) {
-        timer_->enableTimer(std::chrono::milliseconds(10));
+    listener->timer = fake_upstream_->dispatcher()->createTimer([this, listener = listener.get()] {
+      absl::MutexLock lock(listener->mu);
+      if (listener->handler == nullptr) {
+        // the handler was cleaned up already
         return;
       }
-      timer_ = nullptr;
+      absl::ReleasableMutexLock lock2(fake_upstream_->lock());
+      if (!fake_upstream_->hasNewConnections()) {
+        listener->timer->enableTimer(std::chrono::milliseconds(10));
+        return;
+      }
+      listener->timer = nullptr;
       auto& sc = fake_upstream_->consumeConnection();
-      lock.Release();
-      handler_->onNewConnection(sc.connection());
+      lock2.Release();
+      listener->handler->onNewConnection(sc.connection());
     });
-    timer_->enableTimer(std::chrono::milliseconds(10));
+    listener->mu.unlock();
+
+    listeners_mu_.lock();
+    listeners_.push_back(std::move(listener));
+    listeners_.back()->mu.lock();
+    listeners_.back()->timer->enableTimer(std::chrono::milliseconds(10));
+    listeners_.back()->mu.unlock();
+    listeners_mu_.unlock();
+
     return testing::AssertionSuccess();
   });
 }

--- a/test/extensions/filters/network/ssh/ssh_integration_test.h
+++ b/test/extensions/filters/network/ssh/ssh_integration_test.h
@@ -114,16 +114,24 @@ public:
                                                  std::chrono::milliseconds timeout) override;
 
   [[nodiscard]]
-  testing::AssertionResult configureSshUpstream(std::shared_ptr<SshFakeUpstreamHandlerOpts> opts,
-                                                Server::Configuration::ServerFactoryContext& ctx) override;
+  testing::AssertionResult listenForSshConnection(std::shared_ptr<SshFakeUpstreamHandlerOpts> opts,
+                                                  Server::Configuration::ServerFactoryContext& ctx) override;
 
   void cleanup() override;
 
+  struct FakeUpstreamConnectionListenCtx {
+    absl::Mutex mu;
+    Envoy::Event::TimerPtr timer ABSL_GUARDED_BY(mu);
+    std::unique_ptr<SshFakeUpstreamHandler> handler ABSL_GUARDED_BY(mu);
+  };
+
 private:
   FakeUpstream* fake_upstream_{};
-  Envoy::Event::TimerPtr timer_;
-  std::unique_ptr<SshFakeUpstreamHandler> handler_;
+  absl::Mutex listeners_mu_;
+  std::vector<std::unique_ptr<FakeUpstreamConnectionListenCtx>> listeners_ ABSL_GUARDED_BY(listeners_mu_);
 };
+
+using FakeUpstreamShimImplPtr = std::unique_ptr<FakeUpstreamShimImpl>;
 
 class SshIntegrationTest : public SecretsProviderImpl,
                            public HttpIntegrationTest {
@@ -153,7 +161,7 @@ protected:
   std::shared_ptr<SshConnectionDriver> makeSshConnectionDriver();
   IntegrationTcpClientPtr makeTcpConnectionWithServerName(uint32_t port, const std::string& server_name);
 
-  AssertionResult configureSshUpstream(SshFakeUpstreamHandlerOpts&& opts, size_t upstream_index = 0);
+  AssertionResult listenForSshConnection(SshFakeUpstreamHandlerOpts&& opts, size_t upstream_index = 0);
   void configureUpstreamTunnelCluster(envoy::config::cluster::v3::Cluster& cluster);
 
   struct ClusterLoadOpts {
@@ -178,11 +186,11 @@ protected:
   int grpcUpstreamClusterIndex() const { return 1 + static_cast<int>(ssh_upstreams_.size()) + 1; }
   int tcpUpstreamClusterIndex() const { return 1 + static_cast<int>(ssh_upstreams_.size()) + 2; }
 
-  FakeUpstreamShimImpl mgmt_upstream_;
-  std::vector<FakeUpstreamShimImpl> ssh_upstreams_;
-  FakeUpstreamShimImpl http_upstream_1_;
-  FakeUpstreamShimImpl http_upstream_2_;
-  FakeUpstreamShimImpl tcp_upstream_;
+  FakeUpstreamShimImplPtr mgmt_upstream_;
+  std::vector<FakeUpstreamShimImplPtr> ssh_upstreams_;
+  FakeUpstreamShimImplPtr http_upstream_1_;
+  FakeUpstreamShimImplPtr http_upstream_2_;
+  FakeUpstreamShimImplPtr tcp_upstream_;
 
   // NB: filesystem EDS subscription doesn't work like api-based subscription: it always reports
   // all changed resources, and ignores the resource name filter (for some reason). So we need

--- a/test/extensions/filters/network/ssh/ssh_task.h
+++ b/test/extensions/filters/network/ssh/ssh_task.h
@@ -28,7 +28,7 @@ namespace test {
   [&](const auto&) { return MiddlewareResult::Continue; }
 
 class TaskCallbacks {
-  template <typename, typename>
+  template <typename, typename, typename>
   friend class Task;
   template <typename>
   friend class TaskSuccess;
@@ -39,7 +39,7 @@ public:
   virtual void sendMessage(wire::Message&&) PURE;
   // Starts a timer that will call taskFailure() after the timeout, unless taskSuccess() has been
   // called before the timer elapses.
-  virtual void setTimeout(std::chrono::milliseconds timeout, const std::string& name) PURE;
+  virtual void setTimeout(std::chrono::milliseconds timeout, std::optional<std::string> name = {}) PURE;
   // Starts a timer that will invoke the given callback after the timeout, unless taskSuccess() or
   // taskFailure() have been called before the timer elapses.
   virtual void setTimeout(std::chrono::milliseconds timeout, std::function<void()> cb) PURE;
@@ -123,7 +123,7 @@ public:
 
 class UntypedTask : public SshMessageMiddleware {
   friend class SshConnectionDriver;
-  template <typename, typename>
+  template <typename, typename, typename>
   friend class Task;
 
 public:
@@ -158,6 +158,14 @@ protected:
     channel_filter_ = c;
   }
 
+  void setName(const std::string& name) {
+    name_ = name;
+  }
+
+  std::string name() const {
+    return name_;
+  }
+
 private:
   void startInternalUntyped(std::any input) {
     startUntyped(std::move(input));
@@ -190,6 +198,7 @@ private:
     return res;
   }
 
+  std::string name_;
   std::optional<Tasks::Channel> channel_filter_;
 };
 
@@ -251,16 +260,21 @@ protected:
   }
 };
 
-template <typename Input = void, typename Output = void>
+template <typename CRTP, typename Input = void, typename Output = void>
 class Task : public virtual UntypedTask,
              public TaskStart<Input>,
              public TaskSuccess<Output> {
   friend class SshConnectionDriver;
+  friend CRTP;
 
 public:
   using input_type = Input;
   using output_type = Output;
-  Task() = default;
+
+private:
+  Task() {
+    setName(std::string(type_name<CRTP>()));
+  }
 };
 
 template <typename Input = void, typename Output = void>
@@ -268,7 +282,7 @@ using TaskPtr = std::unique_ptr<Task<Input, Output>>;
 
 namespace Tasks {
 
-class RequestUserAuthService : public Task<> {
+class RequestUserAuthService : public Task<RequestUserAuthService> {
 public:
   void start() override {
     callbacks_->sendMessage(wire::ServiceRequestMsg{
@@ -289,10 +303,10 @@ public:
   }
 };
 
-class WaitForUserAuthSuccess : public Task<> {
+class WaitForUserAuthSuccess : public Task<WaitForUserAuthSuccess> {
 public:
   void start() override {
-    callbacks_->setTimeout(default_timeout_, "WaitForUserAuthSuccess");
+    callbacks_->setTimeout(default_timeout_);
   };
 
   MiddlewareResult onMessageReceived(wire::Message& msg) override {
@@ -314,30 +328,30 @@ public:
 };
 
 template <typename T>
-class WaitForGlobalRequestSuccess : public Task<> {
+class WaitForGlobalRequestSuccess : public Task<WaitForGlobalRequestSuccess<T>> {
 public:
   void start() override {
-    callbacks_->setTimeout(default_timeout_, fmt::format("WaitForGlobalRequestSuccess({})", type_name<T>()));
+    this->callbacks_->setTimeout(this->default_timeout_, fmt::format("WaitForGlobalRequestSuccess({})", type_name<T>()));
   }
   MiddlewareResult onMessageReceived(wire::Message& msg) override {
     return msg.visit(
       [&](wire::GlobalRequestSuccessMsg& msg) {
         if (msg.resolve<T>().ok()) {
-          taskSuccess();
+          this->taskSuccess();
           return Break;
         }
-        taskFailure(absl::InternalError("received unexpected global request success response"));
+        this->taskFailure(absl::InternalError("received unexpected global request success response"));
         return Break;
       },
       [&](const wire::GlobalRequestFailureMsg& msg) {
-        taskFailure(absl::InternalError(fmt::format("request failed: {}", msg)));
+        this->taskFailure(absl::InternalError(fmt::format("request failed: {}", msg)));
         return Break;
       },
       DEFAULT_CONTINUE);
   };
 };
 
-class AcceptReversePortForward : public Task<void, Channel> {
+class AcceptReversePortForward : public Task<AcceptReversePortForward, void, Channel> {
 public:
   AcceptReversePortForward(const std::string& address_connected, uint32_t port_connected,
                            uint32_t local_channel_id)
@@ -396,7 +410,7 @@ public:
   const uint32_t local_channel_id_;
 };
 
-class RejectReversePortForward : public Task<> {
+class RejectReversePortForward : public Task<RejectReversePortForward> {
 public:
   RejectReversePortForward(const std::string& address_connected, uint32_t port_connected)
       : address_connected_(address_connected),
@@ -431,7 +445,7 @@ public:
   const uint32_t port_connected_;
 };
 
-class OpenSessionChannel : public Task<void, Channel> {
+class OpenSessionChannel : public Task<OpenSessionChannel, void, Channel> {
 public:
   OpenSessionChannel(uint32_t local_channel_id)
       : local_channel_id_(local_channel_id) {}
@@ -439,7 +453,7 @@ public:
     setChannelFilter(Tasks::Channel{
       .local_id = local_channel_id_,
     });
-    callbacks_->setTimeout(default_timeout_, "OpenSessionChannel");
+    callbacks_->setTimeout(default_timeout_);
     callbacks_->sendMessage(wire::ChannelOpenMsg{
       .sender_channel = local_channel_id_,
       .initial_window_size = wire::ChannelWindowSize,
@@ -473,7 +487,7 @@ public:
   uint32_t local_channel_id_;
 };
 
-class WaitForChannelData : public Task<Channel, Channel> {
+class WaitForChannelData : public Task<WaitForChannelData, Channel, Channel> {
 public:
   explicit WaitForChannelData(const std::string& expected_data)
       : expected_data_(expected_data) {}
@@ -512,7 +526,7 @@ public:
 };
 
 template <wire::ChannelMsg T>
-class WaitForChannelMsg : public Task<Channel, T> {
+class WaitForChannelMsg : public Task<WaitForChannelMsg<T>, Channel, T> {
 public:
   WaitForChannelMsg(uint32_t count = 1)
       : count_(count) {}
@@ -536,7 +550,7 @@ public:
   uint32_t count_{};
 };
 
-class SendChannelData : public Task<Channel, Channel> {
+class SendChannelData : public Task<SendChannelData, Channel, Channel> {
 public:
   explicit SendChannelData(const bytes& data)
       : data_(data) {}
@@ -554,7 +568,7 @@ public:
   bytes data_;
 };
 
-class SendWindowAdjust : public Task<Channel, Channel> {
+class SendWindowAdjust : public Task<SendWindowAdjust, Channel, Channel> {
 public:
   explicit SendWindowAdjust(uint32_t bytes_to_add)
       : bytes_to_add_(bytes_to_add) {}
@@ -570,7 +584,7 @@ public:
   uint32_t bytes_to_add_;
 };
 
-class SendChannelEOF : public Task<Channel, Channel> {
+class SendChannelEOF : public Task<SendChannelEOF, Channel, Channel> {
 public:
   void start(Channel channel) override {
     callbacks_->sendMessage(wire::ChannelEOFMsg{
@@ -589,14 +603,14 @@ enum class ExpectEOF {
 
 enum class SendEOF : bool {};
 
-class WaitForChannelCloseByPeer : public Task<Channel> {
+class WaitForChannelCloseByPeer : public Task<WaitForChannelCloseByPeer, Channel> {
 public:
   explicit WaitForChannelCloseByPeer(ExpectEOF expect_eof = ExpectEOF::Optional)
       : eof_requirement_(expect_eof) {}
   void start(Channel channel) override {
     channel_ = channel;
     setChannelFilter(channel);
-    callbacks_->setTimeout(default_timeout_, "WaitForChannelCloseByPeer");
+    callbacks_->setTimeout(default_timeout_);
   }
   MiddlewareResult onMessageReceived(wire::Message& msg) override {
     return msg.visit(
@@ -628,12 +642,12 @@ public:
   const ExpectEOF eof_requirement_;
 };
 
-class WaitForChannelEOF : public Task<Channel, Channel> {
+class WaitForChannelEOF : public Task<WaitForChannelEOF, Channel, Channel> {
 public:
   void start(Channel channel) override {
     channel_ = channel;
     setChannelFilter(channel);
-    callbacks_->setTimeout(default_timeout_, "WaitForChannelEOF");
+    callbacks_->setTimeout(default_timeout_);
   }
   MiddlewareResult onMessageReceived(wire::Message& msg) override {
     return msg.visit(
@@ -650,7 +664,7 @@ public:
   Channel channel_{};
 };
 
-class SendChannelCloseAndWait : public Task<Channel> {
+class SendChannelCloseAndWait : public Task<SendChannelCloseAndWait, Channel> {
 public:
   SendChannelCloseAndWait(SendEOF send_eof = SendEOF(false), ExpectEOF expect_eof = ExpectEOF::Optional)
       : send_eof_(send_eof),
@@ -666,7 +680,7 @@ public:
     callbacks_->sendMessage(wire::ChannelCloseMsg{
       .recipient_channel = channel_.remote_id,
     });
-    callbacks_->setTimeout(default_timeout_, "SendChannelCloseAndWait");
+    callbacks_->setTimeout(default_timeout_);
   }
   MiddlewareResult onMessageReceived(wire::Message& msg) override {
     return msg.visit(
@@ -691,7 +705,7 @@ public:
   const ExpectEOF eof_requirement_;
 };
 
-class WaitForDisconnectWithError : public Task<> {
+class WaitForDisconnectWithError : public Task<WaitForDisconnectWithError> {
 public:
   WaitForDisconnectWithError(const std::string& message)
       : message_(message) {}

--- a/test/extensions/filters/network/ssh/test_mocks.h
+++ b/test/extensions/filters/network/ssh/test_mocks.h
@@ -9,6 +9,7 @@
 #include "source/extensions/filters/network/ssh/transport.h"
 #include "source/extensions/filters/network/ssh/kex.h"
 #include "api/extensions/filters/network/ssh/ssh.pb.h"
+#include "test/extensions/filters/network/ssh/wire/test_field_reflect.h" // IWYU pragma: keep
 #include "test/mocks/stats/mocks.h"
 #pragma clang unsafe_buffer_usage begin
 #include "envoy/buffer/buffer.h"
@@ -179,40 +180,3 @@ public:
 
 } // namespace test
 } // namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec
-
-namespace wire {
-template <typename T, typename... Opts>
-constexpr bool holds_alternative(const BasicMessage<Opts...>& msg) {
-  return msg.message.template holds_alternative<T>();
-}
-template <typename T, typename... Opts>
-constexpr bool holds_alternative(BasicMessage<Opts...>&& msg) {
-  return std::move(msg).message.template holds_alternative<T>();
-}
-template <typename T, typename... Opts>
-constexpr decltype(auto) get(const BasicMessage<Opts...>& msg) {
-  return msg.message.template get<T>();
-}
-template <typename T, typename... Opts>
-constexpr decltype(auto) get(BasicMessage<Opts...>&& msg) {
-  return std::move(msg).message.template get<T>();
-}
-
-template <typename T, typename... Opts>
-constexpr bool holds_alternative(const sub_message<Opts...>& msg) {
-  return msg.template holds_alternative<T>();
-}
-template <typename T, typename... Opts>
-constexpr bool holds_alternative(sub_message<Opts...>&& msg) {
-  return std::move(msg).template holds_alternative<T>();
-}
-template <typename T, typename... Opts>
-constexpr decltype(auto) get(const sub_message<Opts...>& msg) {
-  return msg.template get<T>();
-}
-template <typename T, typename... Opts>
-constexpr decltype(auto) get(sub_message<Opts...>&& msg) {
-  return std::move(msg).template get<T>();
-}
-
-} // namespace wire

--- a/test/extensions/filters/network/ssh/wire/test_field_reflect.h
+++ b/test/extensions/filters/network/ssh/wire/test_field_reflect.h
@@ -430,3 +430,99 @@ struct detail::random_value_impl<UserAuthInfoPrompt> {
 };
 
 } // namespace wire::test
+
+namespace wire {
+template <typename T, typename... Opts>
+constexpr bool holds_alternative(const BasicMessage<Opts...>& msg) {
+  return msg.message.template holds_alternative<T>();
+}
+template <typename T, typename... Opts>
+constexpr bool holds_alternative(BasicMessage<Opts...>&& msg) {
+  return std::move(msg).message.template holds_alternative<T>();
+}
+template <typename T, typename... Opts>
+constexpr decltype(auto) get(const BasicMessage<Opts...>& msg) {
+  return msg.message.template get<T>();
+}
+template <typename T, typename... Opts>
+constexpr decltype(auto) get(BasicMessage<Opts...>&& msg) {
+  return std::move(msg).message.template get<T>();
+}
+
+template <typename T, typename... Opts>
+constexpr bool holds_alternative(const sub_message<Opts...>& msg) {
+  return msg.template holds_alternative<T>();
+}
+template <typename T, typename... Opts>
+constexpr bool holds_alternative(sub_message<Opts...>&& msg) {
+  return std::move(msg).template holds_alternative<T>();
+}
+template <typename T, typename... Opts>
+constexpr decltype(auto) get(const sub_message<Opts...>& msg) {
+  return msg.template get<T>();
+}
+template <typename T, typename... Opts>
+constexpr decltype(auto) get(sub_message<Opts...>&& msg) {
+  return std::move(msg).template get<T>();
+}
+} // namespace wire
+
+// NOLINTBEGIN(readability-identifier-naming)
+template <typename T>
+class WhenResolvedAsMatcher {
+public:
+  explicit WhenResolvedAsMatcher(const testing::Matcher<T>& matcher)
+      : matcher_(matcher) {}
+
+  void DescribeTo(::std::ostream* os) const {
+    *os << "when resolved as " << ::type_name<T>() << ",";
+    matcher_.DescribeTo(os);
+  }
+
+  void DescribeNegationTo(::std::ostream* os) const {
+    *os << "when resolved as " << ::type_name<T>() << ",";
+    matcher_.DescribeNegationTo(os);
+  }
+
+  template <typename Overloaded>
+  bool MatchAndExplain(Overloaded ov, testing::MatchResultListener* listener) const {
+    opt_ref<T> t = ov.template resolve<T>();
+    if (!t.has_value()) {
+      *listener << "which did not resolve";
+      return false;
+    }
+    return MatchPrintAndExplain(t.value().get(), this->matcher_, listener);
+  }
+
+protected:
+  const testing::Matcher<T> matcher_;
+};
+
+template <typename T>
+inline testing::PolymorphicMatcher<WhenResolvedAsMatcher<T>>
+WhenResolvedAs(const testing::Matcher<T>& inner_matcher) {
+  return testing::MakePolymorphicMatcher(WhenResolvedAsMatcher<T>{inner_matcher});
+}
+
+#define MSG(msg_type, ...)                                                                                                               \
+  [&] {                                                                                                                                  \
+    using MsgType_ = msg_type;                                                                                                           \
+    if constexpr (wire::detail::is_overloaded_message<std::decay_t<MsgType_>>) {                                                         \
+      return VariantWith<wire::detail::overload_set_for_t<std::remove_const_t<MsgType_>>>(WhenResolvedAs<MsgType_>(AllOf(__VA_ARGS__))); \
+    } else {                                                                                                                             \
+      return VariantWith<MsgType_>(AllOf(__VA_ARGS__));                                                                                  \
+    }                                                                                                                                    \
+  }()
+
+#define SUB_MSG(submsg_type, ...) \
+  VariantWith<submsg_type>(AllOf(__VA_ARGS__))
+
+// NOLINTEND(readability-identifier-naming)
+
+#define FIELD_EQ(name, ...) FIELD_EQ_IMPL_(name, (__VA_ARGS__))
+
+#define FIELD_EQ_IMPL_(name, ...) \
+  Field(#name, &MsgType_::name, Eq(__VA_ARGS__))
+
+#define FIELD(name, ...) \
+  Field(#name, &MsgType_::name, (__VA_ARGS__))

--- a/test/test_common/test_common.h
+++ b/test/test_common/test_common.h
@@ -51,66 +51,6 @@ constexpr absl::Status to_status(S&& statusor) {
       << "CHECK_CALL failed: the expected statement was not reached"; \
   } while (false)
 
-// NOLINTBEGIN(readability-identifier-naming)
-template <typename T>
-class WhenResolvedAsMatcher {
-public:
-  explicit WhenResolvedAsMatcher(const testing::Matcher<T>& matcher)
-      : matcher_(matcher) {}
-
-  void DescribeTo(::std::ostream* os) const {
-    *os << "when resolved as " << ::type_name<T>() << ",";
-    matcher_.DescribeTo(os);
-  }
-
-  void DescribeNegationTo(::std::ostream* os) const {
-    *os << "when resolved as " << ::type_name<T>() << ",";
-    matcher_.DescribeNegationTo(os);
-  }
-
-  template <typename Overloaded>
-  bool MatchAndExplain(Overloaded ov, testing::MatchResultListener* listener) const {
-    opt_ref<T> t = ov.template resolve<T>();
-    if (!t.has_value()) {
-      *listener << "which did not resolve";
-      return false;
-    }
-    return MatchPrintAndExplain(t.value().get(), this->matcher_, listener);
-  }
-
-protected:
-  const testing::Matcher<T> matcher_;
-};
-
-template <typename T>
-inline testing::PolymorphicMatcher<WhenResolvedAsMatcher<T>>
-WhenResolvedAs(const testing::Matcher<T>& inner_matcher) {
-  return testing::MakePolymorphicMatcher(WhenResolvedAsMatcher<T>{inner_matcher});
-}
-
-#define MSG(msg_type, ...)                                                                                                               \
-  [&] {                                                                                                                                  \
-    using MsgType_ = msg_type;                                                                                                           \
-    if constexpr (wire::detail::is_overloaded_message<std::decay_t<MsgType_>>) {                                                         \
-      return VariantWith<wire::detail::overload_set_for_t<std::remove_const_t<MsgType_>>>(WhenResolvedAs<MsgType_>(AllOf(__VA_ARGS__))); \
-    } else {                                                                                                                             \
-      return VariantWith<MsgType_>(AllOf(__VA_ARGS__));                                                                                  \
-    }                                                                                                                                    \
-  }()
-
-#define SUB_MSG(submsg_type, ...) \
-  VariantWith<submsg_type>(AllOf(__VA_ARGS__))
-
-// NOLINTEND(readability-identifier-naming)
-
-#define FIELD_EQ(name, ...) FIELD_EQ_IMPL_(name, (__VA_ARGS__))
-
-#define FIELD_EQ_IMPL_(name, ...) \
-  Field(#name, &MsgType_::name, Eq(__VA_ARGS__))
-
-#define FIELD(name, ...) \
-  Field(#name, &MsgType_::name, (__VA_ARGS__))
-
 #define CONCATENATE_IMPL_(a, b) a##b
 #define CONCATENATE(a, b) CONCATENATE_IMPL_(a, b)
 #define IN_SEQUENCE ::testing::InSequence CONCATENATE(in_sequence_, __LINE__)


### PR DESCRIPTION
The fake upstreams in integration tests were previously limited to one downstream connection at a time. This makes it so that multiple connection drivers can be active at once.

Also adds support for naming Task objects, and moves some common matcher code for message fields to a better location.