### PR TITLE
fix integration test flakes

### DIFF
--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: test
         run: |
-          bazel coverage --config=buildbarn --test_output=errors //test/...
+          bazel coverage --config=buildbarn --test_output=errors --test_arg='--log-level debug' //test/...
           tar xf bazel-out/_coverage/_coverage_report.dat ./lcov
 
       - name: upload to coveralls
@@ -62,7 +62,7 @@ jobs:
 
       - name: test
         id: asan-test
-        run: bazel test --config=buildbarn  --config=asan --test_output=errors //test/...
+        run: bazel test --config=buildbarn --config=asan --test_output=errors --test_arg='--log-level debug' //test/...
 
   test-tsan:
     if: >-
@@ -84,5 +84,4 @@ jobs:
 
       - name: test
         id: tsan-test
-        run: bazel test --config=buildbarn  --config=tsan --test_output=errors //test/...
-
+        run: bazel test --config=buildbarn --config=tsan --test_output=errors --test_arg='--log-level debug' //test/...

--- a/test/extensions/filters/network/ssh/graceful_shutdown_test.cc
+++ b/test/extensions/filters/network/ssh/graceful_shutdown_test.cc
@@ -105,15 +105,11 @@ TEST_P(GracefulShutdownIntegrationTest, ServerShutdownThenDrain) {
               .then(driver_->createTask<Tasks::WaitForDisconnectWithError>("server shutting down"))
               .start(channel_);
   EXPECT_CALL(channel_recv_, Call(MSG(wire::ChannelCloseMsg, _)));
-  absl::Notification drainComplete;
-  test_server_->server().dispatcher().post([this, &drainComplete] {
+  test_server_->server().dispatcher().post([this] {
     test_server_->server().shutdown();
-    test_server_->server().drainManager().startDrainSequence(Network::DrainDirection::All, [&drainComplete] {
-      drainComplete.Notify();
-    });
+    test_server_->server().drainManager().startDrainSequence(Network::DrainDirection::All, [] {});
   });
   ASSERT_TRUE(driver_->wait(th));
-  ASSERT_FALSE(drainComplete.WaitForNotificationWithTimeout(absl::FromChrono(TestUtility::DefaultTimeout)));
 }
 
 TEST_P(GracefulShutdownIntegrationTest, ServerShutdownTwice) {
@@ -133,15 +129,11 @@ TEST_P(GracefulShutdownIntegrationTest, ServerDrainThenShutdown) {
               .then(driver_->createTask<Tasks::WaitForDisconnectWithError>("server shutting down"))
               .start(channel_);
   EXPECT_CALL(channel_recv_, Call(MSG(wire::ChannelCloseMsg, _)));
-  absl::Notification drainComplete;
-  test_server_->server().dispatcher().post([this, &drainComplete] {
-    test_server_->server().drainManager().startDrainSequence(Network::DrainDirection::All, [&drainComplete] {
-      drainComplete.Notify();
-    });
+  test_server_->server().dispatcher().post([this] {
+    test_server_->server().drainManager().startDrainSequence(Network::DrainDirection::All, [] {});
     test_server_->server().shutdown();
   });
   ASSERT_TRUE(driver_->wait(th));
-  ASSERT_FALSE(drainComplete.WaitForNotificationWithTimeout(absl::FromChrono(TestUtility::DefaultTimeout)));
 }
 
 class WaitForChannelCloseAndDoNotReply : public Task<WaitForChannelCloseAndDoNotReply, Tasks::Channel, Tasks::Channel> {

--- a/test/extensions/filters/network/ssh/reverse_tunnel_test.cc
+++ b/test/extensions/filters/network/ssh/reverse_tunnel_test.cc
@@ -24,6 +24,9 @@ public:
   BaseReverseTunnelIntegrationTest(Network::Address::IpVersion version)
       : SshIntegrationTest({"unused"}, version) {
   }
+  ~BaseReverseTunnelIntegrationTest() {
+    cleanup();
+  }
 };
 
 class HttpReverseTunnelIntegrationTest : public BaseReverseTunnelIntegrationTest,

--- a/test/extensions/filters/network/ssh/reverse_tunnel_test.cc
+++ b/test/extensions/filters/network/ssh/reverse_tunnel_test.cc
@@ -1423,6 +1423,8 @@ TEST_P(DynamicPortForwardTest, AcceptAfterDownstreamDisconnected) {
               .start();
   auto downstream = makeTcpConnectionWithServerName(lookupPort("tcp"), "tcp-cluster");
   ASSERT_TRUE(driver->wait(th));
+  auto th2 = driver->createTask<Tasks::WaitForChannelCloseByPeer>(Tasks::ExpectEOF::Yes)
+               .start(channel);
   downstream->close(Network::ConnectionCloseType::AbortReset);
   test_server_->waitForCounterEq(stat_downstream_disconnect_before_init, 1);
   driver->sendMessage(wire::ChannelOpenConfirmationMsg{
@@ -1433,6 +1435,7 @@ TEST_P(DynamicPortForwardTest, AcceptAfterDownstreamDisconnected) {
   });
   test_server_->waitForCounterEq(stat_upstream_init_canceled_by_downstream_disconnect, 1,
                                  TestUtility::DefaultTimeout, driver->connectionDispatcher().ptr());
+  ASSERT_TRUE(driver->wait(th2));
 }
 
 TEST_P(DynamicPortForwardTest, DownstreamClosesDuringUpstreamSocks5Handshake) {

--- a/test/extensions/filters/network/ssh/ssh_connection_driver.cc
+++ b/test/extensions/filters/network/ssh/ssh_connection_driver.cc
@@ -123,12 +123,15 @@ void SshConnectionDriver::onEvent(Network::ConnectionEvent event) {
   }
   if (event == Network::ConnectionEvent::RemoteClose ||
       event == Network::ConnectionEvent::LocalClose) {
-    disconnected_ = true;
     // Disconnect the management server after the server transport is done, otherwise the server
     // transport will trigger an error
     if (mgmt_connection_ != nullptr) {
       EXPECT_TRUE(mgmt_connection_->close(Network::ConnectionCloseType::FlushWrite, default_timeout_));
+      EXPECT_TRUE(mgmt_connection_->waitForDisconnect(default_timeout_));
+      mgmt_connection_.reset();
+      mgmt_stream_.reset();
     }
+    disconnected_ = true;
   }
 }
 

--- a/test/extensions/filters/network/ssh/ssh_connection_driver.h
+++ b/test/extensions/filters/network/ssh/ssh_connection_driver.h
@@ -60,12 +60,14 @@ public:
 class FakeHttpConnectionShim {
 public:
   virtual ~FakeHttpConnectionShim() = default;
-  ABSL_MUST_USE_RESULT
+  [[nodiscard]]
   virtual testing::AssertionResult waitForNewStream(
     Envoy::Event::Dispatcher& client_dispatcher, std::unique_ptr<FakeStreamShim>& stream,
     std::chrono::milliseconds timeout) PURE;
-  ABSL_MUST_USE_RESULT
+  [[nodiscard]]
   virtual testing::AssertionResult close(Network::ConnectionCloseType close_type, std::chrono::milliseconds timeout) PURE;
+  [[nodiscard]]
+  virtual testing::AssertionResult waitForDisconnect(std::chrono::milliseconds timeout) PURE;
 };
 
 class FakeUpstreamShim {

--- a/test/extensions/filters/network/ssh/ssh_integration_test.cc
+++ b/test/extensions/filters/network/ssh/ssh_integration_test.cc
@@ -77,15 +77,12 @@ void FakeUpstreamShimImpl::cleanup() {
   for (auto& listener : listeners_) {
     absl::Notification done;
     fake_upstream_->dispatcher()->post([listener = listener.get(), &done] mutable {
-      listener->mu.lock();
-      listener->timer->disableTimer();
-      listener->handler.reset();
-      listener->mu.unlock();
-
+      listener->cleanup();
       done.Notify();
     });
     done.WaitForNotification();
   }
+  listeners_.clear();
   fake_upstream_->cleanUp();
 }
 
@@ -175,39 +172,56 @@ AssertionResult FakeUpstreamShimImpl::listenForSshConnection(std::shared_ptr<Ssh
     config->mutable_connection_service_options()
       ->mutable_channel_close_response_grace_period()
       ->set_seconds(1);
-    auto listener = std::make_unique<FakeUpstreamConnectionListenCtx>();
-    listener->mu.lock();
-    listener->handler = std::make_unique<SshFakeUpstreamHandler>(
-      *ctx,
-      config,
-      opts);
-    listener->timer = fake_upstream_->dispatcher()->createTimer([this, listener = listener.get()] {
-      absl::MutexLock lock(listener->mu);
-      if (listener->handler == nullptr) {
-        // the handler was cleaned up already
-        return;
-      }
-      absl::ReleasableMutexLock lock2(fake_upstream_->lock());
-      if (!fake_upstream_->hasNewConnections()) {
-        listener->timer->enableTimer(std::chrono::milliseconds(10));
-        return;
-      }
-      listener->timer->disableTimer();
-      auto& sc = fake_upstream_->consumeConnection();
-      lock2.Release();
-      listener->handler->onNewConnection(sc.connection());
-    });
-    listener->mu.unlock();
-
+    auto listener = std::make_unique<FakeUpstreamConnectionListenCtx>(
+      *fake_upstream_, std::make_unique<SshFakeUpstreamHandler>(*ctx, config, opts));
     listeners_mu_.lock();
     listeners_.push_back(std::move(listener));
-    listeners_.back()->mu.lock();
-    listeners_.back()->timer->enableTimer(std::chrono::milliseconds(10));
-    listeners_.back()->mu.unlock();
+    listeners_.back()->startTimer();
     listeners_mu_.unlock();
 
     return testing::AssertionSuccess();
   });
+}
+
+FakeUpstreamShimImpl::FakeUpstreamConnectionListenCtx::FakeUpstreamConnectionListenCtx(FakeUpstream& fake_upstream, std::unique_ptr<SshFakeUpstreamHandler> handler)
+    : fake_upstream_(fake_upstream) {
+  ASSERT(fake_upstream_.dispatcher()->isThreadSafe());
+  timer_ = fake_upstream_.dispatcher()->createTimer([this] {
+    timerCb();
+  });
+  handler_ = std::move(handler);
+}
+
+void FakeUpstreamShimImpl::FakeUpstreamConnectionListenCtx::startTimer() {
+  ASSERT(fake_upstream_.dispatcher()->isThreadSafe());
+  if (timer_ != nullptr) {
+    timer_->enableTimer(std::chrono::milliseconds(10));
+  }
+}
+
+void FakeUpstreamShimImpl::FakeUpstreamConnectionListenCtx::cleanup() {
+  ASSERT(fake_upstream_.dispatcher()->isThreadSafe());
+  timer_->disableTimer();
+  timer_ = nullptr;
+  handler_ = nullptr;
+}
+
+void FakeUpstreamShimImpl::FakeUpstreamConnectionListenCtx::timerCb() {
+  ASSERT(fake_upstream_.dispatcher()->isThreadSafe());
+  if (handler_ == nullptr) {
+    // the handler was cleaned up already
+    return;
+  }
+  absl::ReleasableMutexLock lock(fake_upstream_.lock());
+  if (!fake_upstream_.hasNewConnections()) {
+    timer_->enableTimer(std::chrono::milliseconds(10));
+    return;
+  }
+  timer_->disableTimer();
+  auto& sc = fake_upstream_.consumeConnection();
+  lock.Release();
+  auto& conn = sc.connection();
+  handler_->onNewConnection(conn);
 }
 
 std::string SshIntegrationTest::defaultConfig(const std::vector<std::string>& routes, Network::Address::IpVersion version) {

--- a/test/extensions/filters/network/ssh/ssh_integration_test.cc
+++ b/test/extensions/filters/network/ssh/ssh_integration_test.cc
@@ -63,9 +63,13 @@ SshIntegrationTest::SshIntegrationTest(std::vector<std::string> ssh_routes, Netw
 SshIntegrationTest::~SshIntegrationTest() = default;
 
 void SshIntegrationTest::cleanup() {
+  tcp_upstream_->cleanup();
+  http_upstream_2_->cleanup();
+  http_upstream_1_->cleanup();
   for (auto& upstream : ssh_upstreams_) {
     upstream->cleanup();
   }
+  mgmt_upstream_->cleanup();
 };
 
 void FakeUpstreamShimImpl::cleanup() {
@@ -420,7 +424,7 @@ IntegrationTcpClientPtr SshIntegrationTest::makeTcpConnectionWithServerName(uint
 
   uint32_t len = ntohl(server_name.size());
   std::string len_str(reinterpret_cast<char*>(&len), sizeof(len));
-  if (auto res = tcp_client->write(len_str + server_name); !res) {
+  if (auto res = tcp_client->write(len_str + server_name, false, true, TestUtility::DefaultTimeout, true); !res) {
     ADD_FAILURE() << "error writing server name: " << res.message();
   }
   return tcp_client;

--- a/test/extensions/filters/network/ssh/ssh_integration_test.h
+++ b/test/extensions/filters/network/ssh/ssh_integration_test.h
@@ -98,6 +98,11 @@ public:
     return real_fake_->close(close_type, timeout);
   }
 
+  [[nodiscard]]
+  testing::AssertionResult waitForDisconnect(std::chrono::milliseconds timeout) override {
+    return real_fake_->waitForDisconnect(timeout);
+  }
+
   std::unique_ptr<FakeHttpConnection> real_fake_;
 };
 
@@ -120,9 +125,17 @@ public:
   void cleanup() override;
 
   struct FakeUpstreamConnectionListenCtx {
-    absl::Mutex mu;
-    Envoy::Event::TimerPtr timer ABSL_GUARDED_BY(mu);
-    std::unique_ptr<SshFakeUpstreamHandler> handler ABSL_GUARDED_BY(mu);
+    FakeUpstreamConnectionListenCtx(FakeUpstream& fake_upstream, std::unique_ptr<SshFakeUpstreamHandler> handler);
+
+    void startTimer();
+    void cleanup();
+
+  private:
+    void timerCb();
+
+    FakeUpstream& fake_upstream_;
+    Envoy::Event::TimerPtr timer_;
+    std::unique_ptr<SshFakeUpstreamHandler> handler_;
   };
 
 private:

--- a/test/extensions/filters/network/ssh/ssh_upstream.h
+++ b/test/extensions/filters/network/ssh/ssh_upstream.h
@@ -64,6 +64,7 @@ public:
 
 class SshFakeUpstreamHandler : public SecretsProviderImpl,
                                public FakeSshUpstreamCallbacks,
+                               public Envoy::Network::ConnectionCallbacks,
                                public Envoy::Event::DispatcherThreadDeletable,
                                public TransportBase<SshFakeUpstreamHandlerCodec> {
 public:
@@ -98,6 +99,7 @@ public:
 
   void onNewConnection(Network::Connection& connection) override {
     connection_ = makeOptRef(connection);
+    connection_->addConnectionCallbacks(*this);
     dispatcher_ = makeOptRef(connection.dispatcher());
     codec_callbacks_ = std::make_unique<CodecCallbacks>(connection);
     setCodecCallbacks(*codec_callbacks_);
@@ -106,6 +108,17 @@ public:
     read_filter_ = std::make_shared<ReadFilter>(*this);
     connection.addReadFilter(read_filter_);
   }
+
+  void onEvent(Envoy::Network::ConnectionEvent event) override {
+    if (event == Envoy::Network::ConnectionEvent::LocalClose ||
+        event == Envoy::Network::ConnectionEvent::RemoteClose) {
+      connection_->removeReadFilter(read_filter_);
+      // IMPORTANT: do not reset the dispatcher. It is needed during cleanup
+    }
+  }
+
+  void onAboveWriteBufferHighWatermark() override {}
+  void onBelowWriteBufferLowWatermark() override {}
 
 protected:
   class FakeUpstreamConnectionService : public ConnectionService {
@@ -128,6 +141,7 @@ protected:
   };
 
   Envoy::OptRef<Envoy::Event::Dispatcher> connectionDispatcher() const override {
+    ASSERT(dispatcher_.has_value());
     return dispatcher_;
   }
 


### PR DESCRIPTION
Addresses issues with the following tests:
- GracefulShutdownIntegrationTest: for some reason, in a couple of tests we were waiting for notifications that are not supposed to fire to time out, using the default timeout which is 10-30s depending on build mode. I don't think we need to do these checks though, because the callback passed to startDrainSequence is unrelated to the registered drain callbacks; it is actually scheduled based on a timer, which may not fire if the server is already shut down before the timer elapses. Either way our own drain callbacks are fired immediately.
- ReverseTunnelIntegrationTest/AcceptAfterDownstreamConnected: Was missing a task to receive a channel close message. Depending on timing, the test would have exited before this message is received, but it could occasionally be received which would cause a failure. 

And general improvements to all integration tests:
- `makeTcpConnectionWithServerName` will no longer fail if the connection is disconnected before it returns, as long as the expected bytes are written and verified. Many tests disconnect shortly after connect, so this was a common source of flakes.
- A missing waitForDisconnect method was added to the fake http connection shim interface. Calling this is generally always required after calling close. This affects the fake management server connections which use http2. The managment connection should now be closed at the correct time during test teardown.
- Fixed fake ssh upstreams not handling connection events
- Fixed some issues with test cleanup related to https://github.com/pomerium/envoy-custom/pull/239 