### PR TITLE
luajit: allow (partial) asan builds

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -66,7 +66,7 @@ http_archive(
         "//patches/envoy:fix-tcmalloc-macos-constraints.patch",
         "//patches/envoy:fix-transport-socket-options.patch",
         "//patches/envoy:fix-allow-dev-shm.patch",  # exists in upstream main but not in 1.38.x
-        "//patches/envoy:fix-lua-wrappers-test.patch",
+        "//patches/envoy:fix-lua-wrappers-test.patch",  # https://github.com/envoyproxy/envoy/pull/45665
     ],
     sha256 = "af833ff8f9799499b44dee4276dad5fd5785638e73cb17ed38718565e49c7a5a",
     strip_prefix = "envoy-" + envoy_version,
@@ -115,6 +115,7 @@ external_http_archive(
     patch_args = ["-p1"],
     patches = [
         "//patches/luajit:0001-libunwind-fde-offset.patch",
+        "//patches/luajit:fix-luajit-asan.patch",
     ],
 )
 

--- a/bazel/foreign_cc/luajit.bzl
+++ b/bazel/foreign_cc/luajit.bzl
@@ -32,6 +32,31 @@ def luajit_copts():
                          "*******************************",
     )
 
+# Extra copts that apply only to host build tools
+def luajit_host_only_copts():
+    return select({
+        "@envoy//bazel:asan_build": [
+            "-fno-sanitize=undefined",
+        ],
+        "//conditions:default": [],
+    })
+
+# Extra copts that do not apply to host build tools
+def luajit_target_only_copts():
+    return select({
+        "@envoy//bazel:asan_build": [
+            # False positives maybe related to unknown type info for some function pointers
+            "-fno-sanitize=function",
+            # There are many instances of UB from the "offsetof" pattern described in
+            # https://en.wikipedia.org/wiki/Offsetof, but where the pointer might actually be a fake
+            # address like 0x4 or 0x6 which is not suitably aligned. The ubsan warnings here are not
+            # false positives, but there isn't much we can do about it. The compiler generates the
+            # intended code anyway. Example: https://godbolt.org/z/7rKeK3sE7
+            "-fno-sanitize=alignment",
+        ],
+        "//conditions:default": [],
+    })
+
 def luajit_host_bin_env():
     return select({
         "@envoy//bazel:asan_build": "ASAN_OPTIONS=detect_leaks=0 ",
@@ -169,7 +194,7 @@ def lj_cc_binary(name, host = False, **kwargs):
 
     cc_binary(
         name = "_" + name,
-        conlyopts = luajit_copts(),
+        conlyopts = luajit_copts() + (luajit_host_only_copts() if host else luajit_target_only_copts()),
         **{key: value for key, value in kwargs.items() if key != "visibility"}
     )
 
@@ -209,6 +234,6 @@ def lj_cc_library(name, host = False, **kwargs):
 
     cc_library(
         name = "_" + name,
-        conlyopts = luajit_copts(),
+        conlyopts = luajit_copts() + (luajit_host_only_copts() if host else luajit_target_only_copts()),
         **{key: value for key, value in kwargs.items() if key != "visibility"}
     )

--- a/patches/envoy/0009-luajit.patch
+++ b/patches/envoy/0009-luajit.patch
@@ -16,7 +16,7 @@ index 9b4cae8785..f69a536317 100644
 +        "@luajit",
      ],
  )
- 
+
 @@ -41,10 +41,10 @@ envoy_cc_library(
      hdrs = ["protobuf_converter.h"],
      deps = [
@@ -29,39 +29,3 @@ index 9b4cae8785..f69a536317 100644
 +        "@luajit",
      ],
  )
-diff --git a/test/extensions/filters/http/lua/BUILD b/test/extensions/filters/http/lua/BUILD
-index dc74a842d6..8c1398ef1f 100644
---- a/test/extensions/filters/http/lua/BUILD
-+++ b/test/extensions/filters/http/lua/BUILD
-@@ -16,6 +16,7 @@ envoy_extension_cc_test(
-     srcs = ["lua_filter_test.cc"],
-     extension_names = ["envoy.filters.http.lua"],
-     rbe_pool = "6gig",
-+    tags = ["no_san"],
-     deps = [
-         "//source/common/stream_info:stream_info_lib",
-         "//source/extensions/filters/http/lua:lua_filter_lib",
-@@ -39,6 +40,7 @@ envoy_extension_cc_test(
-     srcs = ["wrappers_test.cc"],
-     extension_names = ["envoy.filters.http.lua"],
-     rbe_pool = "6gig",
-+    tags = ["no_san"],
-     deps = [
-         "//source/common/network:address_lib",
-         "//source/common/network:upstream_subject_alt_names_lib",
-@@ -61,6 +63,7 @@ envoy_extension_cc_test(
-     srcs = ["lua_integration_test.cc"],
-     extension_names = ["envoy.filters.http.lua"],
-     rbe_pool = "4core",
-+    tags = ["no_san"],
-     deps = [
-         "//source/common/protobuf:utility_lib",
-         "//source/common/router:string_accessor_lib",
-@@ -83,6 +86,7 @@ envoy_extension_cc_test(
-     srcs = ["config_test.cc"],
-     extension_names = ["envoy.filters.http.lua"],
-     rbe_pool = "6gig",
-+    tags = ["no_san"],
-     deps = [
-         "//source/extensions/filters/http/lua:config",
-         "//test/mocks/server:factory_context_mocks",

--- a/patches/luajit/fix-luajit-asan.patch
+++ b/patches/luajit/fix-luajit-asan.patch
@@ -1,0 +1,26 @@
+diff --git a/src/lj_bcread.c b/src/lj_bcread.c
+index 55709522..a20a98c4 100644
+--- a/src/lj_bcread.c
++++ b/src/lj_bcread.c
+@@ -141,7 +141,7 @@ static uint32_t bcread_uleb128_33(LexState *ls)
+     int sh = -1;
+     v &= 0x3f;
+     do {
+-     v |= ((*p & 0x7f) << (sh += 7));
++     v |= (((uint32_t)(*p & 0x7f)) << (sh += 7));
+    } while (*p++ >= 0x80);
+   }
+   ls->p = (char *)p;
+diff --git a/src/lj_buf.c b/src/lj_buf.c
+index 01dcad5b..a03407ca 100644
+--- a/src/lj_buf.c
++++ b/src/lj_buf.c
+@@ -295,7 +295,7 @@ uint32_t LJ_FASTCALL lj_buf_ruleb128(const char **pp)
+   if (LJ_UNLIKELY(v >= 0x80)) {
+     int sh = 0;
+     v &= 0x7f;
+-    do { v |= ((*w & 0x7f) << (sh += 7)); } while (*w++ >= 0x80);
++    do { v |= (((uint32_t)(*w & 0x7f)) << (sh += 7)); } while (*w++ >= 0x80);
+   }
+   *pp = (const char *)w;
+   return v;


### PR DESCRIPTION
Allow running the upstream luajit tests with partial asan instrumentation. Some categories need to be skipped, and there is also a patch to address a couple of warnings that had easy fixes.