### PR TITLE
improve user facing messages for unknown channel filter errors

### DIFF
--- a/source/extensions/filters/network/ssh/channel_filter_config.cc
+++ b/source/extensions/filters/network/ssh/channel_filter_config.cc
@@ -1,4 +1,5 @@
 #include "source/extensions/filters/network/ssh/channel_filter_config.h"
+#include <ranges>
 
 #pragma clang unsafe_buffer_usage begin
 #include "source/common/config/utility.h"
@@ -29,18 +30,25 @@ size_t ChannelFilterManager::numConfiguredFilters() const {
   return filter_configs_.size();
 }
 
+std::vector<std::string> ChannelFilterManager::allFilterNames() const {
+  return std::views::keys(filter_configs_) | std::ranges::to<std::vector>();
+}
+
 absl::Status ChannelFilterManager::configureFilters(const ExtensionConfigList& configs) {
   std::vector<std::pair<std::string, ProtobufTypes::MessagePtr>> updatedConfigs;
   for (const auto& config : configs) {
     if (!factories_.contains(config.name())) {
-      return absl::NotFoundError(fmt::format("channel filter not found: {}", config.name()));
+      return absl::NotFoundError(fmt::format(
+        "authorization server requested an unknown channel filter: '{}' "
+        "(the filter may be provided by an extension which was not loaded or failed to load)",
+        config.name()));
     }
     auto& factory = factories_[config.name()];
     auto factoryConfig = factory->createEmptyConfigProto();
     auto stat = Envoy::Config::Utility::translateOpaqueConfig(
       config.typed_config(), context_->messageValidationContext().dynamicValidationVisitor(), *factoryConfig);
     if (!stat.ok()) {
-      return absl::InvalidArgumentError(fmt::format("invalid channel filter config: {}", stat.message()));
+      return absl::InternalError(fmt::format("invalid channel filter config: {}", stat.message()));
     }
     updatedConfigs.emplace_back(config.name(), std::move(factoryConfig));
   }

--- a/source/extensions/filters/network/ssh/channel_filter_config.h
+++ b/source/extensions/filters/network/ssh/channel_filter_config.h
@@ -36,6 +36,7 @@ public:
                        Envoy::Server::Configuration::ServerFactoryContext& context);
 
   size_t numConfiguredFilters() const;
+  std::vector<std::string> allFilterNames() const;
   absl::Status configureFilters(const ExtensionConfigList& configs);
 
   std::vector<ChannelFilterPtr> createReadFilters(ChannelFilterCallbacks& channel_callbacks);

--- a/source/extensions/filters/network/ssh/server_transport.cc
+++ b/source/extensions/filters/network/ssh/server_transport.cc
@@ -393,6 +393,8 @@ void SshServerTransport::initUpstream(AuthInfoSharedPtr auth_info) {
     if (auto stat = channel_filter_manager_->configureFilters(
           auth_info_->allow_response->upstream().channel_filters());
         !stat.ok()) {
+      ENVOY_LOG(error, "ssh: stream {}: disconnecting due to configuration error: {}", stream_id_, statusToString(stat));
+      ENVOY_LOG(error, "note: all known channel filters: {}", channel_filter_manager_->allFilterNames());
       terminate(stat);
       return;
     }
@@ -427,6 +429,8 @@ void SshServerTransport::initUpstream(AuthInfoSharedPtr auth_info) {
     if (auto stat = channel_filter_manager_->configureFilters(
           auth_info_->allow_response->upstream().channel_filters());
         !stat.ok()) {
+      ENVOY_LOG(error, "ssh: stream {}: disconnecting due to configuration error: {}", stream_id_, statusToString(stat));
+      ENVOY_LOG(error, "note: all known channel filters: {}", channel_filter_manager_->allFilterNames());
       terminate(stat);
       return;
     }

--- a/test/extensions/filters/network/ssh/channel_filter_test.cc
+++ b/test/extensions/filters/network/ssh/channel_filter_test.cc
@@ -20,6 +20,7 @@ public:
 TEST_F(ChannelFilterTest, ChannelFilterManager_NoFilters) {
   ChannelFilterManager mgr({}, server_factory_context_);
   EXPECT_EQ(0, mgr.numConfiguredFilters());
+  EXPECT_TRUE(mgr.allFilterNames().empty());
 
   testing::StrictMock<MockChannelFilterCallbacks> cb;
 
@@ -38,6 +39,7 @@ TEST_F(ChannelFilterTest, ChannelFilterManager_NoEnabledFilters) {
 
   ChannelFilterManager mgr({}, server_factory_context_);
   EXPECT_EQ(0, mgr.numConfiguredFilters());
+  EXPECT_TRUE(mgr.allFilterNames().empty());
 
   testing::StrictMock<MockChannelFilterCallbacks> cb;
 
@@ -125,9 +127,9 @@ TEST_F(ChannelFilterTest, ChannelFilterManager_ConfigureFilters_NotFound) {
     auto* cfg2 = filterConfigs.Add();
     cfg2->set_name("nonexistent");
   }
-  EXPECT_EQ(absl::NotFoundError("channel filter not found: nonexistent"),
-            mgr.configureFilters(filterConfigs));
+  EXPECT_THAT(mgr.configureFilters(filterConfigs).message(), HasSubstr("authorization server requested an unknown channel filter: 'nonexistent'"));
   EXPECT_EQ(0, mgr.numConfiguredFilters());
+  EXPECT_TRUE(mgr.allFilterNames().empty());
 }
 
 TEST_F(ChannelFilterTest, ChannelFilterManager_ConfigureFilters_InvalidConfig) {
@@ -170,6 +172,7 @@ TEST_F(ChannelFilterTest, ChannelFilterManager_ConfigureFilters_InvalidConfig) {
   EXPECT_THAT(mgr.configureFilters(filterConfigs).message(),
               HasSubstr("invalid channel filter config: Unable to unpack as google.protobuf.StringValue"));
   EXPECT_EQ(0, mgr.numConfiguredFilters());
+  EXPECT_TRUE(mgr.allFilterNames().empty());
 }
 
 TEST_F(ChannelFilterTest, ChannelFilterManager_NoChannelFiltersCreated) {
@@ -225,6 +228,7 @@ TEST_F(ChannelFilterTest, ChannelFilterManager_NoChannelFiltersCreated) {
 
   EXPECT_OK(mgr.configureFilters(filterConfigs));
   EXPECT_EQ(1, mgr.numConfiguredFilters());
+  EXPECT_EQ(std::vector<std::string>{{"test_channel_filter"}}, mgr.allFilterNames());
 
   EXPECT_EQ(0, mgr.createReadFilters(cb).size());
   EXPECT_EQ(0, mgr.createWriteFilters(cb).size());
@@ -292,6 +296,7 @@ TEST_F(ChannelFilterTest, ChannelFilterManager_FiltersCreated) {
 
   EXPECT_OK(mgr.configureFilters(filterConfigs));
   EXPECT_EQ(1, mgr.numConfiguredFilters());
+  EXPECT_EQ(std::vector<std::string>{{"test_channel_filter"}}, mgr.allFilterNames());
 
   auto readFilters = mgr.createReadFilters(cb);
   auto writeFilters = mgr.createWriteFilters(cb);
@@ -412,6 +417,11 @@ TEST_F(ChannelFilterTest, ChannelFilterManager_MultipleFiltersConfigurationOrder
 
   EXPECT_OK(mgr.configureFilters(filterConfigs));
   EXPECT_EQ(filterCfgTypes.size(), mgr.numConfiguredFilters());
+  std::vector<std::string> expectedFilterNames;
+  for (size_t i = 0; i < filterCfgTypes.size(); i++) {
+    expectedFilterNames.push_back(fmt::format("test_channel_filter_{}", i));
+  }
+  EXPECT_EQ(expectedFilterNames, mgr.allFilterNames());
 
   auto readFilters = mgr.createReadFilters(cb);
   auto writeFilters = mgr.createWriteFilters(cb);

--- a/test/extensions/filters/network/ssh/server_transport_test.cc
+++ b/test/extensions/filters/network/ssh/server_transport_test.cc
@@ -777,6 +777,8 @@ TEST_F(ChannelFilterConfigTest, ConfigureChannelFilters) {
   ASSERT_OK(WriteMsg(std::move(authReq)));
 
   EXPECT_EQ(1, transport_.channelFilterManager().numConfiguredFilters());
+  EXPECT_EQ(std::vector<std::string>{{"test_channel_filter"}},
+            transport_.channelFilterManager().allFilterNames());
 }
 
 TEST_F(ChannelFilterConfigTest, ConfigureChannelFilters_InvalidChannelFilterConfig) {
@@ -809,6 +811,7 @@ TEST_F(ChannelFilterConfigTest, ConfigureChannelFilters_InvalidChannelFilterConf
   ASSERT_OK(WriteMsg(std::move(authReq)));
 
   EXPECT_EQ(0, transport_.channelFilterManager().numConfiguredFilters());
+  EXPECT_TRUE(transport_.channelFilterManager().allFilterNames().empty());
 }
 
 TEST_F(ChannelFilterConfigTest, ConfigureChannelFilters_ChannelFilterNotFound) {
@@ -841,10 +844,11 @@ TEST_F(ChannelFilterConfigTest, ConfigureChannelFilters_ChannelFilterNotFound) {
       manage_stream_callbacks_->onReceiveMessage(std::move(response));
     });
 
-  EXPECT_CALL(server_codec_callbacks_, onDecodingFailure(HasSubstr("channel filter not found: nonexistent")));
+  EXPECT_CALL(server_codec_callbacks_, onDecodingFailure(HasSubstr("authorization server requested an unknown channel filter: 'nonexistent'")));
   ASSERT_OK(WriteMsg(std::move(authReq)));
 
   EXPECT_EQ(0, transport_.channelFilterManager().numConfiguredFilters());
+  EXPECT_TRUE(transport_.channelFilterManager().allFilterNames().empty());
 }
 
 // NOLINTBEGIN(readability-identifier-naming)
@@ -1860,6 +1864,8 @@ TEST_F(HandoffTest, HandoffMode_ConfigureChannelFilters) {
   serve_channel_callbacks_[0]->onRemoteClose(Envoy::Grpc::Status::Canceled, "handoff");
 
   EXPECT_EQ(1, transport_.channelFilterManager().numConfiguredFilters());
+  EXPECT_EQ(std::vector<std::string>{{"test_channel_filter"}},
+            transport_.channelFilterManager().allFilterNames());
 }
 
 TEST_F(HandoffTest, HandoffMode_ConfigureChannelFiltersError) {
@@ -1894,6 +1900,7 @@ TEST_F(HandoffTest, HandoffMode_ConfigureChannelFiltersError) {
   ReceiveOnServeChannelStream(msg);
 
   EXPECT_EQ(0, transport_.channelFilterManager().numConfiguredFilters());
+  EXPECT_TRUE(transport_.channelFilterManager().allFilterNames().empty());
 }
 
 TEST_F(ServerTransportTest, SuccessfulUserAuth_MirrorMode) {


### PR DESCRIPTION
This updates error and log messages pertaining to unknown channel filters. On the server side, the logs will look like this:
```
ssh: stream ###: disconnecting due to configuration error: Not Found: authorization server requested an unknown channel filter: 'session_recording' (the filter may be provided by an extension which was not loaded or failed to load)
note: all known channel filters: []
```
And the client receives
```
Received disconnect from host:port: Not Found: authorization server requested an unknown channel filter: 'session_recording' (the filter may be provided by an extension which was not loaded or failed to load)
Disconnected from host:port

```