### PR TITLE
ci: fix coverage report validation and rounding

### DIFF
--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: install dependencies
-        run: sudo apt-get update && sudo apt-get -y install lcov zstd
+        run: sudo apt-get update && sudo apt-get -y install lcov zstd jq
 
       - name: setup bazel
         uses: bazel-contrib/setup-bazel@e8776f58fb6a6e9055cbaf1b38c52ccc5247e9c4
@@ -34,7 +34,9 @@ jobs:
       - name: test
         run: |
           bazel coverage --config=buildbarn --test_output=errors --test_arg='--log-level debug' //test/...
-          tar xf bazel-out/_coverage/_coverage_report.dat ./lcov
+          tar xf bazel-out/_coverage/_coverage_report.dat ./coverage.json ./lcov
+          jq -r '.summary_message' coverage.json
+          jq -e '.summary.threshold_reached' coverage.json >/dev/null
 
       - name: upload to coveralls
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -59,6 +59,7 @@ http_archive(
         "//patches/envoy:0011-integration-tcp-client-write.patch",
         "//patches/envoy:0012-generic-proxy-trace-logs.patch",
         "//patches/envoy:0013-fuzz-toolchain-path.patch",
+        "//patches/envoy:0014-disable-coverage-report-rounding.patch",
         "//patches/envoy:fix-antlr4-cpp-runtime.patch",
         "//patches/envoy:fix-integration-test-server-exit.patch",
         "//patches/envoy:fix-missing-symbolizer-env.patch",

--- a/patches/envoy/0014-disable-coverage-report-rounding.patch
+++ b/patches/envoy/0014-disable-coverage-report-rounding.patch
@@ -1,0 +1,41 @@
+diff --git a/tools/coverage/filter.jq b/tools/coverage/filter.jq
+index 6acd6f3982..4e5c06e707 100644
+--- a/tools/coverage/filter.jq
++++ b/tools/coverage/filter.jq
+@@ -2,11 +2,11 @@
+ 
+ def round_to_precision(precision):
+   . * pow(10; precision)
+-  | round / pow(10; precision);
++  | floor / pow(10; precision);
+ 
+ def calculate_summary:
+   {
+-    coverage_percent: (.coveragePercent | round_to_precision(1)),
++    coverage_percent: (.coveragePercent | round_to_precision(2)),
+     lines_covered: .linesCovered,
+     lines_total: .linesTotal,
+     threshold: (if $config[0] then ($config[0].thresholds.total // 0) else 0 end),
+@@ -21,7 +21,7 @@ def get_default_threshold:
+ def directory_stats(path):
+   {
+     expected_percent: ((if $config[0] and $config[0].directories then $config[0].directories[path] else null end) // get_default_threshold),
+-    coverage_percent: (.coveragePercent | round_to_precision(1)),
++    coverage_percent: (.coveragePercent | round_to_precision(2)),
+     lines_covered: .linesCovered,
+     lines_total: .linesTotal
+   };
+diff --git a/tools/coverage/report_generator.sh.template b/tools/coverage/report_generator.sh.template
+index 631ec26361..e2025272f2 100755
+--- a/tools/coverage/report_generator.sh.template
++++ b/tools/coverage/report_generator.sh.template
+@@ -105,7 +105,8 @@ run_grcov() {
+     mkdir -p "${OUTPUT_DIR}"
+     $GRCOV \
+         "${INFO_FILES[@]}" \
+-        --precision 1 \
++        --precision 5 \
++        --branch \
+         -s "${WORKSPACE_PATH}" \
+         -t html,covdir \
+         --excl-line "LCOV_EXCL_LINE" \

--- a/pomerium.bazelrc
+++ b/pomerium.bazelrc
@@ -32,6 +32,8 @@ build --@io_bazel_rules_go//go/config:pure=True
 build --macos_minimum_os=14.5
 build:linux --features=-libtool
 
+build:coverage --@envoy//tools/coverage:config=@pomerium_envoy//test:coverage_config
+
 common:buildbarn --remote_executor=grpc://frontend.buildbarn.svc.cluster.local:8980
 common:buildbarn --remote_cache=grpc://frontend.buildbarn.svc.cluster.local:8980
 common:buildbarn --jobs=64

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,0 +1,12 @@
+load("@aspect_bazel_lib//lib:yq.bzl", "yq")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+
+envoy_package()
+
+yq(
+    name = "coverage_config",
+    srcs = [":coverage.yaml"],
+    outs = ["coverage_config.json"],
+    args = ["-o=json"],
+    visibility = ["//visibility:public"],
+)

--- a/test/coverage.yaml
+++ b/test/coverage.yaml
@@ -1,0 +1,3 @@
+thresholds:
+  total: 100.0
+  per_directory: 100.0


### PR DESCRIPTION
Fixes a few issues related to coverage reports:
- Use our own coverage.yaml instead of the default upstream one
- Fix coverage % rounding. The upstream behavior appears to be to round to 1 decimal place, but this is undesirable if the threshold is 100%.
- Re-enable branch coverage
- In CI, log the coverage report summary text and fail the workflow if the threshold is not reached.