### PR TITLE
update to Envoy 1.36.8

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,7 +27,7 @@ load("@hedron_compile_commands//:workspace_setup_transitive_transitive_transitiv
 
 hedron_compile_commands_setup_transitive_transitive_transitive()
 
-envoy_version = "ab5b508735aac42f2855099285de9c79258e5166"
+envoy_version = "ee7784f95f506e2a606ae668f0d9f70f9d26af83"
 
 openssh_version = "V_10_2_P1"
 
@@ -58,7 +58,7 @@ http_archive(
         "//patches/envoy:tmp-envoy-41815.patch",
         "//patches/envoy:tmp-transport-socket-options.patch",
     ],
-    sha256 = "55b757518cf19351358a255e52a390d71ca54f59d05214f21946d9c988588dcc",
+    sha256 = "6064371695a3cae6819f45407d275dc432ce59b95bb18071cfd2e981295baa80",
     strip_prefix = "envoy-" + envoy_version,
     url = "https://github.com/envoyproxy/envoy/archive/" + envoy_version + ".zip",
 )


### PR DESCRIPTION
(This PR is stacked on top of #246, in case we want to tag releases both for 1.36.7 and 1.36.8.)

Related issue: https://linear.app/pomerium/issue/ENG-4133/upgrade-envoy-to-1367