### PR TITLE
add 'exec' channel request message type

### DIFF
--- a/source/extensions/filters/network/ssh/wire/messages.cc
+++ b/source/extensions/filters/network/ssh/wire/messages.cc
@@ -187,6 +187,16 @@ absl::StatusOr<size_t> PtyReqChannelRequestMsg::encode(Envoy::Buffer::Instance& 
                         modes);
 }
 
+// ExecChannelRequestMsg
+absl::StatusOr<size_t> ExecChannelRequestMsg::decode(Envoy::Buffer::Instance& buffer, size_t payload_size) noexcept {
+  return decodeSequence(buffer, payload_size,
+                        command);
+}
+absl::StatusOr<size_t> ExecChannelRequestMsg::encode(Envoy::Buffer::Instance& buffer) const noexcept {
+  return encodeSequence(buffer,
+                        command);
+}
+
 // WindowDimensionChangeChannelRequestMsg
 absl::StatusOr<size_t> WindowDimensionChangeChannelRequestMsg::decode(Envoy::Buffer::Instance& buffer, size_t payload_size) noexcept {
   return decodeSequence(buffer, payload_size,

--- a/source/extensions/filters/network/ssh/wire/messages.h
+++ b/source/extensions/filters/network/ssh/wire/messages.h
@@ -298,6 +298,15 @@ struct ShellChannelRequestMsg final : SubMsg<SshMessageType::ChannelRequest, "sh
   }
 };
 
+// https://datatracker.ietf.org/doc/html/rfc4254#section-6.5
+struct ExecChannelRequestMsg final : SubMsg<SshMessageType::ChannelRequest, "exec"> {
+  field<std::string, LengthPrefixed> command;
+
+  constexpr auto operator<=>(const ExecChannelRequestMsg&) const = default;
+  absl::StatusOr<size_t> decode(Envoy::Buffer::Instance& buffer, size_t payload_size) noexcept;
+  absl::StatusOr<size_t> encode(Envoy::Buffer::Instance& buffer) const noexcept;
+};
+
 // https://datatracker.ietf.org/doc/html/rfc4254#section-6.7
 struct WindowDimensionChangeChannelRequestMsg final : SubMsg<SshMessageType::ChannelRequest, "window-change"> {
   field<uint32_t> width_columns;
@@ -317,6 +326,7 @@ struct ChannelRequestMsg final : Msg<SshMessageType::ChannelRequest> {
   field<bool> want_reply;
   sub_message<PtyReqChannelRequestMsg,
               ShellChannelRequestMsg,
+              ExecChannelRequestMsg,
               WindowDimensionChangeChannelRequestMsg>
     request;
 

--- a/test/extensions/filters/network/ssh/wire/test_field_reflect.h
+++ b/test/extensions/filters/network/ssh/wire/test_field_reflect.h
@@ -369,6 +369,8 @@ TEST_FIELDS(WindowDimensionChangeChannelRequestMsg,
             width_px,
             height_px);
 TEST_FIELDS(ShellChannelRequestMsg);
+TEST_FIELDS(ExecChannelRequestMsg,
+            command);
 TEST_FIELDS(HostKeysMsg,
             hostkeys);
 TEST_FIELDS(UserAuthInfoPrompt,


### PR DESCRIPTION
Adds an `ExecChannelRequestMsg` message type. This message is not handled explicitly (it is normally just forwarded as-is) but can now be used with visit() in dynamic extensions for filter-specific purposes.