### PR TITLE
luajit: use libunwind apis for exception frame registration

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -66,6 +66,7 @@ http_archive(
         "//patches/envoy:fix-tcmalloc-macos-constraints.patch",
         "//patches/envoy:fix-transport-socket-options.patch",
         "//patches/envoy:fix-allow-dev-shm.patch",  # exists in upstream main but not in 1.38.x
+        "//patches/envoy:fix-lua-wrappers-test.patch",
     ],
     sha256 = "af833ff8f9799499b44dee4276dad5fd5785638e73cb17ed38718565e49c7a5a",
     strip_prefix = "envoy-" + envoy_version,
@@ -111,6 +112,10 @@ external_http_archive(
 external_http_archive(
     name = "luajit",
     build_file = "//bazel/foreign_cc:luajit.BUILD",
+    patch_args = ["-p1"],
+    patches = [
+        "//patches/luajit:0001-libunwind-fde-offset.patch",
+    ],
 )
 
 envoy_dependencies()

--- a/bazel/foreign_cc/luajit.bzl
+++ b/bazel/foreign_cc/luajit.bzl
@@ -13,7 +13,10 @@ def luajit_copts():
         "-DLJ_ABI_SOFTFP=0",
         "-DLUAJIT_UNWIND_EXTERNAL",
         "-DLUAJIT_ENABLE_LUA52COMPAT",
-    ] + select(
+    ] + select({
+        "@envoy//bazel:dbg_build": ["-DLUA_USE_ASSERT"],
+        "//conditions:default": [],
+    }) + select(
         {
             ":luajit_target_x64": [
                 "-DLUAJIT_TARGET=LUAJIT_ARCH_x64",

--- a/patches/envoy/fix-lua-wrappers-test.patch
+++ b/patches/envoy/fix-lua-wrappers-test.patch
@@ -1,0 +1,13 @@
+diff --git a/test/extensions/filters/common/lua/lua_wrappers.h b/test/extensions/filters/common/lua/lua_wrappers.h
+index b7c1dfb4bb..996a5271e6 100644
+--- a/test/extensions/filters/common/lua/lua_wrappers.h
++++ b/test/extensions/filters/common/lua/lua_wrappers.h
+@@ -31,7 +31,7 @@ public:
+     state_ = std::make_unique<ThreadLocalState>(code, tls_);
+     state_->registerType<T>();
+     coroutine_ = state_->createCoroutine();
+-    lua_pushcclosure(coroutine_->luaState(), luaTestPrint, 1);
++    lua_pushcclosure(coroutine_->luaState(), luaTestPrint, 0);
+     lua_setglobal(coroutine_->luaState(), "testPrint");
+     testing::Mock::AllowLeak(&printer_);
+   }

--- a/patches/luajit/0001-libunwind-fde-offset.patch
+++ b/patches/luajit/0001-libunwind-fde-offset.patch
@@ -1,0 +1,41 @@
+diff --git a/src/lj_err.c b/src/lj_err.c
+index 03b5030b..812b1700 100644
+--- a/src/lj_err.c
++++ b/src/lj_err.c
+@@ -590,16 +590,10 @@ static const uint8_t err_frame_jit_template[] = {
+ };
+ 
+ #define ERR_FRAME_JIT_OFS_HANDLER	0x12
+-#define ERR_FRAME_JIT_OFS_FDE		(LJ_64 ? 0x20 : 0x18)
+ #define ERR_FRAME_JIT_OFS_CODE_SIZE	(LJ_64 ? 0x2c : 0x24)
+-#if LJ_TARGET_OSX
+-#define ERR_FRAME_JIT_OFS_REGISTER	ERR_FRAME_JIT_OFS_FDE
+-#else
+-#define ERR_FRAME_JIT_OFS_REGISTER	0
+-#endif
+ 
+-extern void __register_frame(const void *);
+-extern void __deregister_frame(const void *);
++extern void __unw_add_dynamic_eh_frame_section(uintptr_t);
++extern void __unw_remove_dynamic_eh_frame_section(uintptr_t);
+ 
+ uint8_t *lj_err_register_mcode(void *base, size_t sz, uint8_t *info)
+ {
+@@ -617,7 +611,7 @@ uint8_t *lj_err_register_mcode(void *base, size_t sz, uint8_t *info)
+   memcpy(info + ERR_FRAME_JIT_OFS_HANDLER, &handler, sizeof(handler));
+   *(uint32_t *)(info + ERR_FRAME_JIT_OFS_CODE_SIZE) =
+     (uint32_t)(sz - sizeof(err_frame_jit_template) - (info - (uint8_t *)base));
+-  __register_frame(info + ERR_FRAME_JIT_OFS_REGISTER);
++  __unw_add_dynamic_eh_frame_section((uintptr_t)info);
+ #ifdef LUA_USE_ASSERT
+   {
+     struct dwarf_eh_bases ehb;
+@@ -631,7 +625,7 @@ uint8_t *lj_err_register_mcode(void *base, size_t sz, uint8_t *info)
+ void lj_err_deregister_mcode(void *base, size_t sz, uint8_t *info)
+ {
+   UNUSED(base); UNUSED(sz);
+-  __deregister_frame(info + ERR_FRAME_JIT_OFS_REGISTER);
++  __unw_remove_dynamic_eh_frame_section((uintptr_t)info);
+ }
+ #endif
+ 


### PR DESCRIPTION
When building luajit with libunwind as the unwind library instead of libgcc, it occasionally causes the following error to be logged: `libunwind: __unw_add_dynamic_fde: bad fde: FDE is really a CIE`. This happens when luajit calls `__register_frame`, which is part of an API that is available in both libunwind and libgcc, but does not work the same way in both libraries. Detecting which library is actually in use is not trivial, so luajit assumes that libgcc is in use on Linux, and libunwind is in use on macos.

Since we only build with libunwind on Linux, luajit assumes we are using libgcc and calls `__register_frame` with input in the form expected by libgcc, which is a Call Frame Information record [described here](https://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/ehframechpt.html). The libgcc version of `__register_frame` accepts either a pointer to the start of the CIE, or a pointer to the start of the [first] FDE (but from what I have read this has a performance penalty). The libunwind version of `__register_frame` only accepts a pointer to the FDE however, and if you pass the pointer to the CIE instead you will get the "FDE is really a CIE" error.

For our use case it would be sufficient to always assume libunwind is in use and unconditionally `#define ERR_FRAME_JIT_OFS_REGISTER ERR_FRAME_JIT_OFS_FDE`, but this might be confusing to future readers, and if we ever need to build with libgcc again (or if there is a future bug that causes us to try to link against host libgcc) this would still link without error, and then we might end up with the opposite problem. Instead, we can use libunwind-only apis `__unw_add_dynamic_eh_frame_section` and `__unw_remove_dynamic_eh_frame_section` which accept the full frame (pointer to the CIE) and use these unconditionally. This will cause link errors if attempting to use libgcc. 

More information can be found in https://reviews.llvm.org/D111863 and https://reviews.llvm.org/D44494.

While testing this I noticed that there is an assert in the luajit code that would have previously failed, but the asserts are compiled out unless `LUA_USE_ASSERT` is defined. The luajit build rules were updated to add this define for debug builds only, but doing so causes an unrelated assert to fire in the upstream Envoy luajit tests, which appears to be a legitimate bug (although i have NO idea how it was ever working before). I will open an issue upstream to get this fixed. 