### PR TITLE
patch toolchain path in upstream fuzz tests

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -56,6 +56,7 @@ http_archive(
         "//patches/envoy:0009-luajit.patch",
         "//patches/envoy:0011-integration-tcp-client-write.patch",
         "//patches/envoy:0012-generic-proxy-trace-logs.patch",
+        "//patches/envoy:0013-fuzz-toolchain-path.patch",
         "//patches/envoy:fix-antlr4-cpp-runtime.patch",
         "//patches/envoy:fix-integration-test-server-exit.patch",
         "//patches/envoy:fix-missing-symbolizer-env.patch",

--- a/patches/envoy/0013-fuzz-toolchain-path.patch
+++ b/patches/envoy/0013-fuzz-toolchain-path.patch
@@ -1,0 +1,16 @@
+diff --git a/test/fuzz/BUILD b/test/fuzz/BUILD
+index da576dac59..c523e335c6 100644
+--- a/test/fuzz/BUILD
++++ b/test/fuzz/BUILD
+@@ -26,9 +26,9 @@ exports_files(["headers.dict"])
+ 
+ cc_library(
+     name = "fuzzed_data_provider",
+-    hdrs = ["@llvm_toolchain_llvm//:lib/clang/18/include/fuzzer/FuzzedDataProvider.h"],
++    hdrs = ["@llvm_toolchain_llvm//:lib/clang/22/include/fuzzer/FuzzedDataProvider.h"],
+     include_prefix = "",
+-    strip_include_prefix = "/lib/clang/18/include",
++    strip_include_prefix = "/lib/clang/22/include",
+     visibility = ["//visibility:public"],
+ )
+ 


### PR DESCRIPTION
This adds a patch to adjust some hard-coded toolchain paths used in upstream fuzz tests, which was preventing the ability to run many upstream tests.