### PR TITLE
bazel: add thinlto config

### DIFF
--- a/pomerium.bazelrc
+++ b/pomerium.bazelrc
@@ -30,6 +30,10 @@ build --@io_bazel_rules_go//go/config:pure=True
 build --macos_minimum_os=14.5
 build:linux --features=-libtool
 
+build:thinlto --features=thin_lto
+build:thinlto --ltobackendopt=-Wno-unused-command-line-argument
+build:thinlto --fission=no
+
 common:buildbarn --remote_executor=grpc://frontend.buildbarn.svc.cluster.local:8980
 common:buildbarn --remote_cache=grpc://frontend.buildbarn.svc.cluster.local:8980
 common:buildbarn --jobs=64


### PR DESCRIPTION
Adds a `thinlto` config key that can be used to build envoy with [ThinLTO](https://clang.llvm.org/docs/ThinLTO.html). We could use this in the future when building release binaries, but it does take longer than regular builds so it might only make sense to do this occasionally. In theory this would result in measurable performance improvements.

Example: `bazel build -c opt --config=thinlto //:envoy.stripped`