### PR TITLE
disable google grpc

### DIFF
--- a/pomerium.bazelrc
+++ b/pomerium.bazelrc
@@ -8,6 +8,8 @@ build --config=clang
 build:asan-common --test_env=UBSAN_SYMBOLIZER_PATH
 build:tsan --test_env=TSAN_SYMBOLIZER_PATH
 
+build --define=google_grpc=disabled
+
 # The following options are required to build using hermetic llvm without gcc:
 
 # Force all cc targets built with the llvm toolchain to use compiler-rt and libunwind. This removes


### PR DESCRIPTION
Envoy has two grpc implementations, the regular envoy grpc and one backed by the google grpc library. We do not use google grpc anywhere in Pomerium, so it can be disabled. If it is enabled, there is a non-zero amount of startup and memory overhead as the grpc library will create (#cores) extra threads, resulting in envoy starting twice as many threads as it would with google grpc disabled. 