### PR TITLE
channel filters: prevent call to readDisable on destroyed connection

### DIFF
--- a/source/extensions/filters/network/ssh/transport_base.h
+++ b/source/extensions/filters/network/ssh/transport_base.h
@@ -386,7 +386,9 @@ public:
   }
 
   void connectionReadDisable(bool disable) override {
-    callbacks_->connection()->readDisable(disable);
+    if (auto conn = callbacks_->connection(); conn.has_value()) {
+      conn->readDisable(disable);
+    }
   }
 
   const bytes& sessionId() const final { return kex_result_->session_id; }


### PR DESCRIPTION
If a channel filter has paused a connection using connectionReadDisable(), when the handle goes out of scope on cleanup the connection will be re-enabled. However if e.g. the filter chain is being torn down because the connection was closed, the connection object will no longer be present to call readDisable on.