### PR TITLE
add mgmt client stream validity checks in sendMgmtClientMessage

### DIFF
--- a/source/extensions/filters/network/ssh/server_transport.cc
+++ b/source/extensions/filters/network/ssh/server_transport.cc
@@ -518,7 +518,11 @@ SshServerTransport::handleHostKeysProve(const wire::HostKeysProveRequestMsg& msg
 
 void SshServerTransport::sendMgmtClientMessage(const ClientMessage& msg) {
   ASSERT(msg.message_case() != ClientMessage::MessageCase::MESSAGE_NOT_SET, "empty ClientMessage sent");
-  mgmt_client_->stream().sendMessage(msg, false);
+  if (mgmt_client_ != nullptr) {
+    if (auto& stream = mgmt_client_->stream(); stream != nullptr) {
+      stream.sendMessage(msg, false);
+    }
+  }
 }
 
 void SshServerTransport::terminate(absl::Status status) {


### PR DESCRIPTION
Adds the same validity checks in sendMgmtClientMessage() as are present in terminate(), to fix a crash that can occur if a channel event is sent after a call to terminate() but before the associated connection close event is received.