### PR TITLE
ssh: fix validation for enabled channel filter factories

### DIFF
--- a/source/extensions/filters/network/ssh/config.cc
+++ b/source/extensions/filters/network/ssh/config.cc
@@ -6,6 +6,10 @@
 #include "source/extensions/filters/network/ssh/service_connection.h" // IWYU pragma: keep
 #include "source/extensions/filters/network/ssh/service_userauth.h"   // IWYU pragma: keep
 
+#pragma clang unsafe_buffer_usage begin
+#include "source/common/config/utility.h"
+#pragma clang unsafe_buffer_usage end
+
 namespace Envoy::Extensions::NetworkFilters::GenericProxy::Codec {
 
 CodecFactoryPtr SshCodecFactoryConfig::createCodecFactory(
@@ -47,6 +51,73 @@ SshCodecFactory::SshCodecFactory(Envoy::Server::Configuration::ServerFactoryCont
     throw Envoy::EnvoyException(statusToString(hostKeys.status()));
   }
   host_keys_ = std::move(hostKeys).value();
+
+  // Verify that all enabled channel filters listed in the configuration exist at this time, either
+  // because they are statically linked in or have been loaded from a dynamic extension (which would
+  // have already happened by this point).
+  if (config->enabled_channel_filter_factories_size() > 0) {
+    const auto& knownFactories = Envoy::Registry::FactoryRegistry<ChannelFilterFactoryConfig>::factories();
+    try {
+      for (const auto& requestedFactory : config->enabled_channel_filter_factories()) {
+        if (!knownFactories.contains(requestedFactory.name())) {
+          throw Envoy::EnvoyException(fmt::format(
+            "no registered channel filter factory found for name: '{}' "
+            "(the filter may be provided by an extension which was not loaded or failed to load)",
+            requestedFactory.name()));
+        }
+        // This should already be validated by regular proto validation
+        ASSERT(requestedFactory.has_typed_config());
+
+        // Validate the factory config here, since exceptions thrown in this context are caught
+        // and handled by envoy. The ChannelFilterManager will also do this (and not discard the
+        // result) later when the filter chain is created, but if an exception is thrown at that
+        // time it will be fatal.
+
+        auto emptyConfig = knownFactories.at(requestedFactory.name())->createEmptyConfigProto();
+        if (auto type = TypeUtil::typeUrlToDescriptorFullName(requestedFactory.typed_config().type_url());
+            type == xds::type::v3::TypedStruct::default_instance().GetTypeName()) {
+          // NB: if TypedStruct is used, envoy will decode it via json round-trip and will NOT check
+          // if the type_url field of the TypedStruct matches the expected type. This is probably a
+          // bug. It will still cause an error if the json decode fails but the error message will
+          // be very confusing. To prevent this, check the type ourselves first then use
+          // translateOpaqueConfig, instead of using translateAnyToFactoryConfig.
+          xds::type::v3::TypedStruct typedStruct;
+          auto ok = requestedFactory.typed_config().UnpackTo(&typedStruct);
+          if (!ok) {
+            throw Envoy::EnvoyException("bug: malformed TypedStruct in channel filter factory config");
+          }
+          if (auto actualTypeName = TypeUtil::typeUrlToDescriptorFullName(typedStruct.type_url());
+              actualTypeName != emptyConfig->GetTypeName()) {
+            throw Envoy::EnvoyException(fmt::format(
+              "type mismatch in configuration for channel filter factory '{}' (expecting {}, got {})",
+              requestedFactory.name(), emptyConfig->GetTypeName(), actualTypeName));
+          }
+        }
+        auto& visitor = context.messageValidationContext().dynamicValidationVisitor();
+        THROW_IF_NOT_OK(Envoy::Config::Utility::translateOpaqueConfig(
+          requestedFactory.typed_config(),
+          visitor,
+          *emptyConfig));
+        // Validate emptyConfig the same way MessageUtil::validate does, but only using the
+        // abstract message (MessageUtil::validate uses ADL to find a `Validate` function from the
+        // generated code)
+        if (!visitor.skipValidation()) {
+          MessageUtil::checkForUnexpectedFields(*emptyConfig, visitor);
+        }
+        MessageUtil::validateDurationFields(*emptyConfig);
+        MessageUtil::recursivePgvCheck(*emptyConfig);
+      }
+    } catch (const std::exception& e) {
+      // TODO: fmt::formatter for std::vector<std::string_view> is currently broken in upstream
+      std::vector<std::string> names;
+      for (auto name : Envoy::Registry::FactoryRegistry<ChannelFilterFactoryConfig>::registeredNames(true)) {
+        names.push_back(std::string(name));
+      }
+      ENVOY_LOG(error, "ssh filter configuration error: {}", e.what());
+      ENVOY_LOG(error, "note: all known channel filter factories: {}", names);
+      throw;
+    }
+  }
 }
 
 ServerCodecPtr SshCodecFactory::createServerCodec() const {

--- a/source/extensions/filters/network/ssh/config.h
+++ b/source/extensions/filters/network/ssh/config.h
@@ -28,7 +28,8 @@ public:
 };
 
 class SshCodecFactory : public CodecFactory,
-                        public SecretsProvider {
+                        public SecretsProvider,
+                        public Envoy::Logger::Loggable<Envoy::Logger::Id::config> {
 public:
   SshCodecFactory(Envoy::Server::Configuration::ServerFactoryContext& context,
                   std::shared_ptr<pomerium::extensions::ssh::CodecConfig> config,

--- a/test/extensions/filters/network/ssh/BUILD
+++ b/test/extensions/filters/network/ssh/BUILD
@@ -343,6 +343,7 @@ envoy_cc_test(
         ":test_mocks",
         "@envoy//test/extensions/filters/network/generic_proxy/mocks:codec_mocks",
         "@envoy//test/mocks/server:factory_context_mocks",
+        "@envoy//test/test_common:registry_lib",
     ],
 )
 

--- a/test/extensions/filters/network/ssh/config_test.cc
+++ b/test/extensions/filters/network/ssh/config_test.cc
@@ -1,9 +1,13 @@
 #include "source/extensions/filters/network/ssh/config.h"
+#include "test/extensions/filters/network/ssh/test_mocks.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/extensions/filters/network/ssh/test_env_util.h"
+#include "test/test_common/test_common.h"
+#include "test/test_common/registry.h"
 
 #pragma clang unsafe_buffer_usage begin
 #include "api/extensions/filters/network/ssh/ssh.pb.h"
+#include "api/extensions/filters/network/ssh/ssh.pb.validate.h"
 #include "source/extensions/filters/network/generic_proxy/interface/codec.h"
 #pragma clang unsafe_buffer_usage end
 
@@ -46,7 +50,7 @@ TEST(FactoryTest, FactoryTest) {
   ASSERT_NE(nullptr, dynamic_cast<SshCodecFactory&>(*factory).userCaKey());
 }
 
-TEST(FactoryTest, FactoryTest_Error) {
+TEST(FactoryTest, Error) {
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   auto* factoryConfig = Registry::FactoryRegistry<CodecFactoryConfig>::getFactory(
@@ -65,7 +69,7 @@ TEST(FactoryTest, FactoryTest_Error) {
                             "test error");
 }
 
-TEST(FactoryTest, FactoryTest_ErrorLoadingHostKeys) {
+TEST(FactoryTest, ErrorLoadingHostKeys) {
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   auto* factoryConfig = Registry::FactoryRegistry<CodecFactoryConfig>::getFactory(
@@ -79,7 +83,7 @@ TEST(FactoryTest, FactoryTest_ErrorLoadingHostKeys) {
                             "Not Found: error loading ssh host key [1/2] from file /nonexistent: No such file or directory");
 }
 
-TEST(FactoryTest, FactoryTest_ErrorLoadingUserCaKey) {
+TEST(FactoryTest, ErrorLoadingUserCaKey) {
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   auto* factoryConfig = Registry::FactoryRegistry<CodecFactoryConfig>::getFactory(
@@ -91,6 +95,172 @@ TEST(FactoryTest, FactoryTest_ErrorLoadingUserCaKey) {
   EXPECT_THROW_WITH_MESSAGE(factoryConfig->createCodecFactory(*cfg, context),
                             EnvoyException,
                             "Not Found: error loading ssh user ca key from file /nonexistent: No such file or directory");
+}
+
+TEST(FactoryTest, InvalidNonexistentChannelFilterFactory) {
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+
+  auto* factoryConfig = Registry::FactoryRegistry<CodecFactoryConfig>::getFactory(
+    "envoy.generic_proxy.codecs.ssh");
+  ASSERT_NE(factoryConfig, nullptr);
+
+  auto cfg = newTestConfig();
+  auto* f = cfg->add_enabled_channel_filter_factories();
+  f->set_name("nonexistent");
+  f->mutable_typed_config()->set_type_url("type.googleapis.com/google.protobuf.Int32Value");
+
+  EXPECT_THROW_WITH_REGEX(factoryConfig->createCodecFactory(*cfg, context),
+                          EnvoyException,
+                          "no registered channel filter factory found for name: 'nonexistent'");
+}
+
+class ChannelFilterFactoryConfigTest : public testing::Test {
+public:
+  void SetUp() {
+    factoryConfig = Registry::FactoryRegistry<CodecFactoryConfig>::getFactory(
+      "envoy.generic_proxy.codecs.ssh");
+    ASSERT_NE(factoryConfig, nullptr);
+
+    ON_CALL(factory, createEmptyConfigProto).WillByDefault([] {
+      // using some type that has validation rules
+      return std::make_unique<envoy::config::core::v3::DataSource>();
+    });
+    ON_CALL(factory, name).WillByDefault(Return("test_channel_filter"));
+
+    inject_ = std::make_unique<Registry::InjectFactory<ChannelFilterFactoryConfig>>(factory);
+  }
+
+  Envoy::Extensions::NetworkFilters::GenericProxy::CodecFactoryConfig* factoryConfig{};
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  testing::NiceMock<MockChannelFilterFactoryConfig> factory;
+
+private:
+  std::unique_ptr<Registry::InjectFactory<ChannelFilterFactoryConfig>> inject_;
+};
+
+TEST_F(ChannelFilterFactoryConfigTest, Invalid_MissingTypedConfig) {
+  auto cfg = newTestConfig();
+  auto* f = cfg->add_enabled_channel_filter_factories();
+  f->set_name("test_channel_filter");
+
+  // this validation should happen before our own validation logic is run
+  EXPECT_THROW_WITH_REGEX(factoryConfig->createCodecFactory(*cfg, context),
+                          EnvoyException,
+                          "TypedExtensionConfigValidationError.TypedConfig: value is required");
+}
+
+TEST_F(ChannelFilterFactoryConfigTest, Invalid_WrongType) {
+  auto cfg = newTestConfig();
+  auto* f = cfg->add_enabled_channel_filter_factories();
+  f->set_name("test_channel_filter");
+  google::protobuf::Int32Value v;
+  v.set_value(1);
+  f->mutable_typed_config()->PackFrom(v);
+  // this should reach our validation logic
+  EXPECT_THROW_WITH_REGEX(factoryConfig->createCodecFactory(*cfg, context),
+                          EnvoyException,
+                          "Unable to unpack as envoy.config.core.v3.DataSource");
+}
+
+TEST_F(ChannelFilterFactoryConfigTest, Valid) {
+  auto cfg = newTestConfig();
+  auto* f = cfg->add_enabled_channel_filter_factories();
+  f->set_name("test_channel_filter");
+  envoy::config::core::v3::DataSource v;
+  v.set_filename("test"); // will satisfy protovalidate
+  f->mutable_typed_config()->PackFrom(v);
+
+  EXPECT_NO_THROW(factoryConfig->createCodecFactory(*cfg, context));
+}
+
+TEST_F(ChannelFilterFactoryConfigTest, Valid_TypedStruct) {
+  // Make sure that using TypedStruct for enabled channel filter configs works the same way as
+  // using regular Any. Checking that config validation is delayed is done in a separate test
+  // further below.
+
+  auto cfg = newTestConfig();
+  auto* f = cfg->add_enabled_channel_filter_factories();
+
+  // The type will be known at the time the codec factory is created, otherwise the channel filter
+  // factory wouldn't be able to load. However the type might not be known at the time the listener
+  // configuration is received from the LDS.
+  xds::type::v3::TypedStruct ts;
+  ts.set_type_url("type.googleapis.com/envoy.config.core.v3.DataSource");
+  // match the DataSource 'filename' field (in the 'specifier' oneof)
+  auto* fields = ts.mutable_value()->mutable_fields();
+  (*fields)["filename"].set_string_value("test");
+
+  f->set_name("test_channel_filter");
+  f->mutable_typed_config()->PackFrom(ts); // use the TypedStruct instead
+
+  ASSERT_NO_THROW(factoryConfig->createCodecFactory(*cfg, context));
+}
+
+TEST_F(ChannelFilterFactoryConfigTest, Invalid_TypedStructWithWrongType) {
+  // Similar to the above test using TypedStruct, but using a type that does not match and should
+  // be rejected during creation of the codec factory.
+
+  auto cfg = newTestConfig();
+  auto* f = cfg->add_enabled_channel_filter_factories();
+
+  xds::type::v3::TypedStruct ts;
+  ts.set_type_url("type.googleapis.com/google.protobuf.StringValue");
+  auto* fields = ts.mutable_value()->mutable_fields();
+  (*fields)["value"].set_string_value("test");
+  f->set_name("test_channel_filter");
+  f->mutable_typed_config()->PackFrom(ts);
+
+  EXPECT_THROW_WITH_MESSAGE(factoryConfig->createCodecFactory(*cfg, context),
+                            EnvoyException,
+                            "type mismatch in configuration for channel filter factory 'test_channel_filter' "
+                            "(expecting envoy.config.core.v3.DataSource, got google.protobuf.StringValue)");
+}
+
+TEST_F(ChannelFilterFactoryConfigTest, Invalid_MalformedTypedStruct) {
+  auto cfg = newTestConfig();
+  auto* f = cfg->add_enabled_channel_filter_factories();
+
+  f->set_name("test_channel_filter");
+  f->mutable_typed_config()->set_type_url("type.googleapis.com/xds.type.v3.TypedStruct");
+  f->mutable_typed_config()->set_value("malformed");
+
+  EXPECT_THROW_WITH_MESSAGE(factoryConfig->createCodecFactory(*cfg, context),
+                            EnvoyException,
+                            "bug: malformed TypedStruct in channel filter factory config");
+}
+
+TEST_F(ChannelFilterFactoryConfigTest, Invalid_TypedStructWithMatchingTypeButMessageFailsValidation) {
+  auto cfg = newTestConfig();
+  auto* f = cfg->add_enabled_channel_filter_factories();
+
+  xds::type::v3::TypedStruct ts;
+  ts.set_type_url("type.googleapis.com/envoy.config.core.v3.DataSource");
+  auto* fields = ts.mutable_value()->mutable_fields();
+  // the unknown field should be ignored, but the missing oneof should cause a validation error
+  (*fields)["some_unknown_field"].set_string_value("asdf");
+  f->set_name("test_channel_filter");
+  f->mutable_typed_config()->PackFrom(ts);
+
+  EXPECT_THROW_WITH_REGEX(factoryConfig->createCodecFactory(*cfg, context),
+                          EnvoyException,
+                          R"(Proto constraint validation failed \(field: "specifier", reason: is required\))");
+}
+
+TEST_F(ChannelFilterFactoryConfigTest, Invalid_TypedStructWithMatchingTypeButInvalidData_DecodeFailed) {
+  auto cfg = newTestConfig();
+  auto* f = cfg->add_enabled_channel_filter_factories();
+
+  // this will trigger a (legitimate) json decode error which has a different error message
+  xds::type::v3::TypedStruct ts;
+  ts.set_type_url("type.googleapis.com/envoy.config.core.v3.DataSource");
+  auto* fields = ts.mutable_value()->mutable_fields();
+  (*fields)["filename"].set_number_value(1); // should be a string
+  f->set_name("test_channel_filter");
+  f->mutable_typed_config()->PackFrom(ts);
+
+  EXPECT_THROW_WITH_REGEX(factoryConfig->createCodecFactory(*cfg, context),
+                          EnvoyException,
+                          "Unable to parse JSON as proto");
 }
 
 TEST(FactoryTest, ConfigValidation) {
@@ -155,6 +325,52 @@ TEST(FactoryTest, ConfigValidation) {
       cfg);
     , Envoy::ProtoValidationException,
     "CodecConfigValidationError.GrpcService: value is required");
+}
+
+TEST(FactoryTest, DelayedChannelFilterFactoriesConfigValidation) {
+  pomerium::extensions::ssh::CodecConfig cfg;
+
+  auto good_config = R"(
+    host_keys:
+      - filename: /path/to/file1
+      - filename: /path/to/file2
+      - inline_string: test
+      - inline_bytes: dGVzdAo=
+    user_ca_key:
+      filename: /path/to/key
+    grpc_service:
+      envoy_grpc:
+        cluster_name: test
+)"s;
+
+  // incorrect usage
+  EXPECT_THROW_WITH_REGEX(
+    TestUtility::loadFromYamlAndValidate(
+      good_config + R"(
+    enabled_channel_filter_factories:
+      - name: dynamic
+        typed_config:
+          "@type": "type.googleapis.com/some.type.NotKnownUntilLater"
+          value:
+            foo: "bar"
+    )",
+      cfg);
+    , Envoy::ProtoValidationException,
+    "could not find @type 'type.googleapis.com/some.type.NotKnownUntilLater'");
+
+  // correct usage
+  EXPECT_NO_THROW(
+    TestUtility::loadFromYamlAndValidate(
+      good_config + R"(
+    enabled_channel_filter_factories:
+      - name: dynamic
+        typed_config:
+          "@type": "type.googleapis.com/xds.type.v3.TypedStruct"
+          type_url: type.googleapis.com/some.type.NotKnownUntilLater
+          value:
+            foo: "bar"
+    )",
+      cfg));
 }
 
 } // namespace test


### PR DESCRIPTION
This adds earlier validation for `enabled_channel_filter_factories` in the ssh codec config, to allow envoy to properly reject an invalid configuration instead of only validating when the codec is created (at which point validation errors will be fatal).

Partial fix for https://linear.app/pomerium/issue/ENG-4096